### PR TITLE
Add VESTIGE_DATA_DIR support and improve data directory handling

### DIFF
--- a/crates/vestige-mcp/src/main.rs
+++ b/crates/vestige-mcp/src/main.rs
@@ -58,7 +58,8 @@ fn expand_tilde(path: &str) -> PathBuf {
             return if path == "~" {
                 home
             } else {
-                home.join(&path[2..])
+                let remainder = path[2..].trim_start_matches(|c| c == '/' || c == '\\');
+                home.join(remainder)
             };
         }
     }

--- a/crates/vestige-mcp/src/main.rs
+++ b/crates/vestige-mcp/src/main.rs
@@ -223,7 +223,7 @@ async fn main() {
     );
 
     // Treat `data_dir` as a directory: create it and derive the DB file path.
-    let data_db = config.data_dir.map(|dir| {
+    let data_db = if let Some(dir) = config.data_dir {
         if let Err(e) = std::fs::create_dir_all(&dir) {
             error!(
                 "Failed to create data directory '{}': {}",
@@ -235,10 +235,18 @@ async fn main() {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+            if let Err(e) = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)) {
+                warn!(
+                    "Failed to set permissions on data directory '{}': {}",
+                    dir.display(),
+                    e
+                );
+            }
         }
-        dir.join("vestige.db")
-    });
+        Some(dir.join("vestige.db"))
+    } else {
+        None
+    };
 
     // Initialize storage with optional custom data directory
     let storage = match Storage::new(data_db) {

--- a/crates/vestige-mcp/src/main.rs
+++ b/crates/vestige-mcp/src/main.rs
@@ -78,15 +78,17 @@ struct Config {
 fn parse_args() -> Config {
     let args: Vec<String> = std::env::args().collect();
     // Check for VESTIGE_DATA_DIR environment variable first
-    let mut data_dir: Option<PathBuf> = std::env::var("VESTIGE_DATA_DIR")
-        .ok()
-        .and_then(|s| {
-            let trimmed = s.trim();
-            if trimmed.is_empty() {
-                None
-            } else {
-                Some(expand_tilde(trimmed))
+    let mut data_dir: Option<PathBuf> = std::env::var_os("VESTIGE_DATA_DIR")
+        .and_then(|value| match value.to_str() {
+            Some(s) => {
+                let trimmed = s.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(expand_tilde(trimmed))
+                }
             }
+            None => Some(PathBuf::from(value)),
         });
     let mut http_port: u16 = std::env::var("VESTIGE_HTTP_PORT")
         .ok()

--- a/crates/vestige-mcp/src/main.rs
+++ b/crates/vestige-mcp/src/main.rs
@@ -44,6 +44,27 @@ use vestige_core::Storage;
 use protocol::stdio::StdioTransport;
 use server::McpServer;
 
+/// Expand a leading `~` in `path` to the current user's home directory.
+///
+/// Uses the `HOME` environment variable on Unix and `USERPROFILE` on Windows.
+/// Returns the path unchanged when it does not start with `~` or when the
+/// home directory cannot be determined.
+fn expand_tilde(path: &str) -> PathBuf {
+    if path == "~" || path.starts_with("~/") || path.starts_with("~\\") {
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .map(PathBuf::from);
+        if let Some(home) = home {
+            return if path == "~" {
+                home
+            } else {
+                home.join(&path[2..])
+            };
+        }
+    }
+    PathBuf::from(path)
+}
+
 /// Parsed CLI configuration.
 struct Config {
     data_dir: Option<PathBuf>,
@@ -63,7 +84,7 @@ fn parse_args() -> Config {
             if trimmed.is_empty() {
                 None
             } else {
-                Some(PathBuf::from(trimmed))
+                Some(expand_tilde(trimmed))
             }
         });
     let mut http_port: u16 = std::env::var("VESTIGE_HTTP_PORT")
@@ -128,7 +149,7 @@ fn parse_args() -> Config {
                     std::process::exit(1);
                 }
                 // CLI flag overrides environment variable
-                data_dir = Some(PathBuf::from(&args[i]));
+                data_dir = Some(expand_tilde(&args[i]));
             }
             arg if arg.starts_with("--data-dir=") => {
                 // Safe: we just verified the prefix exists with starts_with
@@ -139,7 +160,7 @@ fn parse_args() -> Config {
                     std::process::exit(1);
                 }
                 // CLI flag overrides environment variable
-                data_dir = Some(PathBuf::from(path));
+                data_dir = Some(expand_tilde(path));
             }
             "--http-port" => {
                 i += 1;
@@ -201,8 +222,26 @@ async fn main() {
         env!("CARGO_PKG_VERSION")
     );
 
+    // Treat `data_dir` as a directory: create it and derive the DB file path.
+    let data_db = config.data_dir.map(|dir| {
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            error!(
+                "Failed to create data directory '{}': {}",
+                dir.display(),
+                e
+            );
+            std::process::exit(1);
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+        }
+        dir.join("vestige.db")
+    });
+
     // Initialize storage with optional custom data directory
-    let storage = match Storage::new(config.data_dir) {
+    let storage = match Storage::new(data_db) {
         Ok(s) => {
             info!("Storage initialized successfully");
 

--- a/crates/vestige-mcp/src/main.rs
+++ b/crates/vestige-mcp/src/main.rs
@@ -55,7 +55,10 @@ struct Config {
 /// Exits the process if `--help` or `--version` is requested.
 fn parse_args() -> Config {
     let args: Vec<String> = std::env::args().collect();
-    let mut data_dir: Option<PathBuf> = None;
+    // Check for VESTIGE_DATA_DIR environment variable first
+    let mut data_dir: Option<PathBuf> = std::env::var("VESTIGE_DATA_DIR")
+        .ok()
+        .map(PathBuf::from);
     let mut http_port: u16 = std::env::var("VESTIGE_HTTP_PORT")
         .ok()
         .and_then(|s| s.parse().ok())
@@ -83,16 +86,19 @@ fn parse_args() -> Config {
                 println!();
                 println!("ENVIRONMENT:");
                 println!(
-                    "    RUST_LOG                  Log level filter (e.g., debug, info, warn, error)"
+                    "    RUST_LOG                       Log level filter (e.g., debug, info, warn, error)"
                 );
                 println!(
-                    "    VESTIGE_AUTH_TOKEN         Override the bearer token for HTTP transport"
+                    "    VESTIGE_DATA_DIR               Custom data directory (overridden by --data-dir)"
                 );
-                println!("    VESTIGE_HTTP_PORT          HTTP transport port (default: 3928)");
-                println!("    VESTIGE_DASHBOARD_ENABLED     Enable dashboard (default: disabled)");
-                println!("    VESTIGE_DASHBOARD_PORT     Dashboard port (default: 3927)");
                 println!(
-                    "    VESTIGE_SYSTEM_PROMPT_MODE Inject the full composition mandate into every MCP session (minimal|full, default: minimal)"
+                    "    VESTIGE_AUTH_TOKEN             Override the bearer token for HTTP transport"
+                );
+                println!("    VESTIGE_HTTP_PORT              HTTP transport port (default: 3928)");
+                println!("    VESTIGE_DASHBOARD_ENABLED      Enable dashboard (default: disabled)");
+                println!("    VESTIGE_DASHBOARD_PORT         Dashboard port (default: 3927)");
+                println!(
+                    "    VESTIGE_SYSTEM_PROMPT_MODE     Inject the full composition mandate into every MCP session (minimal|full, default: minimal)"
                 );
                 println!();
                 println!("EXAMPLES:");
@@ -100,6 +106,7 @@ fn parse_args() -> Config {
                 println!("    vestige-mcp --data-dir /custom/path");
                 println!("    vestige-mcp --http-port 8080");
                 println!("    RUST_LOG=debug vestige-mcp");
+                println!("    VESTIGE_DATA_DIR=~/.my-vestige vestige-mcp");
                 std::process::exit(0);
             }
             "--version" | "-V" => {
@@ -113,6 +120,7 @@ fn parse_args() -> Config {
                     eprintln!("Usage: vestige-mcp --data-dir <PATH>");
                     std::process::exit(1);
                 }
+                // CLI flag overrides environment variable
                 data_dir = Some(PathBuf::from(&args[i]));
             }
             arg if arg.starts_with("--data-dir=") => {
@@ -123,6 +131,7 @@ fn parse_args() -> Config {
                     eprintln!("Usage: vestige-mcp --data-dir <PATH>");
                     std::process::exit(1);
                 }
+                // CLI flag overrides environment variable
                 data_dir = Some(PathBuf::from(path));
             }
             "--http-port" => {

--- a/crates/vestige-mcp/src/main.rs
+++ b/crates/vestige-mcp/src/main.rs
@@ -58,7 +58,14 @@ fn parse_args() -> Config {
     // Check for VESTIGE_DATA_DIR environment variable first
     let mut data_dir: Option<PathBuf> = std::env::var("VESTIGE_DATA_DIR")
         .ok()
-        .map(PathBuf::from);
+        .and_then(|s| {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(PathBuf::from(trimmed))
+            }
+        });
     let mut http_port: u16 = std::env::var("VESTIGE_HTTP_PORT")
         .ok()
         .and_then(|s| s.parse().ok())
@@ -106,7 +113,7 @@ fn parse_args() -> Config {
                 println!("    vestige-mcp --data-dir /custom/path");
                 println!("    vestige-mcp --http-port 8080");
                 println!("    RUST_LOG=debug vestige-mcp");
-                println!("    VESTIGE_DATA_DIR=~/.my-vestige vestige-mcp");
+                println!("    VESTIGE_DATA_DIR=$HOME/.my-vestige vestige-mcp");
                 std::process::exit(0);
             }
             "--version" | "-V" => {

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -37,7 +37,23 @@ Separate memory per codebase. Good for:
 - Different coding styles per project
 - Team environments
 
-**Claude Code Setup:**
+**Method 1: Environment Variable**
+
+Set `VESTIGE_DATA_DIR` in your project's `.claude/settings.local.json`:
+```json
+{
+  "mcpServers": {
+    "vestige": {
+      "command": "vestige-mcp",
+      "env": {
+        "VESTIGE_DATA_DIR": "./.vestige"
+      }
+    }
+  }
+}
+```
+
+**Method 2: Command-line Argument**
 
 Add to your project's `.claude/settings.local.json`:
 ```json
@@ -51,7 +67,9 @@ Add to your project's `.claude/settings.local.json`:
 }
 ```
 
-This creates `.vestige/vestige.db` in your project root. Add `.vestige/` to `.gitignore`.
+Both methods create `.vestige/vestige.db` in your project root. Add `.vestige/` to `.gitignore`.
+
+**Note:** The `--data-dir` flag takes precedence over the `VESTIGE_DATA_DIR` environment variable.
 
 **Multiple Named Instances:**
 
@@ -64,7 +82,9 @@ For power users who want both global AND project memory:
     },
     "vestige-project": {
       "command": "vestige-mcp",
-      "args": ["--data-dir", "./.vestige"]
+      "env": {
+        "VESTIGE_DATA_DIR": "./.vestige"
+      }
     }
   }
 }
@@ -80,7 +100,9 @@ For setups with multiple Claude instances (e.g., Claude Desktop + Claude Code, o
   "mcpServers": {
     "vestige": {
       "command": "vestige-mcp",
-      "args": ["--data-dir", "~/shared-vestige"]
+      "env": {
+        "VESTIGE_DATA_DIR": "~/shared-vestige"
+      }
     }
   }
 }
@@ -94,7 +116,9 @@ Claude Desktop config - for "Domovoi":
   "mcpServers": {
     "vestige": {
       "command": "vestige-mcp",
-      "args": ["--data-dir", "~/vestige-domovoi"]
+      "env": {
+        "VESTIGE_DATA_DIR": "~/vestige-domovoi"
+      }
     }
   }
 }
@@ -106,7 +130,9 @@ Claude Code config - for "Storm":
   "mcpServers": {
     "vestige": {
       "command": "vestige-mcp",
-      "args": ["--data-dir", "~/vestige-storm"]
+      "env": {
+        "VESTIGE_DATA_DIR": "~/vestige-storm"
+      }
     }
   }
 }

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -94,6 +94,8 @@ For power users who want both global AND project memory:
 
 For setups with multiple Claude instances (e.g., Claude Desktop + Claude Code, or two personas):
 
+> **Note:** `VESTIGE_DATA_DIR` and `--data-dir` both support `~/…` paths. The server expands a leading `~` to the current user's home directory, so these values work correctly in JSON configs where the shell does not perform expansion.
+
 **Shared Memory (Both Claudes share memories):**
 ```json
 {

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -67,7 +67,7 @@ Add to your project's `.claude/settings.local.json`:
 }
 ```
 
-Both methods create `.vestige/vestige.db` in your project root. Add `.vestige/` to `.gitignore`.
+In the examples above, both methods create `./.vestige/vestige.db` relative to your project root. Add `.vestige/` to `.gitignore`.
 
 **Note:** The `--data-dir` flag takes precedence over the `VESTIGE_DATA_DIR` environment variable.
 


### PR DESCRIPTION
This pull request improves how the `vestige-mcp` server handles custom data directories, making it easier to configure persistent storage using environment variables or command-line flags. It also updates the documentation to clarify these options and adds support for tilde (`~`) expansion in paths, ensuring compatibility with user home directories.

**Configuration and path handling improvements:**

- Added support for specifying the data directory using the `VESTIGE_DATA_DIR` environment variable, which is now checked before command-line arguments. The CLI flag `--data-dir` still takes precedence if both are provided. (`crates/vestige-mcp/src/main.rs`, [[1]](diffhunk://#diff-3db9900560c6be0e25c081d2fadd11e319c75040f8afff7ba6d36de41069f16bL58-R89) [[2]](diffhunk://#diff-3db9900560c6be0e25c081d2fadd11e319c75040f8afff7ba6d36de41069f16bL116-R152) [[3]](diffhunk://#diff-3db9900560c6be0e25c081d2fadd11e319c75040f8afff7ba6d36de41069f16bL126-R163)
- Implemented tilde (`~`) expansion for both `VESTIGE_DATA_DIR` and `--data-dir`, allowing paths like `~/my-vestige` to correctly resolve to the user's home directory. (`crates/vestige-mcp/src/main.rs`, [crates/vestige-mcp/src/main.rsR47-R67](diffhunk://#diff-3db9900560c6be0e25c081d2fadd11e319c75040f8afff7ba6d36de41069f16bR47-R67))
- The server now ensures the data directory exists (creating it if necessary) and sets secure permissions on Unix systems. The database file is always stored as `vestige.db` inside the specified directory. (`crates/vestige-mcp/src/main.rs`, [crates/vestige-mcp/src/main.rsR225-R252](diffhunk://#diff-3db9900560c6be0e25c081d2fadd11e319c75040f8afff7ba6d36de41069f16bR225-R252))

**Documentation updates:**

- Updated `docs/STORAGE.md` to document both environment variable and CLI flag methods for setting the data directory, including examples for `.claude/settings.local.json`. Clarified that `--data-dir` overrides `VESTIGE_DATA_DIR`. (`docs/STORAGE.md`, [[1]](diffhunk://#diff-510215304e2f23ddd542521b593ad803cd8296c2aefb61baba8faafc3488be92L40-R56) [[2]](diffhunk://#diff-510215304e2f23ddd542521b593ad803cd8296c2aefb61baba8faafc3488be92L54-R72)
- Noted that both methods support `~` expansion, and updated all configuration examples to use the environment variable for consistency and improved shell-agnostic behavior. (`docs/STORAGE.md`, [[1]](diffhunk://#diff-510215304e2f23ddd542521b593ad803cd8296c2aefb61baba8faafc3488be92L67-R87) [[2]](diffhunk://#diff-510215304e2f23ddd542521b593ad803cd8296c2aefb61baba8faafc3488be92R97-R107) [[3]](diffhunk://#diff-510215304e2f23ddd542521b593ad803cd8296c2aefb61baba8faafc3488be92L97-R123) [[4]](diffhunk://#diff-510215304e2f23ddd542521b593ad803cd8296c2aefb61baba8faafc3488be92L109-R137)