### PR TITLE
fix(deep_reference): incorporate query relevance into recommended/confidence

### DIFF
--- a/crates/vestige-mcp/src/tools/cross_reference.rs
+++ b/crates/vestige-mcp/src/tools/cross_reference.rs
@@ -568,21 +568,33 @@ pub async fn execute(
     // ====================================================================
     // STAGE 8: Synthesis + Reasoning Chain Generation
     // ====================================================================
-    // Find the recommended answer: highest trust, not superseded, most recent
-    let recommended = scored.iter()
+    // Composite score: half query relevance (combined_score from
+    // hybrid_search + reranker) and half FSRS-6 trust. Both signals belong
+    // in the recommended pick — relevance picks the right *topic*, trust
+    // picks the most reliable variant within that topic.
+    let composite = |s: &ScoredMemory| s.combined_score as f64 * 0.5 + s.trust * 0.5;
+
+    // Find the recommended answer: highest composite, not superseded, most recent
+    let recommended = scored
+        .iter()
         .filter(|s| !superseded_ids.contains(&s.id))
         .max_by(|a, b| {
-            // Primary: trust. Secondary: date.
-            a.trust.partial_cmp(&b.trust)
+            composite(a)
+                .partial_cmp(&composite(b))
                 .unwrap_or(std::cmp::Ordering::Equal)
                 .then_with(|| a.updated_at.cmp(&b.updated_at))
         });
 
-    // Build evidence list (top memories by trust, not superseded)
-    let mut non_superseded: Vec<&ScoredMemory> = scored.iter()
+    // Build evidence list (top memories by composite, not superseded)
+    let mut non_superseded: Vec<&ScoredMemory> = scored
+        .iter()
         .filter(|s| !superseded_ids.contains(&s.id))
         .collect();
-    non_superseded.sort_by(|a, b| b.trust.partial_cmp(&a.trust).unwrap_or(std::cmp::Ordering::Equal));
+    non_superseded.sort_by(|a, b| {
+        composite(b)
+            .partial_cmp(&composite(a))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
     let evidence: Vec<Value> = non_superseded.iter()
         .take(10)
         .enumerate()
@@ -605,8 +617,10 @@ pub async fn execute(
         .collect();
     evolution.truncate(15); // cap timeline length
 
-    // Confidence scoring
-    let base_confidence = recommended.map(|r| r.trust).unwrap_or(0.0);
+    // Confidence scoring: derived from the same composite as `recommended`,
+    // so confidence actually moves with query relevance instead of being a
+    // function of trust + corpus size alone.
+    let base_confidence = recommended.map(composite).unwrap_or(0.0);
     let agreement_boost = (evidence.len() as f64 * 0.03).min(0.2);
     let contradiction_penalty = contradictions.len() as f64 * 0.1;
     let confidence = (base_confidence + agreement_boost - contradiction_penalty).clamp(0.0, 1.0);
@@ -685,6 +699,129 @@ pub async fn execute(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cognitive::CognitiveEngine;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+    use tokio::sync::Mutex;
+    use vestige_core::Storage;
+
+    fn test_cognitive() -> Arc<Mutex<CognitiveEngine>> {
+        Arc::new(Mutex::new(CognitiveEngine::new()))
+    }
+
+    async fn test_storage() -> (Arc<Storage>, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let storage = Storage::new(Some(dir.path().join("test.db"))).unwrap();
+        (Arc::new(storage), dir)
+    }
+
+    async fn ingest_one(storage: &Arc<Storage>, content: &str, tags: &[&str]) -> String {
+        storage
+            .ingest(vestige_core::IngestInput {
+                content: content.to_string(),
+                node_type: "fact".to_string(),
+                source: None,
+                sentiment_score: 0.0,
+                sentiment_magnitude: 0.0,
+                tags: tags.iter().map(|s| s.to_string()).collect(),
+                valid_from: None,
+                valid_until: None,
+            })
+            .unwrap()
+            .id
+    }
+
+    // ========================================================================
+    // BUG A: `recommended` is picked by FSRS trust only, ignoring query relevance.
+    // ========================================================================
+    #[tokio::test]
+    async fn test_recommended_uses_query_relevance_not_just_trust() {
+        let (storage, _dir) = test_storage().await;
+
+        let id_a = ingest_one(
+            &storage,
+            "PostgreSQL connection pooling with pgbouncer transaction mode \
+             requires careful tuning of max_connections and pool_mode settings.",
+            &["postgres", "database"],
+        )
+        .await;
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        let _id_b = ingest_one(
+            &storage,
+            "Making sourdough bread requires a mature starter, long bulk \
+             fermentation, and attention to dough hydration levels.",
+            &["baking", "bread"],
+        )
+        .await;
+
+        let args = serde_json::json!({
+            "query": "PostgreSQL connection pooling pgbouncer max_connections"
+        });
+        let result = execute(&storage, &test_cognitive(), Some(args))
+            .await
+            .expect("execute should succeed");
+
+        assert_eq!(
+            result["recommended"]["memory_id"].as_str(),
+            Some(id_a.as_str()),
+            "Expected recommended={} (matches query). Got {:?}. \
+             Root cause: lines 565-572 select `recommended` by trust only, \
+             discarding the combined_score signal from hybrid_search + reranker.",
+            id_a,
+            result["recommended"]["memory_id"]
+        );
+    }
+
+    // ========================================================================
+    // Confidence sanity: must vary with query relevance.
+    // ========================================================================
+    #[tokio::test]
+    async fn test_confidence_varies_with_query_relevance() {
+        let (storage, _dir) = test_storage().await;
+
+        ingest_one(
+            &storage,
+            "The Borrow Checker enforces Rust's ownership rules at compile time, \
+             preventing data races and use-after-free without a garbage collector.",
+            &["rust"],
+        )
+        .await;
+
+        let relevant = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "query": "Rust borrow checker ownership compile time"
+            })),
+        )
+        .await
+        .expect("execute should succeed");
+
+        let irrelevant = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "query": "18th century Dutch maritime trade routes"
+            })),
+        )
+        .await
+        .expect("execute should succeed");
+
+        let rel_conf = relevant["confidence"].as_f64().unwrap_or(0.0);
+        let irr_conf = irrelevant["confidence"].as_f64().unwrap_or(0.0);
+
+        assert!(
+            rel_conf > irr_conf,
+            "Confidence should be higher for a relevant query. Got \
+             relevant={}, irrelevant={}. Currently `confidence` derives from \
+             recommended.trust + evidence count (lines 602-605), both \
+             invariant under query changes.",
+            rel_conf,
+            irr_conf
+        );
+    }
 
     #[test]
     fn test_schema_structure() {


### PR DESCRIPTION
> ⚠️ **Sam — this PR contains a design decision (the relevance/trust weighting). Please read the "Design choice that needs your call" section below before merging.** I picked a 50/50 blend as a starting point. The exact line to tweak is `cross_reference.rs:573` and is called out below.

## The bug

`deep_reference` (and its `cross_reference` alias) ignores query relevance when picking the recommended memory. The Stage 8 `recommended` selector and the evidence sort both rank by FSRS-6 trust only, discarding the `combined_score` signal that the upstream `hybrid_search` + cross-encoder reranker just computed. Confidence is derived from `recommended.trust + evidence_count`, neither of which moves with the query — so any query against the same corpus returns the same primary memory and the same confidence score.

## Empirical reproduction

I ran 15 `deep_reference` probes against an 11-memory corpus on live MCP (v2.0.4 main HEAD `17038fc`):
- 9 queries each phrased to uniquely target one memory in the corpus
- 6 control queries with zero relevant memories (e.g. "PostgreSQL connection pooling", "sous vide pork belly temperature")

Results from the live MCP server, confirmed by a scripted analyzer:

| Metric | Observed | Expected for relevance-aware tool |
|---|---|---|
| Distinct primary memories returned across 15 queries | **1** | ~9 (one per specific query, low for controls) |
| Distinct confidence values | **1** (0.82 for everything) | varied |
| Ground-truth accuracy on 9 specific-target queries | **1 / 9 (11.1%)** | ~9/9 |
| Confidence on "sous vide pork belly temperature" | **0.82** with status `"resolved"` | low / `no_evidence` |

The 1 hit on specific queries is coincidental — `e2eaa266` (a Neural Cascade stats memory) is returned for every query, and one of my queries happened to target it. Random guessing across the 11-memory corpus would be ~9% baseline, so the tool is currently performing at random.

## Source-level root cause

`crates/vestige-mcp/src/tools/cross_reference.rs:565-572` (pre-fix):

\`\`\`rust
let recommended = scored.iter()
    .filter(|s| !superseded_ids.contains(&s.id))
    .max_by(|a, b| {
        // Primary: trust. Secondary: date.
        a.trust.partial_cmp(&b.trust)
            .unwrap_or(std::cmp::Ordering::Equal)
            .then_with(|| a.updated_at.cmp(&b.updated_at))
    });
\`\`\`

The `combined_score` field on `ScoredMemory` (computed by `storage.hybrid_search` at line 372 and reranked by `cog.reranker.rerank` at line 389) is never read after Stage 1. Lines 578 (evidence sort) and 602 (`base_confidence`) have the same shape: trust-only.

## The fix (this PR)

A 4-line change. Introduce a `composite` closure and use it in three places:

\`\`\`rust
// crates/vestige-mcp/src/tools/cross_reference.rs:573
let composite = |s: &ScoredMemory| s.combined_score as f64 * 0.5 + s.trust * 0.5;
\`\`\`

Used in:
- **`recommended` `max_by`** — picks the memory whose composite of query relevance and FSRS trust is highest
- **`non_superseded` evidence `sort_by`** — orders the evidence list by the same composite
- **`base_confidence`** — derives from `composite(recommended)` instead of `recommended.trust`, so confidence actually moves with query relevance

## ⚠️ Design choice that needs your call

**The 50/50 weighting is a knob, not a derivation.** I picked it as a starting point because the docs describe `deep_reference` as combining "FSRS-6 trust scoring" with "broad retrieval + cross-encoder reranking", which reads as roughly equal weight. But this is your tool and your design intent — please pick the weights you want.

**Here is the one line to change in `cross_reference.rs`** (around line 573 after this PR is applied):

\`\`\`rust
let composite = |s: &ScoredMemory| s.combined_score as f64 * 0.5 + s.trust * 0.5;
\`\`\`

Some alternatives to consider:

| Weighting | Behavior | When you'd want this |
|---|---|---|
| `0.5 * relevance + 0.5 * trust` *(this PR)* | Balanced | Default; matches the documented "trust + reranking" framing |
| `0.7 * relevance + 0.3 * trust` | Relevance-led | Treats `deep_reference` more like an enhanced search; trust is a tiebreaker |
| `0.3 * relevance + 0.7 * trust` | Trust-led | Prioritizes well-established memories; relevance just narrows the field |
| `relevance.max(0.4) * trust` | Multiplicative gate | Trust matters only above a relevance floor; fully irrelevant memories drop out |
| Lexicographic on relevance, then trust | Pure relevance with trust tiebreaker | Closest to a search engine; trust decides between equally-relevant matches |

If you'd prefer one of these (or something else), tell me what you want and I'll update the PR. I have a regression test that pins the *property* (relevance must influence the pick) without pinning the exact weights, so any sensible blend will keep the tests green.

## Tests

Two new regression tests in `crates/vestige-mcp/src/tools/cross_reference.rs`. **Both verified to FAIL on `main` and PASS with the fix via negative control** — I temporarily set the composite to `1.0 * trust + 0.0 * relevance` (simulating the broken behavior) and confirmed both tests fail again, then restored the fix.

- **`test_recommended_uses_query_relevance_not_just_trust`**
  Two-memory corpus, ingested in order so the off-topic memory wins the trust tiebreaker. Query targets the on-topic memory. The fix ensures `recommended` is the on-topic one.

- **`test_confidence_varies_with_query_relevance`**
  Single-memory corpus. Two `execute()` calls — one with a relevant query, one with an irrelevant one. The fix ensures the relevant query produces higher confidence.

Both tests assert behavioral *properties* (not exact values), so they remain valid under any reasonable weighting choice.

**Full crate suite: `VESTIGE_TEST_MOCK_EMBEDDINGS=1 cargo test -p vestige-mcp --lib` → 410 / 410 passing** (was 408 + 2 new).

## Out of scope (observed but not in this PR)

While running the live MCP probes I observed two further inconsistencies in `cross_reference.rs` that I **cannot reproduce in `cargo test`** — the synthetic test environment with mock embeddings doesn't trigger the conditions needed. I'm intentionally NOT including them in this PR because I can't write a regression test for them, and I don't want to ship a fix without one. Reporting them here for visibility only:

1. **`effective_sim` floor at `cross_reference.rs:551` fabricates contradictions** between memories with zero topical overlap when one contains a `CORRECTION_SIGNALS` keyword. Live MCP shows `"CONTRADICTING EVIDENCE (6):"` in reasoning text for queries like "sous vide pork belly temperature" against my Neural Cascade corpus, with similarity always exactly `0.30` (the floor value).

2. **Stage 5 (strict) and Stage 7 (loose) contradiction pipelines disagree** in the same response: top-level `contradictions` field is empty/absent, `status` is `"resolved"`, but the `reasoning` text claims 6 contradictions exist. Two parallel detection pipelines (lines 484-517 vs 539-561) using different thresholds.

I have raw JSON for all 15 probes and a node analyzer script if you'd like them as a separate issue. Just say the word.

## CI note

`cargo fmt --all --check` and `cargo clippy --workspace -- -D warnings` both fail on `main` HEAD due to **pre-existing upstream rustfmt violations** in `cross_reference.rs` (lines 72-90, 595, 635, 679+) and warnings elsewhere. **None are introduced by this PR.** My specific changes are rustfmt-clean and clippy-clean. Same caveat as #26 — happy to send a separate cleanup PR if helpful.

## Related

- Builds on the verification work in #25
- Second contribution after #26. Thanks again for the welcoming reception. 🙏