### PR TITLE
Add Dockerfile for MCP registry introspection (Glama)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Dockerfile for running the Vestige MCP server in an isolated sandbox.
+#
+# Used by registries such as Glama to start the server and run the standard
+# MCP stdio introspection exchange (tools/list, resources/list, prompts/list).
+# The server speaks MCP over stdio, which is exactly what these tools expect.
+#
+# Base must be glibc (Debian), not musl/Alpine: the npm postinstall downloads
+# the prebuilt x86_64-unknown-linux-gnu Rust binary from the GitHub release, and
+# a -gnu binary will not run on an Alpine/musl image.
+
+FROM node:20-slim
+
+# ca-certificates lets the postinstall fetch the release asset over HTTPS.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the published package globally. Its postinstall downloads the matching
+# prebuilt vestige-mcp binary for linux/x64 from the GitHub release.
+RUN npm install -g vestige-mcp-server@latest
+
+# Keep all memory data inside the container under a writable path.
+ENV VESTIGE_DATA_DIR=/data
+RUN mkdir -p /data
+
+# Start the MCP server on stdio. The `vestige-mcp` bin execs the native binary
+# and inherits stdio, so the MCP client talks to it directly.
+ENTRYPOINT ["vestige-mcp"]


### PR DESCRIPTION
Adds a Dockerfile so MCP registries (Glama in particular) can start Vestige in an isolated sandbox and run the standard MCP stdio introspection (tools/list, resources/list, prompts/list). Without it, Glama shows the server as cannot be installed / not tested, which blocks the score and the awesome-mcp-servers listing.

What it does:
- node:20-slim (glibc) base. Required because the npm postinstall downloads the prebuilt x86_64-unknown-linux-gnu binary from the GitHub release. A -gnu binary does not run on a musl/Alpine image.
- Installs vestige-mcp-server@latest globally; the postinstall fetches the matching native binary at build time.
- VESTIGE_DATA_DIR=/data keeps all memory state inside the container.
- ENTRYPOINT vestige-mcp speaks MCP over stdio, which is the transport Glama uses.

Verified locally: npm install runs the postinstall and fetches the binary, the server boots and applies its migrations, and it answers initialize plus tools/list over stdio with the full tool surface.

Closes the Glama gate requested on the punkpeye/awesome-mcp-servers listing PR.