### PR TITLE
Add feature flags to build for older systems with glibc <2.38

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2074,15 +2074,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inotify"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2288,6 +2279,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,15 +2475,6 @@ checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -2956,6 +2948,7 @@ version = "2.0.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5df903c0d2c07b56950f1058104ab0c8557159f2741782223704de9be73c3c"
 dependencies = [
+ "libloading 0.9.0",
  "ndarray",
  "ort-sys",
  "smallvec",
@@ -3204,69 +3197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "pyo3"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
-dependencies = [
- "cfg-if",
- "indoc",
- "libc",
- "memoffset",
- "once_cell",
- "portable-atomic",
- "pyo3-build-config",
- "pyo3-ffi",
- "pyo3-macros",
- "unindent",
-]
-
-[[package]]
-name = "pyo3-build-config"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
-dependencies = [
- "once_cell",
- "target-lexicon",
-]
-
-[[package]]
-name = "pyo3-ffi"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
-dependencies = [
- "libc",
- "pyo3-build-config",
-]
-
-[[package]]
-name = "pyo3-macros"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
-dependencies = [
- "proc-macro2",
- "pyo3-macros-backend",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pyo3-macros-backend"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
-dependencies = [
- "heck",
- "proc-macro2",
- "pyo3-build-config",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3990,12 +3920,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "target-lexicon"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
-
-[[package]]
 name = "tempfile"
 version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4370,7 +4294,7 @@ checksum = "76b761acf8af3494640d826a8609e2265e19778fb43306c7f15379c78c9b05b0"
 dependencies = [
  "gemm 0.18.2",
  "half",
- "libloading",
+ "libloading 0.8.9",
  "memmap2",
  "num",
  "num-traits",
@@ -4441,12 +4365,6 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"
@@ -4584,30 +4502,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vestige-agent"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "rand",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 2.0.18",
- "tracing",
- "uuid",
- "xxhash-rust",
-]
-
-[[package]]
-name = "vestige-agent-py"
-version = "0.1.0"
-dependencies = [
- "pyo3",
- "serde_json",
- "vestige-agent",
-]
 
 [[package]]
 name = "vestige-core"
@@ -5234,12 +5128,6 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "xxhash-rust"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "y4m"

--- a/crates/vestige-core/Cargo.toml
+++ b/crates/vestige-core/Cargo.toml
@@ -22,10 +22,18 @@ bundled-sqlite = ["rusqlite/bundled"]
 encryption = ["rusqlite/bundled-sqlcipher"]
 
 # Core embeddings with fastembed (ONNX-based, local inference)
-embeddings = ["dep:fastembed"]
+# Downloads a pre-built ONNX Runtime binary at build time (requires glibc >= 2.38)
+embeddings = ["dep:fastembed", "fastembed/ort-download-binaries-native-tls"]
 
 # HNSW vector search with USearch (20x faster than FAISS)
 vector-search = ["dep:usearch"]
+
+# Use runtime-loaded ORT instead of the downloaded pre-built binary.
+# Required on systems with glibc < 2.38 (Ubuntu 22.04, Debian 12, RHEL/Rocky 9).
+# Mutually exclusive with the default `embeddings` feature's download strategy.
+# Usage: --no-default-features --features ort-dynamic,vector-search,bundled-sqlite
+# Runtime requirement: libonnxruntime.so must be on LD_LIBRARY_PATH or ORT_DYLIB_PATH set.
+ort-dynamic = ["dep:fastembed", "fastembed/ort-load-dynamic", "fastembed/hf-hub-native-tls", "fastembed/image-models"]
 
 # Nomic Embed Text v2 MoE (475M params, 305M active, Candle backend)
 # Requires: fastembed with nomic-v2-moe feature
@@ -77,7 +85,7 @@ notify = "8"
 # ============================================================================
 # nomic-embed-text-v1.5: 768 dimensions, 8192 token context, Matryoshka support
 # v5.11: Adds Nomic v2 MoE (nomic-v2-moe feature) + Qwen3 reranker (qwen3 feature)
-fastembed = { version = "5.11", optional = true }
+fastembed = { version = "5.11", default-features = false, features = ["hf-hub-native-tls", "image-models"], optional = true }
 
 # ============================================================================
 # OPTIONAL: Vector Search (USearch - HNSW, 20x faster than FAISS)

--- a/crates/vestige-mcp/Cargo.toml
+++ b/crates/vestige-mcp/Cargo.toml
@@ -13,6 +13,9 @@ repository = "https://github.com/samvallad33/vestige"
 default = ["embeddings", "vector-search"]
 embeddings = ["vestige-core/embeddings"]
 vector-search = ["vestige-core/vector-search"]
+# For systems with glibc < 2.38 — use runtime-loaded ORT instead of the downloaded pre-built binary.
+# Usage: cargo install --path crates/vestige-mcp --no-default-features --features ort-dynamic,vector-search
+ort-dynamic = ["vestige-core/ort-dynamic"]
 
 [[bin]]
 name = "vestige-mcp"
@@ -32,7 +35,7 @@ path = "src/bin/cli.rs"
 # ============================================================================
 # Includes: FSRS-6, spreading activation, synaptic tagging, hippocampal indexing,
 # memory states, context memory, importance signals, dreams, and more
-vestige-core = { version = "2.0.4", path = "../vestige-core", default-features = false, features = ["bundled-sqlite"] }
+vestige-core = { version = "2.0.4", path = "../vestige-core", default-features = false, features = ["bundled-sqlite", "embeddings", "vector-search"] }
 
 # ============================================================================
 # MCP Server Dependencies


### PR DESCRIPTION
The default build downloads a pre-built ONNX Runtime binary that was compiled against glibc 2.38+. On older but widely-used systems this causes a hard linker failure:
```
rust-lld: error: undefined symbol: __isoc23_strtoll
rust-lld: error: undefined symbol: __isoc23_strtol
rust-lld: error: undefined symbol: __isoc23_strtoull
```
These symbols were introduced in glibc 2.38 (August 2023). Affected systems include Ubuntu 22.04 LTS (glibc 2.35, supported until 2027), Debian 12 Bookworm (glibc 2.36, current stable), and RHEL/Rocky/AlmaLinux 9 (glibc 2.34, enterprise LTS) — all common server and developer workstation environments.
Changes:
- crates/vestige-core/Cargo.toml — adds an ort-dynamic feature that switches fastembed from the download ORT strategy to ort-load-dynamic (runtime dlopen via libloading). The embeddings feature is unchanged and continues to use the download strategy by default. The fastembed dep is set to default-features = false with the ORT strategy made explicit, so the two paths are clearly separated.
- crates/vestige-mcp/Cargo.toml — propagates the ort-dynamic feature upward, and fixes a pre-existing issue where vestige-core was declared with only features = ["bundled-sqlite"], which caused the #[cfg(all(feature = "embeddings", feature = "vector-search"))]-gated Storage methods (hybrid_search, semantic_search, get_node_embedding) to be absent at lib compilation time.

Default behaviour is unchanged. A plain cargo install on a modern system behaves identically to before.

Usage on older systems. Compile ORT from source (no patch needed, just env vars):
```
CC=/usr/bin/gcc-12 CXX=/usr/bin/g++-12 ORT_STRATEGY=build \
cargo install --path crates/vestige-mcp --locked
```

@samvallad33 : If you want I can add a sections with build instructions to the Readme.

---
Also fixes: hybrid_search, semantic_search, and get_node_embedding not found on Arc<Storage> in vestige-mcp lib compilation — caused by vestige-core being depended on with only features = ["bundled-sqlite"], leaving both embeddings and vector-search absent from the lib crate's feature set.
