### PR TITLE
fix(intention): accept snake_case in_minutes / file_pattern on TriggerSpec

### DIFF
--- a/crates/vestige-mcp/src/tools/intention_unified.rs
+++ b/crates/vestige-mcp/src/tools/intention_unified.rs
@@ -152,8 +152,10 @@ struct TriggerSpec {
     #[serde(rename = "type")]
     trigger_type: Option<String>,
     at: Option<String>,
+    #[serde(alias = "in_minutes")]
     in_minutes: Option<i64>,
     codebase: Option<String>,
+    #[serde(alias = "file_pattern")]
     file_pattern: Option<String>,
     topic: Option<String>,
     condition: Option<String>,
@@ -817,6 +819,77 @@ mod tests {
 
         let value = result.unwrap();
         assert!(value["triggerAt"].is_string());
+    }
+
+    #[tokio::test]
+    async fn test_set_action_with_duration_trigger_snake_case() {
+        // The public JSON schema (see schema() above) declares `in_minutes` in
+        // snake_case. The TriggerSpec struct uses `rename_all = "camelCase"` so
+        // without an explicit `#[serde(alias = "in_minutes")]` the snake_case
+        // input is silently dropped (becomes None), `triggerAt` becomes null,
+        // and the time-based intention never fires.
+        let (storage, _dir) = test_storage().await;
+        let args = serde_json::json!({
+            "action": "set",
+            "description": "Check build status",
+            "trigger": {
+                "type": "time",
+                "in_minutes": 30
+            }
+        });
+        let result = execute(&storage, &test_cognitive(), Some(args)).await;
+        assert!(result.is_ok());
+
+        let value = result.unwrap();
+        assert!(
+            value["triggerAt"].is_string(),
+            "snake_case in_minutes should derive triggerAt; got: {:?}",
+            value["triggerAt"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_set_action_with_file_pattern_snake_case() {
+        // The public JSON schema declares `file_pattern` in snake_case. Verify
+        // it survives deserialization by setting an intention with ONLY
+        // file_pattern (no codebase — otherwise the check-side codebase branch
+        // would short-circuit and mask a dropped file_pattern field).
+        //
+        // Note: file_pattern matching currently uses substring containment, not
+        // glob, so the "pattern" must be a plain substring of the file path.
+        let (storage, _dir) = test_storage().await;
+        let args = serde_json::json!({
+            "action": "set",
+            "description": "Review test files",
+            "trigger": {
+                "type": "context",
+                "file_pattern": ".test.cjs"
+            }
+        });
+        let result = execute(&storage, &test_cognitive(), Some(args)).await;
+        assert!(
+            result.is_ok(),
+            "set should succeed with snake_case file_pattern"
+        );
+
+        // Check should fire when a matching file is in context.
+        let check_args = serde_json::json!({
+            "action": "check",
+            "context": {
+                "file": "tests/neural-cascade.test.cjs"
+            }
+        });
+        let check = execute(&storage, &test_cognitive(), Some(check_args))
+            .await
+            .unwrap();
+        let triggered = check["triggered"].as_array().expect("triggered array");
+        assert!(
+            !triggered.is_empty(),
+            "file_pattern must survive snake_case deserialization and match on file substring; \
+             got triggered: {:?}, pending: {:?}",
+            check["triggered"],
+            check["pending"]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Follow-up to #25 — Bug #8 was half-fixed. The `check` action correctly re-derives trigger time from `in_minutes + created_at` (per your fix at `intention_unified.rs:359`), but the `set` action was still silently dropping `in_minutes` **before** it could be persisted, so time-based intentions never fired.

Same root cause affects `file_pattern`.

## Root cause

`TriggerSpec` uses `#[serde(rename_all = "camelCase")]`, but the public JSON schema in `schema()` (lines 52, 60) declares the fields in **snake_case** (`in_minutes`, `file_pattern`). When a caller sends snake_case (matching the documented schema), serde silently drops the unknown field to `None`.

Reproduction from my side — after calling `intention.set({trigger: {type: "time", in_minutes: 1}})`, the stored row:

```sql
sqlite> SELECT id, trigger_data FROM intentions WHERE trigger_type='time';
6522e671...|{"type":"time","at":null,"inMinutes":null,...}
bad649ff...|{"type":"time","at":null,"inMinutes":null,...}
```

Single-word fields (`topic`, `condition`, `codebase`) stored correctly; multi-word snake_case fields always dropped.

## Fix

Two `#[serde(alias = "...")]` attributes on the affected fields. Purely additive — serde aliases don't change the default name, so existing camelCase callers are unaffected.

```rust
+    #[serde(alias = "in_minutes")]
     in_minutes: Option<i64>,
     codebase: Option<String>,
+    #[serde(alias = "file_pattern")]
     file_pattern: Option<String>,
```

## Tests

Two new regression tests added, **both verified to FAIL without the aliases** via negative control (reverted the attrs, re-ran the tests, confirmed failures with descriptive panic messages, re-applied the attrs, confirmed passes).

- `test_set_action_with_duration_trigger_snake_case` — sends `"in_minutes": 30`, asserts `triggerAt` is a non-null string. Without the fix: `triggerAt: Null`.
- `test_set_action_with_file_pattern_snake_case` — sends `"file_pattern": ".test.cjs"` with **no codebase** (important: the `check` action's if/else-if chain at line 457-480 has codebase short-circuit file_pattern, so a test that sets both would falsely pass even when file_pattern is dropped). Calls `check` with a matching file path. Without the fix: `triggered: []`.

Full crate suite: **408 passing, 0 failing** (previously 406 + 2 new).

## Scope decisions

- I deliberately did **not** add an alias for `ContextSpec::current_time` — that field is marked `#[allow(dead_code)]` and no code reads it, so an alias would be unverifiable. Happy to address separately if you want to wire it up.
- I also noticed `file_pattern` matching uses `str::contains()` (substring), not glob — so `"*.test.cjs"` as a pattern never matches `"foo.test.cjs"` as a file path. Not in scope for this PR but worth flagging; I can file a separate issue if you'd like.

## CI note

`cargo fmt --all --check` and `cargo clippy --workspace -- -D warnings` both fail on v2.0.4 `main`, but the failures are in **pre-existing upstream code not touched by this PR** — rustfmt wants tuple match arms reformatted in `intention_unified.rs` lines 265-280 and various `.await.unwrap()` chains throughout the tests module (added in v2.0.4), and clippy flags two collapsible `if` blocks in `explore.rs` lines 124 and 196. My own additions are clean against both. Happy to send a separate formatting/clippy-cleanup PR if helpful.

## Related

- Closes the `set`-side half of #25 (Bug #8).
- First contribution — thank you for being so welcoming. 🙏