### PR TITLE
docs(launch): purge retracted CauseBench figures from launch assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,32 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  retracted-claims-tripwire:
+    name: Retracted-claims tripwire
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail if retracted CauseBench figures reappear
+        run: |
+          # CauseBench was withdrawn and its numbers retracted (CHANGELOG,
+          # v2.2.x). This job fails if any retracted figure reappears outside
+          # the files that legitimately QUOTE it inside a retraction notice.
+          set -u
+          PATTERNS='root-cause recall@1|Vestige 60%|vector search 0%|on CauseBench'
+          ALLOW='^(CHANGELOG\.md|docs/launch/causal-brain-demo\.html|docs/launch/backward-trace-animation-storyboard\.md|\.github/workflows/ci\.yml)'
+          HITS=$(grep -rInE "$PATTERNS" \
+            --include='*.md' --include='*.html' --include='*.rs' \
+            --include='*.ts' --include='*.svelte' --include='*.js' \
+            --exclude-dir=node_modules --exclude-dir=target \
+            --exclude-dir=build . 2>/dev/null \
+            | sed 's|^\./||' | grep -vE "$ALLOW" || true)
+          if [ -n "$HITS" ]; then
+            echo "::error::Retracted CauseBench figures found — these numbers were withdrawn and must not be republished:"
+            echo "$HITS"
+            exit 1
+          fi
+          echo "clean: no retracted figures outside retraction notices"
+
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/apps/dashboard/OBSERVATORY-SPEC.md
+++ b/apps/dashboard/OBSERVATORY-SPEC.md
@@ -608,8 +608,9 @@ NO solid panels. Instruments float, glow faintly, and never block the canvas
 `causal-brain-demo.html` IS Moment C (salience-rescue / backward-trace) as a 2D canvas
 proof: brain point cloud (two lobes, center-dense), a failure flare on the deep right, a
 vector-search stall on confounders, then a BACKWARD arrow tracing to the dormant cause on
-the deep-left which **ignites**, then a verdict card ("Vestige 60% · vector search 0%"),
-then the VESTIGE wordmark. Beat clock: brain forms 0-1.5s, fail fades in ~0.3s, vector
+the deep-left which **ignites**, then a verdict card (scene-derived cause label + receipt
+line, as `RescueVerdict.svelte` ships it — never a benchmark figure: the old CauseBench
+"60% / 0%" stat is retracted, see CHANGELOG), then the VESTIGE wordmark. Beat clock: brain forms 0-1.5s, fail fades in ~0.3s, vector
 stalls 4-6.5s, backward trace fires 6.5-10.5s, verdict 10.5-13s, signature 13-15s, loop.
 The Observatory's `?demo=salience-rescue` must reproduce this exact narrative in real
 WebGPU with real memory nodes. Study its `spectral`, `seedBrain`, `glow`, and beat

--- a/docs/launch/backward-trace-animation-storyboard.md
+++ b/docs/launch/backward-trace-animation-storyboard.md
@@ -1,5 +1,17 @@
 # Backward-Trace Animation — Storyboard ("The X Rocket")
 
