### PR TITLE
fix(ci): restore vector-search feature to Windows MSVC release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,14 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             archive: zip
-            cargo_flags: "--no-default-features --features embeddings,ort-download"
+            # vector-search (usearch HNSW index) is REQUIRED. Without it the
+            # storage layer's #[cfg(feature = "vector-search")] paths compile
+            # out, so embeddings are never persisted or queried: the binary
+            # reports "Embedding Service: Not Ready", 0% coverage, consolidate
+            # generates 0 embeddings, and no model download is ever attempted.
+            # usearch builds cleanly on MSVC because vestige-core pins it with
+            # features=["fp16lib"] (see crates/vestige-core/Cargo.toml).
+            cargo_flags: "--no-default-features --features embeddings,ort-download,vector-search"
             needs_onnxruntime: false
           # Intel Mac uses the ort-dynamic feature to runtime-link against a
           # system libonnxruntime (Homebrew), sidestepping the missing


### PR DESCRIPTION
## Problem

On the **v2.2.0 `x86_64-pc-windows-msvc`** build the embedding service never becomes ready. New memories get no embedding, semantic search returns nothing, and `vestige health` reports **"Embedding Service: Not Ready"**. The same machine, model cache, and data work correctly on v2.1.23.

Reporter's repro (fresh data dir + fresh empty cache):

```
vestige ingest "the quick brown fox jumps over the lazy dog" --data-dir <tmp>
vestige stats --data-dir <tmp>
```

v2.2.0 → `With Embeddings: 0`, `Coverage: 0.0%`, `Embedding Service: Not Ready`, **no model download is ever attempted**.
v2.1.23 (same machine/cache) → `With Embeddings: 1`, `Coverage: 100.0%`, `Ready`.

## Root cause

The Windows release build dropped the `vector-search` feature:

```yaml
# release.yml, x86_64-pc-windows-msvc
cargo_flags: "--no-default-features --features embeddings,ort-download"   # missing vector-search
```

`vector-search = ["dep:usearch"]` gates the usearch HNSW index. Without it, the storage layer's `#[cfg(feature = "vector-search")]` paths (in `storage/sqlite.rs`, `embeddings/mod.rs`, `lib.rs`) compile out, so embeddings are never persisted or queried. That produces every symptom: 0% coverage, "Not Ready", `consolidate` generates 0 embeddings, and — the tell — **no model download is attempted**, because nothing ever asks the vector store to store a vector (the lazy `is_ready()` gate on the ingest path stays false and never triggers init).

Compare the other release targets, which all keep `vector-search`:
- Linux `x86_64-unknown-linux-gnu`: `cargo_flags: ""` (full defaults include `vector-search`)
- Intel Mac: `--no-default-features --features ort-dynamic,vector-search`
- ARM Mac: `cargo_flags: ""` (defaults)

Only Windows dropped it. This is not a usearch/fp16lib build regression (that was fixed properly by pinning usearch with `features=["fp16lib"]` to dodge the MSVC C1021 `#warning`) — `vector-search` was likely omitted as a workaround that is now both unnecessary and the actual cause.

## Fix

Add `vector-search` back to the Windows `cargo_flags` so the surface matches the intended default set (`embeddings,ort-download,vector-search`).

## Verification

- `cargo build --release -p vestige-mcp --no-default-features --features embeddings,ort-download,vector-search` compiles and links cleanly (the feature combo is valid post-refactor).
- `cargo clippy` on the same feature set is clean (only pre-existing dead-code warnings).
- Behavioral: the reporter's repro on a `vector-search`-enabled build downloads the nomic model on `consolidate` and reaches **100% embedding coverage** (`With Embeddings: 1`).

CI note: `ci.yml`'s release-build matrix does not include a Windows target, so this configuration is compiled for the first time at release time — which is why it slipped through. Adding a Windows compile-check to CI would prevent recurrence (out of scope for this one-line fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)