### PR TITLE
fix(core): re-enable usearch fp16lib to unbreak Windows MSVC build (#93)

### DIFF
--- a/crates/vestige-core/Cargo.toml
+++ b/crates/vestige-core/Cargo.toml
@@ -130,8 +130,19 @@ candle-core = { version = "0.10.2", optional = true }
 #
 # Disable default features so release binaries do not include SimSIMD's
 # Haswell+/AVX2/FMA dispatch targets. Those kernels can trigger illegal
-# instructions on older x86_64 CPUs that Vestige otherwise supports.
-usearch = { version = "=2.23.0", default-features = false, optional = true }
+# instructions on older x86_64 CPUs that Vestige otherwise supports (#71).
+#
+# But re-enable `fp16lib` explicitly. usearch's defaults are
+# ["simsimd", "fp16lib"]; with BOTH off, build.rs sets USEARCH_USE_FP16LIB=0
+# and USEARCH_USE_SIMSIMD=0, which selects the bare half-precision `#else`
+# branch in include/usearch/index_plugins.hpp. That branch carries a
+# `#warning` directive, which MSVC's cl.exe treats as fatal error C1021,
+# breaking the Windows build (GCC/Clang only warn). `fp16lib` is a scalar,
+# self-contained fp16<->fp32 conversion library with NO SIMD intrinsics, so
+# re-enabling it sets USEARCH_USE_FP16LIB=1 (taking the non-warning branch)
+# WITHOUT reintroducing the SimSIMD illegal-instruction risk from #71. Do not
+# drop this feature.
+usearch = { version = "=2.23.0", default-features = false, features = ["fp16lib"], optional = true }
 
 # LRU cache for query embeddings
 lru = "0.16"


### PR DESCRIPTION
## Summary

Fixes #93. Building any crate that pulls in `usearch` (via the default `vector-search` feature) on **Windows + MSVC** fails compiling usearch's bundled C++:

```
include\usearch/index_plugins.hpp(404): fatal error C1021: invalid preprocessor command 'warning'
error: failed to run custom build command for `usearch v2.23.0`
```

Reproduces on v2.1.26, v2.1.27, and `main`. v2.1.25 built cleanly.

## Root cause

The v2.1.26 pin set `default-features = false` on usearch to drop SimSIMD's AVX2/Haswell dispatch — the illegal-instruction crash on older x86_64 CPUs from #71. That part is intended and correct.

But usearch's defaults are `["simsimd", "fp16lib"]`. Disabling **all** defaults also dropped the *unrelated* `fp16lib` feature. With both off, usearch's `build.rs` sets `USEARCH_USE_FP16LIB=0` and `USEARCH_USE_SIMSIMD=0`, which selects the bare `#else` half-precision branch in `index_plugins.hpp` — and that branch carries:

```cpp
#warning "It's recommended to use SimSIMD and fp16lib for half-precision numerics"
```

GCC/Clang treat `#warning` as a non-fatal diagnostic (so Linux/macOS never caught it). MSVC's `cl.exe` treats it as **fatal error C1021**. `/Zc:preprocessor` does not change this.

## Fix

Re-enable **`fp16lib` only**, keeping SimSIMD disabled:

```toml
usearch = { version = "=2.23.0", default-features = false, features = ["fp16lib"], optional = true }
```

`fp16lib` is a scalar, self-contained fp16↔fp32 conversion library with **no SIMD intrinsics** (its build.rs entry only sets `USEARCH_USE_FP16LIB=1`; only the separate `simsimd` feature compiles `simsimd/c/lib.c`). So this takes the non-warning `#if USEARCH_USE_FP16LIB` branch **without reintroducing the #71 illegal-instruction risk**. Restores the v2.1.25 half-precision path while keeping #71's portability fix.

- usearch stays pinned at `=2.23.0`.
- `Cargo.lock` is **unchanged** (feature selection only).

## Verification (macOS aarch64 — MSVC repro is Windows-only)

- `cargo build -p vestige-core` ✅ (usearch C++ compiled + linked)
- `cargo build -p vestige-mcp` ✅ (the crate that failed on Windows)
- `cargo test -p vestige-core vector` → **9/9 pass** (HNSW add/search/update/remove/threshold)
- `cargo clippy -p vestige-core` ✅ clean
- `cargo tree -e features` confirms `usearch feature "fp16lib"` is active and **`simsimd` is NOT** → #71 fix preserved

The actual `C1021` failure is Windows/MSVC-only and cannot be exercised on this host; the issue author confirmed this exact one-line change produces a clean MSVC build of all three vestige-mcp binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)