+> ⚠️ **The CauseBench numbers this storyboard was written around are RETRACTED.**
+> CauseBench was withdrawn and its published figures retracted (see `CHANGELOG.md`,
+> v2.2.x). **Do not publish `root-cause recall@1`, `Vestige 60%`, `vector search 0%`,
+> or any other CauseBench figure**, from this document or anywhere else.
+>
+> The animation *design* below is still good and is kept for that reason. Where a
+> stat is called for, use the pre-registered, reproducible
+> [Silent Rotation](https://github.com/samvallad33/vestige/tree/benchmark/silent-rotation)
+> result instead: **no memory 21/25 converged wrong, dense cosine 12/23, Vestige 0/23**.
+> The stat lines below have already been updated; the surrounding prose still
+> describes the incident *shape*, which remains accurate.
+
 **Purpose:** the single most shareable launch artifact. A ~15s looping clip,
 pinned to the top of the launch thread on X and used as the Show HN demo. It
 shows the ONE thing nothing else does: when a failure hits, Vestige's arrow
@@ -13,12 +25,18 @@ pitch.
 
 ---
 
-## The case shown (canonical CauseBench archetype)
+## The case shown (canonical root-cause archetype)
 
-Uses the exact incident SHAPE the benchmark is built on (see
-`benchmarks/causebench/data/real/*.meta.json`: a config/limit/cert/migration/flag
-change that shares an *entity* with a later failure but *none of its words*, with
-a more-recent confounder planted to defeat naive recency).
+Uses the incident SHAPE that makes causal recall hard: a
+config/limit/cert/migration/flag change that shares an *entity* with a later
+failure but *none of its words*, with a more-recent confounder planted to defeat
+naive recency.
+
+(This shape was originally drawn from the CauseBench fixtures. That benchmark and
+its numbers are retracted and `benchmarks/causebench/` no longer exists, but the
+incident shape itself is unchanged and is the same one
+[Silent Rotation](https://github.com/samvallad33/vestige/tree/benchmark/silent-rotation)
+exercises.)
 
 Timeline of stored memories (left = 3 weeks ago, right = today):
 
@@ -63,8 +81,10 @@ pool-size change to #1.
 
 **Beat 4 — 10.5s to 13.0s · THE VERDICT**
 - The promoted cause card shows a teal `#1` badge; the vector `#7` badge greys beside it for contrast.
-- Two-line stat, big: `root-cause recall@1` / `Vestige 60% · vector search 0%`
-- Small honest sub-label: `on CauseBench · reproducible`
+- Two-line stat, big: `converged on the wrong cause` / `Vestige 0/23 · no memory 21/25`
+- Small honest sub-label: `dense cosine 12/23 · on Silent Rotation · pre-registered`
+- Keep the big line at roughly 30 characters. `.v` renders up to 72px in
+  `causal-brain-demo.html`; longer strings overflow the card.
 
 **Beat 5 — 13.0s to 15.0s · SIGNATURE + LOOP RESET**
 - Wordmark `vestige` fades in bottom-left, tiny. Tagline: `memory that finds the cause, not the resemblance.`
@@ -84,9 +104,10 @@ pool-size change to #1.
   sans for captions. No narration — captions carry it, so it works muted in a
   feed (most X video autoplays silent).
 - **Honesty guardrails (non-negotiable, same as the chart):** the stat frame
-  must say `60%` with `on CauseBench` attached, and pair it with `vector search
-  0%`. Never imply an industry benchmark. Never show the FALSE cross-session
-  claim.
+  must name `Silent Rotation` and keep the competitor arms beside Vestige's
+  number, never Vestige's alone. Never imply an industry benchmark. Never show
+  the FALSE cross-session claim. Never reinstate any CauseBench figure: that
+  benchmark was withdrawn and its numbers retracted.
 - **Loop length:** 15s is the sweet spot for X autoplay + a clean GIF under
   ~8MB. If the GIF is too heavy, cut Beat 1 to 2s and land at 13s total.
 
@@ -100,7 +121,8 @@ pool-size change to #1.
 > But a root cause never looks like the bug it creates.
 >
 > So I built memory that reaches *backward in time* to the change that actually
-> caused it. 60% root-cause recall where vector search scores 0%. 🧵👇
+> caused it. In a pre-registered test, agents with no memory converged on the
+> wrong cause 21 times out of 25. With Vestige, 0 out of 23. 🧵👇
 >
 > [pinned: the 15s clip]
 

--- a/docs/launch/causal-brain-demo.html
+++ b/docs/launch/causal-brain-demo.html
@@ -40,10 +40,17 @@
 <div id="stage"><canvas id="c"></canvas></div>
 <div class="layer">
   <div class="cap mono" id="cap"></div>
+  <!--
+    The CauseBench figures that used to sit here ("root-cause recall@1 /
+    Vestige 60% - vector search 0%") were RETRACTED; see CHANGELOG.md under
+    v2.2.x. Do not reinstate them anywhere. Replaced with Silent Rotation,
+    which is pre-registered and reproducible:
+    https://github.com/samvallad33/vestige/tree/benchmark/silent-rotation
+  -->
   <div class="verdict" id="verdict">
-    <div class="k">root-cause recall@1</div>
-    <div class="v">Vestige 60% &middot; vector search 0%</div>
-    <div class="s">on CauseBench &middot; reproducible</div>
+    <div class="k">converged on the wrong cause</div>
+    <div class="v">Vestige 0/23 &middot; no memory 21/25</div>
+    <div class="s">dense cosine 12/23 &middot; on Silent Rotation &middot; pre-registered</div>
   </div>
   <div class="wordmark" id="wordmark">VESTIGE</div>
 </div>


### PR DESCRIPTION
## Problem

CauseBench was withdrawn and its published numbers retracted (`CHANGELOG.md`, v2.2.x), but two launch assets still carry the retracted figure:

- `docs/launch/causal-brain-demo.html` **renders** `root-cause recall@1 / Vestige 60% · vector search 0% / on CauseBench`
- `docs/launch/backward-trace-animation-storyboard.md` instructs whoever builds the clip to publish that number, and pointed at `benchmarks/causebench/data/real/*.meta.json`, a path that no longer exists

Anyone cloning the repo finds retracted benchmark numbers in a repo whose own CHANGELOG says they are retracted.

## What changed

Both now carry the pre-registered [Silent Rotation](https://github.com/samvallad33/vestige/tree/benchmark/silent-rotation) result instead:

```
converged on the wrong cause
Vestige 0/23 · no memory 21/25
dense cosine 12/23 · on Silent Rotation · pre-registered
```

The storyboard gets a retraction banner at the top, and its "honesty guardrails" section now says never to reinstate a CauseBench figure.

## Why neither file is deleted

`causal-brain-demo.html` is not a dead asset. It is the cited source for code that ships:

- `apps/dashboard/src/lib/observatory/shaders/render-edges.wgsl.ts:52` and `render-nodes.wgsl.ts:45` both say *"ported EXACTLY from causal-brain-demo.html"*
- `apps/dashboard/src/lib/observatory/overlays/RescueVerdict.svelte:4` ports its `.verdict` structure
- `apps/dashboard/OBSERVATORY-SPEC.md:565,575,608` cites it as a design source

Deleting it would orphan that provenance. The storyboard's animation design is also still good, so it is kept and corrected rather than removed.

## Verification

- No retracted figure remains anywhere outside the deliberate retraction notices (repo-wide grep across `.md`, `.html`, `.ts`, `.svelte`, `.rs`)
- **No live dashboard source ever carried these numbers.** `RescueVerdict.svelte` takes content via props, and a grep of `apps/dashboard/src` for `recall@1`/`CauseBench` returns nothing, before and after
- Demo integrity unchanged: 6/6 element ids present, 8 open / 8 close divs, comments balanced, and the JS only sets `verdict.style.opacity`, never the text
- Hero `.v` line kept at exactly 30 characters, the length its `clamp(32px,6.4vw,72px)` sizing was designed around. My first replacement was 52 chars and would have overflowed the card

Docs only. No Rust or dashboard source touched, so no test or clippy run applies.
