### PR TITLE
Add CUDA feature for qwen3-embeddings (Windows/Linux NVIDIA support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,56 @@ cargo build --release -p vestige-mcp --features qwen3-embeddings,metal
 VESTIGE_EMBEDDING_MODEL=qwen3-0.6b vestige consolidate
 ```
 
+### Building with CUDA support (NVIDIA hosts — Windows / Linux)
+
+The `cuda` feature routes Qwen3 embedding through NVIDIA GPUs via
+`candle-core/cuda`. On a host with the CUDA toolkit installed and a
+supported NVIDIA runtime, this drops Qwen3-Embedding inference from
+CPU-bound to GPU-bound (typically ~40-50x speedup for batched workloads).
+
+```bash
+# Linux / Windows + CUDA toolkit (12.x or 13.x)
+cargo build --release -p vestige-mcp --features qwen3-embeddings,cuda
+
+# Optional cuDNN acceleration on top of CUDA
+cargo build --release -p vestige-mcp --features qwen3-embeddings,cudnn
+
+VESTIGE_EMBEDDING_MODEL=qwen3-0.6b vestige consolidate
+```
+
+**Prerequisites:**
+
+- NVIDIA driver + CUDA toolkit (12.x or 13.x). Verify with `nvcc --version`.
+- A C++ host compiler that `nvcc` can drive (Linux: `gcc`; Windows:
+  MSVC / `cl.exe` from a recent Visual Studio Build Tools install).
+
+**Windows + MSVC + CUDA 13.x build note.** Recent CCCL headers (shipped
+with CUDA 13.x) require the modern preprocessor. Without it, the
+`candle-kernels` `.cu` compile pass fails with `fatal error C1189:
+[...] CCCL requires MSVC/cl.exe with traditional preprocessor` (see
+`cuda/include/cuda/std/__cccl/compiler.h`). Set this env var before
+`cargo build` to instruct `nvcc` to pass `/Zc:preprocessor` to the
+host compiler:
+
+```powershell
+# PowerShell
+$env:NVCC_PREPEND_FLAGS = '-Xcompiler="/Zc:preprocessor"'
+cargo build --release -p vestige-mcp --features qwen3-embeddings,cuda
+```
+
+```cmd
+:: cmd.exe
+set NVCC_PREPEND_FLAGS=-Xcompiler="/Zc:preprocessor"
+cargo build --release -p vestige-mcp --features qwen3-embeddings,cuda
+```
+
+Linux + CUDA 13.x builds with `gcc` do not need the equivalent flag.
+
+**Verifying GPU is actually used.** With CUDA-enabled builds, run
+`VESTIGE_EMBEDDING_MODEL=qwen3-0.6b vestige consolidate` on a corpus of
+~1000+ memories and watch `nvidia-smi` — embedding passes should pin a
+single GPU while the run is active.
+
 ---
 
 ## CLI

--- a/crates/vestige-core/Cargo.toml
+++ b/crates/vestige-core/Cargo.toml
@@ -60,6 +60,19 @@ qwen3-reranker = ["qwen3-embeddings"]
 # Metal GPU acceleration on Apple Silicon (significantly faster inference)
 metal = ["fastembed/metal"]
 
+# CUDA GPU acceleration on NVIDIA hardware (Windows / Linux, x86_64 + aarch64).
+# Propagates to `candle-core/cuda`, which pulls in `cudarc` and `candle-kernels`
+# (per-build nvcc compile pass). Pair with the `qwen3-embeddings` feature so
+# the Candle backend is actually present in the build graph; on its own,
+# `cuda` is a no-op for builds that don't include `candle-core`.
+#
+# Build: cargo build --release -p vestige-mcp --features qwen3-embeddings,cuda
+# See README "Building with CUDA support" for prerequisites + MSVC notes.
+cuda = ["qwen3-embeddings", "candle-core/cuda"]
+
+# cuDNN on top of CUDA — additional fused kernels, faster inference paths.
+cudnn = ["cuda", "candle-core/cudnn"]
+
 
 [dependencies]
 # Serialization

--- a/crates/vestige-core/src/embeddings/local.rs
+++ b/crates/vestige-core/src/embeddings/local.rs
@@ -209,6 +209,16 @@ fn get_backend() -> Result<std::sync::MutexGuard<'static, EmbeddingBackend>, Emb
 
 #[cfg(feature = "qwen3-embeddings")]
 fn qwen3_device() -> Device {
+    // CUDA branch — ordered before Metal so NVIDIA hosts (Windows / Linux)
+    // route Qwen3 embedding through GPU when the `cuda` feature is enabled
+    // at build time. Without this branch, builds with `--features cuda`
+    // still fall through to `Device::Cpu` on every non-Apple platform.
+    #[cfg(feature = "cuda")]
+    {
+        if let Ok(device) = Device::new_cuda(0) {
+            return device;
+        }
+    }
     #[cfg(feature = "metal")]
     {
         if let Ok(device) = Device::new_metal(0) {

--- a/crates/vestige-mcp/Cargo.toml
+++ b/crates/vestige-mcp/Cargo.toml
@@ -24,6 +24,10 @@ ort-dynamic = ["embeddings", "vestige-core/ort-dynamic"]
 qwen3-embeddings = ["embeddings", "vestige-core/qwen3-embeddings"]
 qwen3-reranker = ["qwen3-embeddings"]
 metal = ["embeddings", "vestige-core/metal"]
+# CUDA GPU acceleration on NVIDIA hardware (Windows / Linux, x86_64 + aarch64).
+# Pairs with `qwen3-embeddings` — see vestige-core Cargo.toml.
+cuda = ["qwen3-embeddings", "vestige-core/cuda"]
+cudnn = ["cuda", "vestige-core/cudnn"]
 
 [[bin]]
 name = "vestige-mcp"


### PR DESCRIPTION
## Why

`qwen3-embeddings` builds today route Qwen3 embedding inference through CPU on every NVIDIA host. Both `crates/vestige-core/Cargo.toml` and `crates/vestige-mcp/Cargo.toml` expose only a `metal` feature flag for GPU acceleration, and `qwen3_device()` in `crates/vestige-core/src/embeddings/local.rs:210` only tries `Device::new_metal(0)` before falling back to `Device::Cpu`. NVIDIA users (Windows / Linux) currently have no path to GPU acceleration for the Candle-backed embedding path, even though `candle-core` ships a `cuda` feature.

Worked-example impact on a real deployment: a 3,276-memory `vestige consolidate` re-embed dropped from a CPU-bound ~4 hour projected wall-clock (killed at 7.4% coverage after 18 min) to ~5 min total on an RTX PRO 6000 — roughly **~45× speedup**, sustained 60-95% GPU utilization.

## What changed

Three small commits, mirroring the existing `metal` shape:

1. **`feat(cargo): expose cuda + cudnn feature flags propagating to candle-core`**
   Adds `cuda = ["qwen3-embeddings", "candle-core/cuda"]` and `cudnn = ["cuda", "candle-core/cudnn"]` to `vestige-core/Cargo.toml`, with the matching propagation entries in `vestige-mcp/Cargo.toml`. Pairs with `qwen3-embeddings` (where `candle-core` is brought into the build graph) so `cuda` is never a silent no-op. Default build is unchanged; CUDA / cuDNN are opt-in.

2. **`feat(qwen3-embeddings): add CUDA device branch in qwen3_device()`**
   Adds a `#[cfg(feature = "cuda")] { if let Ok(device) = Device::new_cuda(0) { return device; } }` branch BEFORE the existing Metal branch in `qwen3_device()`. Without this, a `--features cuda` build still falls through to `Device::Cpu`. Branch ordering (CUDA → Metal → CPU) keeps every existing build path identical: builds without `cuda` see no behavior change.

3. **`docs(readme): add 'Building with CUDA support' section`**
   New README section under "Optional Features" documenting the build invocation, prerequisites (CUDA 12.x / 13.x toolkit + host C++ compiler), the Windows / MSVC / CUDA 13.x preprocessor workaround, and how to verify the GPU is actually being used.

## Build notes (Windows / MSVC / CUDA 13.x)

On Windows with the CUDA 13.x toolkit + MSVC, the first `--features cuda` build fails at the `candle-kernels` `.cu` compile step with:

```
fatal error C1189: #error: CCCL requires MSVC/cl.exe with traditional preprocessor
```

CCCL headers shipped with CUDA 13.x (see `cuda/include/cuda/std/__cccl/compiler.h`) gate on the modern conforming preprocessor. Setting `NVCC_PREPEND_FLAGS=-Xcompiler="/Zc:preprocessor"` instructs `nvcc` to pass `/Zc:preprocessor` to the host compiler and unblocks the build. The README section walks through the PowerShell + cmd.exe variants. Linux + `gcc` + CUDA 13.x does not need the equivalent flag.

## Backwards compatibility

100% backwards compatible. Default build invocation (`cargo build --release -p vestige-mcp`) is byte-identical with this branch versus `main` — no new dependencies are added to the default feature graph, no behavior change. CUDA is strictly opt-in via `--features cuda` (or `--features cudnn`), and `cuda` itself transitively enables `qwen3-embeddings` so users can't accidentally request a no-op CUDA build.

## Local CI

On the PR branch, against current `main` (HEAD `a8550410`, post-PR #56):

- `cargo check -p vestige-core` (default features) — clean
- `cargo check -p vestige-core --no-default-features --features "bundled-sqlite,vector-search,ort-download,qwen3-embeddings"` — clean
- `cargo check -p vestige-core --no-default-features --features "bundled-sqlite,vector-search,ort-download,qwen3-embeddings,cuda"` — feature graph resolves, `cudarc` builds (using `CUDARC_CUDA_VERSION=12090` against a CUDA 13.2 toolkit, since `cudarc 0.19.7` doesn't auto-detect CUDA 13.x version strings yet). Full nvcc kernel compile then proceeds to the host-compiler step (the MSVC preprocessor workaround described above).
- `cargo clippy -p vestige-core --no-deps -- -D warnings` — clean (default features)
- `cargo clippy -p vestige-core --no-deps --no-default-features --features "...,qwen3-embeddings" -- -D warnings` — clean
- `VESTIGE_TEST_MOCK_EMBEDDINGS=1 cargo test -p vestige-core --lib` — **385 passed, 0 failed**

A separate downstream issue worth flagging independently: `qwen3_device()`'s existing fallthrough to `Device::Cpu` on non-Apple platforms is the underlying bug this PR addresses. Even before the `cuda` feature existed, the function silently CPU-routed on Linux / Windows hosts that built `qwen3-embeddings`. The CUDA branch is the structural fix; the broader question (should `qwen3_device()` document or log when it falls back to CPU?) is a worthwhile UX follow-up that could be tracked as a separate issue.

## Cross-link

Worked-example deployment notes: 3,276-memory `vestige consolidate` on RTX PRO 6000, peak VRAM 92,529 MiB (model + workspace), sustained 60-95% GPU utilization. Happy to share more numbers if useful for a release-notes blurb.
