### PR TITLE
feat: dream connection eviction uses composite score instead of FIFO

### DIFF
--- a/crates/vestige-core/src/advanced/dreams.rs
+++ b/crates/vestige-core/src/advanced/dreams.rs
@@ -1076,6 +1076,9 @@ pub struct DiscoveredConnection {
     pub connection_type: DiscoveredConnectionType,
     /// Reasoning for this connection
     pub reasoning: String,
+    /// When this connection was discovered (used for recency scoring during eviction)
+    #[serde(default = "Utc::now")]
+    pub discovered_at: DateTime<Utc>,
 }
 
 /// Types of connections discovered during dreaming
@@ -1277,6 +1280,7 @@ impl MemoryDreamer {
                         similarity,
                         connection_type,
                         reasoning,
+                        discovered_at: Utc::now(),
                     });
                 }
             }
@@ -1699,10 +1703,38 @@ impl MemoryDreamer {
     fn store_connections(&self, connections: &[DiscoveredConnection]) {
         if let Ok(mut stored) = self.connections.write() {
             stored.extend(connections.iter().cloned());
-            // Keep last 1000 connections
+            // Keep the 1000 highest-scoring connections using a composite score
+            // that balances quality (similarity) and recency (age-based decay).
+            //
+            // score = similarity * 0.6 + recency * 0.4
+            //
+            // Recency uses exponential decay with a 7-day half-life:
+            //   recency = 0.5 ^ (age_days / 7.0)
+            //
+            // This means:
+            //   - A brand-new connection with similarity 0.5 scores 0.70
+            //   - A week-old connection with similarity 0.9 scores 0.74
+            //   - A month-old connection with similarity 0.9 scores 0.58
+            // Strong old connections are retained longer than weak new ones,
+            // but eventually yield to fresh high-quality discoveries.
             let len = stored.len();
             if len > 1000 {
-                stored.drain(0..(len - 1000));
+                let now = Utc::now();
+                stored.sort_unstable_by(|a, b| {
+                    let score = |c: &DiscoveredConnection| -> f64 {
+                        let age_days = now
+                            .signed_duration_since(c.discovered_at)
+                            .num_seconds()
+                            .max(0) as f64
+                            / 86_400.0;
+                        let recency = (0.5_f64).powf(age_days / 7.0);
+                        c.similarity * 0.6 + recency * 0.4
+                    };
+                    score(b)
+                        .partial_cmp(&score(a))
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+                stored.truncate(1000);
             }
         }
     }

--- a/crates/vestige-mcp/src/dashboard/handlers.rs
+++ b/crates/vestige-mcp/src/dashboard/handlers.rs
@@ -539,17 +539,23 @@ pub async fn trigger_dream(
 
     // Run dream through CognitiveEngine
     let cog = cognitive.lock().await;
-    let pre_dream_count = cog.dreamer.get_connections().len();
+    // Capture start time before the dream — composite-score eviction in store_connections
+    // reorders the buffer, making positional slicing (pre_dream_count..) unreliable.
+    let dream_start = Utc::now();
     let dream_result = cog.dreamer.dream(&dream_memories).await;
     let insights = cog.dreamer.synthesize_insights(&dream_memories);
     let all_connections = cog.dreamer.get_connections();
     drop(cog);
 
     // Persist new connections
-    let new_connections = &all_connections[pre_dream_count..];
+    // Filter by timestamp — same approach as dream.rs to avoid positional index issues.
+    let new_connections: Vec<&vestige_core::DiscoveredConnection> = all_connections
+        .iter()
+        .filter(|c| c.discovered_at >= dream_start)
+        .collect();
     let mut connections_persisted = 0u64;
     let now = Utc::now();
-    for conn in new_connections {
+    for conn in new_connections.iter() {
         let link_type = match conn.connection_type {
             vestige_core::DiscoveredConnectionType::Semantic => "semantic",
             vestige_core::DiscoveredConnectionType::SharedConcept => "shared_concepts",

--- a/crates/vestige-mcp/src/tools/dream.rs
+++ b/crates/vestige-mcp/src/tools/dream.rs
@@ -89,7 +89,12 @@ pub async fn execute(
     }).collect();
 
     let cog = cognitive.lock().await;
-    let pre_dream_count = cog.dreamer.get_connections().len();
+    // Capture start time before the dream so we can identify newly discovered
+    // connections by timestamp rather than by buffer position. This is robust
+    // against the composite-score eviction sort in store_connections, which
+    // reorders the buffer and makes positional slicing (pre_dream_count..)
+    // unreliable.
+    let dream_start = Utc::now();
     let dream_result = cog.dreamer.dream(&dream_memories).await;
     let insights = cog.dreamer.synthesize_insights(&dream_memories);
     let all_connections = cog.dreamer.get_connections();
@@ -115,12 +120,17 @@ pub async fn execute(
         }
     }
 
-    // v1.9.0: Persist only NEW connections from this dream (skip accumulated ones)
-    let new_connections = all_connections.get(pre_dream_count..).unwrap_or(&[]);
+    // Identify new connections from this dream by timestamp rather than buffer
+    // position — positional slicing is broken after composite-score eviction
+    // reorders the buffer.
+    let new_connections: Vec<&vestige_core::DiscoveredConnection> = all_connections
+        .iter()
+        .filter(|c| c.discovered_at >= dream_start)
+        .collect();
     let mut connections_persisted = 0u64;
     {
         let now = Utc::now();
-        for conn in new_connections {
+        for conn in new_connections.iter() {
             let link_type = match conn.connection_type {
                 vestige_core::DiscoveredConnectionType::Semantic => "semantic",
                 vestige_core::DiscoveredConnectionType::SharedConcept => "shared_concepts",
@@ -162,7 +172,7 @@ pub async fn execute(
     // Hydrate live cognitive engine with newly persisted connections
     if connections_persisted > 0 {
         let mut cog = cognitive.lock().await;
-        for conn in new_connections {
+        for conn in new_connections.iter() {
             let link_type_enum = match conn.connection_type {
                 vestige_core::DiscoveredConnectionType::Semantic => LinkType::Semantic,
                 vestige_core::DiscoveredConnectionType::SharedConcept => LinkType::Semantic,


### PR DESCRIPTION
## Problem

I discovered that the persistence of the connections could be improved. @samvallad33 I hope this does not have negative side effects - from my understanding of the persisted connections, the following will lead to an improvement.

`MemoryDreamer::store_connections` kept the connection buffer at 1000 entries using a pure FIFO drain:

```rust
stored.drain(0..(len - 1000));
```

Connections are appended chronologically, so the drain unconditionally removed the oldest entries - regardless of their similarity score. A high-quality connection discovered at the start of a long dream run could be evicted in favour of a weaker one added seconds later. 


## Fix

### 1. Add `discovered_at` to `DiscoveredConnection` (`dreams.rs`)

```rust
#[serde(default = "Utc::now")]
pub discovered_at: DateTime<Utc>,
```

Set to `Utc::now()` at the point of discovery in `discover_connections`.
`serde` default ensures backwards compatibility if the struct is ever deserialised
from older data (it is currently in-memory only, but the guard costs nothing).

### 2. Composite score eviction in `store_connections` (`dreams.rs`)

Replace the FIFO drain with a quality-aware sort + truncate:

```
score = similarity × 0.6 + recency × 0.4
recency = 0.5 ^ (age_days / 7.0)   // exponential decay, 7-day half-life
```

Example scores at the cap boundary:

| Connection | similarity | age | score |
|---|---|---|---|
| New, average | 0.50 | 0 days | 0.70 |
| Old, strong | 0.90 | 7 days | 0.74 |
| Old, strong | 0.90 | 30 days | 0.58 |
| New, weak | 0.30 | 0 days | 0.58 |

Strong old connections outlast weak new ones, but eventually yield to fresh
high-quality discoveries.

### 3. Fix new-connection identification in `dream.rs` and `handlers.rs`

The composite sort reorders the buffer, breaking the positional slice that was used to identify connections from the current dream:

```rust
// BROKEN after sort reorders the buffer
let new_connections = all_connections.get(pre_dream_count..).unwrap_or(&[]);
```

Replaced with a timestamp filter in both callers:

```rust
let dream_start = Utc::now(); // captured before dream() is called
let new_connections: Vec<_> = all_connections
    .iter()
    .filter(|c| c.discovered_at >= dream_start)
    .collect();
```