### PR TITLE
fix(trace): wire the Memory PR write gate into the real tool path (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to Vestige will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed — Memory PR write gate wired into the real tool path (#117)
+
+`gate_writes` — the risk gate that quarantines risky memory writes and opens
+Memory PRs for review — existed and was tested but had **no production
+caller**, so `ReviewMode` was inert and `memory_prs` never populated outside
+tests. It now runs on every traced tool call:
+
+- New shared reader for `<data_dir>/review_mode.json` (default `risk_gated`;
+  missing/corrupt files can never silently disable gating). The dashboard and
+  the write path read the mode through one implementation.
+- Risky writes are suppressed until their Memory PR is decided, and the tool
+  response now carries `memoryPrs` + `memoryPrNotice` so the calling agent
+  knows. The notice is truthful per-write: quarantined writes are reported as
+  held; destructive writes (already applied) are reported as recorded for
+  review, never as "quarantined".
+- Gating rides on the trace gate: `VESTIGE_TRACE_ENABLED=0` disables Memory
+  PRs along with the black box. Documented in `docs/CONFIGURATION.md`.
+
 ## [2.3.0] - 2026-07-26 — "Cognitive Observatory + Zero-Knowledge Sync"
 
 Two audits (39 verified fixes), three dormant features brought to life, a

--- a/crates/vestige-mcp/src/dashboard/handlers.rs
+++ b/crates/vestige-mcp/src/dashboard/handlers.rs
@@ -2343,14 +2343,12 @@ fn review_mode_path(state: &AppState) -> PathBuf {
 }
 
 /// Read the persisted review mode, defaulting to RiskGated.
+///
+/// Delegates to [`crate::trace_recorder::read_review_mode`] so the dashboard and
+/// the MCP write path read the mode through exactly one implementation. If these
+/// ever diverged, the UI could report "Paranoid" while writes were auto-landing.
 pub fn read_review_mode(state: &AppState) -> vestige_core::ReviewMode {
-    let path = review_mode_path(state);
-    fs::read_to_string(&path)
-        .ok()
-        .and_then(|s| serde_json::from_str::<Value>(&s).ok())
-        .and_then(|v| v.get("mode").and_then(|m| m.as_str()).map(String::from))
-        .map(|s| vestige_core::ReviewMode::from_label(&s))
-        .unwrap_or_default()
+    crate::trace_recorder::read_review_mode(&state.storage)
 }
 
 // ============================================================================

--- a/crates/vestige-mcp/src/server.rs
+++ b/crates/vestige-mcp/src/server.rs
@@ -1267,17 +1267,36 @@ impl McpServer {
                 if !opened.is_empty()
                     && let Some(obj) = content.as_object_mut()
                 {
-                    // Tell the calling agent its write is held, so it does not
-                    // assume the memory is live and act on it.
+                    // Tell the calling agent exactly what happened. A held write
+                    // is quarantined until the PR is decided; a destructive write
+                    // (or a failed suppression) is NOT held — the PR is an audit
+                    // record of something that already happened. Saying
+                    // "quarantined" for those would be false.
+                    let held = opened
+                        .iter()
+                        .filter(|o| o.get("held").and_then(|v| v.as_bool()) == Some(true))
+                        .count();
+                    let recorded = opened.len() - held;
+                    let mut parts = Vec::new();
+                    if held > 0 {
+                        parts.push(format!(
+                            "{held} write(s) quarantined until their Memory PR is decided"
+                        ));
+                    }
+                    if recorded > 0 {
+                        parts.push(format!(
+                            "{recorded} write(s) already applied but recorded for review \
+                             (destructive or unsuppressable — nothing is held)"
+                        ));
+                    }
                     obj.insert("memoryPrs".to_string(), serde_json::json!(opened));
                     obj.insert(
                         "memoryPrNotice".to_string(),
                         serde_json::json!(format!(
-                            "{} write(s) were held for review under review mode '{}' and are \
-                             quarantined until decided. Review them in the dashboard under \
-                             Memory PRs, or via GET /api/memory-prs.",
-                            opened.len(),
-                            mode.as_str()
+                            "Review mode '{}': {}. Review in the dashboard under Memory PRs \
+                             or via GET /api/memory-prs.",
+                            mode.as_str(),
+                            parts.join("; ")
                         )),
                     );
                 }
@@ -1954,6 +1973,62 @@ mod tests {
         assert!(
             text.contains("memoryPrNotice"),
             "response must carry the human-readable notice: {text}"
+        );
+        // Truthfulness: this was a normal (non-destructive) write, so it must
+        // report held=true and the notice must say quarantined.
+        assert!(
+            text.contains("\"held\":true"),
+            "a suppressed write must report held=true: {text}"
+        );
+        assert!(
+            text.contains("quarantined until"),
+            "notice for a held write must say quarantined: {text}"
+        );
+    }
+
+    /// The third leg of the mode matrix: Fast mode must open NO Memory PR
+    /// through the real tool path — every write auto-commits.
+    #[tokio::test]
+    async fn fast_mode_opens_no_memory_pr() {
+        use vestige_core::MemoryPrStatus;
+
+        let (storage, _dir) = test_storage().await;
+        std::fs::write(
+            storage.data_dir().join("review_mode.json"),
+            r#"{"mode":"fast"}"#,
+        )
+        .unwrap();
+
+        let cognitive = Arc::new(Mutex::new(CognitiveEngine::new()));
+        let mut server = McpServer::new(storage.clone(), cognitive);
+        server
+            .handle_request(make_request("initialize", Some(init_params())))
+            .await;
+
+        let response = server
+            .handle_request(make_request(
+                "tools/call",
+                Some(serde_json::json!({
+                    "name": "smart_ingest",
+                    "arguments": { "content": "Fast mode write that must auto-commit." }
+                })),
+            ))
+            .await
+            .unwrap();
+        assert!(response.error.is_none());
+
+        assert_eq!(
+            storage
+                .list_memory_prs(Some(MemoryPrStatus::Pending), 10)
+                .unwrap()
+                .len(),
+            0,
+            "Fast mode must never open a Memory PR"
+        );
+        let text = serde_json::to_string(&response.result).unwrap();
+        assert!(
+            !text.contains("memoryPrNotice"),
+            "Fast mode must not attach a gating notice: {text}"
         );
     }
 

--- a/crates/vestige-mcp/src/server.rs
+++ b/crates/vestige-mcp/src/server.rs
@@ -2032,6 +2032,129 @@ mod tests {
         );
     }
 
+    /// A destructive write is necessarily post-commit in this gate: the node
+    /// has already been purged when the gate observes the result. The response
+    /// must therefore say that it was recorded for review, never that it is
+    /// quarantined or held.
+    #[tokio::test]
+    async fn destructive_write_is_recorded_for_review_not_reported_as_held() {
+        let (storage, _dir) = test_storage().await;
+        std::fs::write(
+            storage.data_dir().join("review_mode.json"),
+            r#"{"mode":"paranoid"}"#,
+        )
+        .unwrap();
+        let node = storage
+            .ingest(vestige_core::IngestInput {
+                content: "Memory scheduled for destructive review.".to_string(),
+                node_type: "fact".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+
+        let cognitive = Arc::new(Mutex::new(CognitiveEngine::new()));
+        let mut server = McpServer::new(storage.clone(), cognitive);
+        server
+            .handle_request(make_request("initialize", Some(init_params())))
+            .await;
+
+        let response = server
+            .handle_request(make_request(
+                "tools/call",
+                Some(serde_json::json!({
+                    "name": "memory",
+                    "arguments": {
+                        "action": "purge",
+                        "id": node.id.clone(),
+                        "confirm": true,
+                        "reason": "exercise the post-commit review notice"
+                    }
+                })),
+            ))
+            .await
+            .unwrap();
+        assert!(response.error.is_none(), "purge should succeed");
+        assert!(
+            storage.get_node(&node.id).unwrap().is_none(),
+            "the post-commit gate cannot claim to have prevented the purge"
+        );
+
+        let structured = response
+            .result
+            .as_ref()
+            .and_then(|result| result.get("structuredContent"))
+            .expect("structured tool result");
+        assert_eq!(structured["memoryPrs"][0]["held"], false);
+        let notice = structured["memoryPrNotice"]
+            .as_str()
+            .expect("destructive write notice");
+        assert!(notice.contains("already applied but recorded for review"));
+        assert!(notice.contains("nothing is held"));
+        assert!(!notice.contains("quarantined until"));
+    }
+
+    /// Dashboard events must not announce a write as landed before the Memory
+    /// PR is opened. The receipt/gate merge seam is deliberately exercised
+    /// through the real MCP dispatch path, not by calling either helper alone.
+    #[tokio::test]
+    async fn memory_pr_event_precedes_memory_created_event() {
+        use crate::dashboard::events::VestigeEvent;
+        use std::time::Duration;
+
+        let (storage, _dir) = test_storage().await;
+        std::fs::write(
+            storage.data_dir().join("review_mode.json"),
+            r#"{"mode":"paranoid"}"#,
+        )
+        .unwrap();
+        let (event_tx, mut events) = tokio::sync::broadcast::channel(16);
+        let cognitive = Arc::new(Mutex::new(CognitiveEngine::new()));
+        let mut server = McpServer::new_with_events(storage, cognitive, event_tx);
+        server
+            .handle_request(make_request("initialize", Some(init_params())))
+            .await;
+
+        let response = server
+            .handle_request(make_request(
+                "tools/call",
+                Some(serde_json::json!({
+                    "name": "smart_ingest",
+                    "arguments": { "content": "A write whose dashboard order is audited." }
+                })),
+            ))
+            .await
+            .unwrap();
+        assert!(response.error.is_none(), "smart_ingest should succeed");
+
+        let mut observed = Vec::new();
+        for _ in 0..8 {
+            let event = tokio::time::timeout(Duration::from_millis(100), events.recv())
+                .await
+                .expect("expected a queued dashboard event")
+                .expect("dashboard event channel should remain open");
+            match event {
+                VestigeEvent::MemoryPrOpened { .. } => observed.push("memory-pr-opened"),
+                VestigeEvent::MemoryCreated { .. } => {
+                    observed.push("memory-created");
+                    break;
+                }
+                _ => {}
+            }
+        }
+        let opened_at = observed
+            .iter()
+            .position(|event| *event == "memory-pr-opened")
+            .expect("gating must open a Memory PR");
+        let created_at = observed
+            .iter()
+            .position(|event| *event == "memory-created")
+            .expect("emit_tool_event must publish the created memory");
+        assert!(
+            opened_at < created_at,
+            "dashboard must observe the Memory PR before the memory-created event: {observed:?}"
+        );
+    }
+
     /// A corrupt or missing `review_mode.json` must never silently disable
     /// gating: it falls back to the default RiskGated.
     #[tokio::test]

--- a/crates/vestige-mcp/src/server.rs
+++ b/crates/vestige-mcp/src/server.rs
@@ -520,6 +520,8 @@ impl McpServer {
             );
         }
 
+        // `mut` so the post-call block can annotate a successful result with any
+        // Memory PRs or receipts it attaches to a successful result.
         let mut result = match request.name.as_str() {
             // ================================================================
             // UNIFIED TOOLS (v1.1+) - Preferred API
@@ -1239,9 +1241,49 @@ impl McpServer {
                     obj.insert("receiptId".to_string(), serde_json::json!(receipt_id));
                     obj.insert("receipt".to_string(), receipt);
                 }
+
+                // Memory PR gate: classify the writes this tool just made under
+                // the active ReviewMode and, for risky ones, quarantine the new
+                // node and open a Memory PR. `gate_writes` no-ops for non-write
+                // tools, and `classify_write` auto-commits everything in Fast
+                // mode, so this is safe on every call.
+                //
+                // This closes the dead seam: the gate and its tests existed but
+                // it had no production caller, so `ReviewMode` was inert and
+                // nothing ever landed in `memory_prs` outside tests.
+                //
+                // Note this rides on `trace_enabled()` with the rest of the black
+                // box: a Memory PR is an auditable trace artifact and is reviewed
+                // through the same surfaces, so disabling tracing disables gating.
+                let mode = crate::trace_recorder::read_review_mode(&self.storage);
+                let opened = crate::trace_recorder::gate_writes(
+                    &self.storage,
+                    self.event_tx.as_ref(),
+                    &trace_run_id,
+                    &request.name,
+                    content,
+                    mode,
+                );
+                if !opened.is_empty()
+                    && let Some(obj) = content.as_object_mut()
+                {
+                    // Tell the calling agent its write is held, so it does not
+                    // assume the memory is live and act on it.
+                    obj.insert("memoryPrs".to_string(), serde_json::json!(opened));
+                    obj.insert(
+                        "memoryPrNotice".to_string(),
+                        serde_json::json!(format!(
+                            "{} write(s) were held for review under review mode '{}' and are \
+                             quarantined until decided. Review them in the dashboard under \
+                             Memory PRs, or via GET /api/memory-prs.",
+                            opened.len(),
+                            mode.as_str()
+                        )),
+                    );
+                }
             }
-            // Emit after receipt attachment so any listening dashboard opens the
-            // same evidence artifact returned to the calling agent.
+            // Emit after receipt attachment and gating so the dashboard sees the
+            // same final evidence and review state returned to the calling agent.
             self.emit_tool_event(&request.name, &saved_args, content);
         }
 
@@ -1837,6 +1879,116 @@ mod tests {
                 "version": "1.0.0"
             }
         })
+    }
+
+    // ========================================================================
+    // MEMORY PR GATE WIRING
+    // ========================================================================
+
+    /// Regression test for the dead seam: `gate_writes` and its unit tests
+    /// existed, but nothing in production ever called it, so `ReviewMode` was
+    /// inert and `memory_prs` only ever filled up inside `#[cfg(test)]`.
+    ///
+    /// This drives a real `tools/call` through `handle_request` and asserts a
+    /// Memory PR actually lands. Paranoid mode is used deliberately so the test
+    /// pins the WIRING, not the risk heuristic (which is covered by the unit
+    /// tests in `trace_recorder`).
+    #[tokio::test]
+    async fn memory_pr_gate_is_wired_into_the_real_tool_path() {
+        use vestige_core::MemoryPrStatus;
+
+        let (storage, _dir) = test_storage().await;
+        std::fs::write(
+            storage.data_dir().join("review_mode.json"),
+            r#"{"mode":"paranoid"}"#,
+        )
+        .unwrap();
+
+        let cognitive = Arc::new(Mutex::new(CognitiveEngine::new()));
+        let mut server = McpServer::new(storage.clone(), cognitive);
+        server
+            .handle_request(make_request("initialize", Some(init_params())))
+            .await;
+
+        assert_eq!(
+            storage
+                .list_memory_prs(Some(MemoryPrStatus::Pending), 10)
+                .unwrap()
+                .len(),
+            0,
+            "no Memory PRs before the call"
+        );
+
+        let response = server
+            .handle_request(make_request(
+                "tools/call",
+                Some(serde_json::json!({
+                    "name": "smart_ingest",
+                    "arguments": { "content": "Staging was migrated to Postgres 17." }
+                })),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            response.error.is_none(),
+            "smart_ingest should succeed: {:?}",
+            response.error
+        );
+
+        let prs = storage
+            .list_memory_prs(Some(MemoryPrStatus::Pending), 10)
+            .unwrap();
+        assert_eq!(
+            prs.len(),
+            1,
+            "a write through the real tool path must open a Memory PR in Paranoid mode"
+        );
+
+        // The calling agent must be told its write is held, otherwise it will
+        // assume the memory is live and act on it.
+        let text = serde_json::to_string(&response.result).unwrap();
+        assert!(
+            text.contains("memoryPrs"),
+            "response must carry the opened PRs: {text}"
+        );
+        assert!(
+            text.contains("memoryPrNotice"),
+            "response must carry the human-readable notice: {text}"
+        );
+    }
+
+    /// A corrupt or missing `review_mode.json` must never silently disable
+    /// gating: it falls back to the default RiskGated.
+    #[tokio::test]
+    async fn review_mode_falls_back_to_risk_gated() {
+        let (storage, _dir) = test_storage().await;
+        assert_eq!(
+            crate::trace_recorder::read_review_mode(&storage),
+            vestige_core::ReviewMode::RiskGated,
+            "missing file defaults to RiskGated"
+        );
+
+        std::fs::write(
+            storage.data_dir().join("review_mode.json"),
+            "{ not valid json",
+        )
+        .unwrap();
+        assert_eq!(
+            crate::trace_recorder::read_review_mode(&storage),
+            vestige_core::ReviewMode::RiskGated,
+            "corrupt file defaults to RiskGated, never Fast"
+        );
+
+        std::fs::write(
+            storage.data_dir().join("review_mode.json"),
+            r#"{"mode":"fast"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            crate::trace_recorder::read_review_mode(&storage),
+            vestige_core::ReviewMode::Fast,
+            "a valid mode is honored"
+        );
     }
 
     // ========================================================================

--- a/crates/vestige-mcp/src/trace_recorder.rs
+++ b/crates/vestige-mcp/src/trace_recorder.rs
@@ -203,9 +203,20 @@ pub fn gate_writes(
         // Quarantine the just-written node so it's held out of retrieval until
         // the PR is decided. For a destructive write there's no live node to
         // suppress — the PR records the action for review/audit instead.
-        if node.is_some() {
-            let _ = storage.suppress_memory(&id);
-        }
+        // `held` is reported truthfully to the caller: a destructive write is
+        // NOT held (it already happened), and a failed suppression must not be
+        // announced as a quarantine.
+        let held = if node.is_some() {
+            match storage.suppress_memory(&id) {
+                Ok(_) => true,
+                Err(e) => {
+                    tracing::warn!("memory PR gate: quarantine of {id} failed: {e}");
+                    false
+                }
+            }
+        } else {
+            false
+        };
 
         let kind = match decision.as_str() {
             "supersede" | "replace" | "superseded" => MemoryPrKind::MemorySuperseded,
@@ -273,6 +284,10 @@ pub fn gate_writes(
             "title": pr.title,
             "signals": signals,
             "subjectId": id,
+            // true: node suppressed until the PR is decided. false: nothing is
+            // held — either the write was destructive (already applied, PR is
+            // an audit record) or suppression failed.
+            "held": held,
         }));
     }
 

--- a/crates/vestige-mcp/src/trace_recorder.rs
+++ b/crates/vestige-mcp/src/trace_recorder.rs
@@ -98,6 +98,27 @@ fn is_write_decision(label: &str) -> bool {
     )
 }
 
+/// Read the persisted [`vestige_core::ReviewMode`] for this brain.
+///
+/// The mode lives in `<data_dir>/review_mode.json` and is written by the
+/// dashboard (`POST /api/memory-prs/mode`). Anything missing, unreadable, or
+/// unrecognised falls back to the default [`vestige_core::ReviewMode::RiskGated`],
+/// so a corrupt file can never silently disable gating.
+///
+/// This is the single source of truth: the dashboard handler delegates here so
+/// the MCP write path and the dashboard can never disagree about the mode.
+pub fn read_review_mode(storage: &Storage) -> vestige_core::ReviewMode {
+    std::fs::read_to_string(storage.data_dir().join("review_mode.json"))
+        .ok()
+        .and_then(|s| serde_json::from_str::<Value>(&s).ok())
+        .and_then(|v| {
+            v.get("mode")
+                .and_then(|m| m.as_str())
+                .map(vestige_core::ReviewMode::from_label)
+        })
+        .unwrap_or_default()
+}
+
 /// Risk-gate the writes in a tool result. For each write the tool just made,
 /// build a [`vestige_core::WriteContext`], classify it under the active
 /// [`vestige_core::ReviewMode`], and — if risky — quarantine the just-written

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -72,6 +72,35 @@ These are read only by `vestige sync --cloud`. Leave them unset and Vestige stay
 
 ---
 
+## Review Modes (Memory PR write gating)
+
+Vestige can hold risky memory writes for review instead of letting them land
+silently. Each held write is suppressed (excluded from normal retrieval) and
+opens a **Memory PR** you decide in the dashboard (Memory PRs tab) or via
+`GET /api/memory-prs`.
+
+| Mode | Behavior |
+|------|----------|
+| `fast` | Never gate. Every write auto-commits. |
+| `risk_gated` | **Default.** Ordinary writes auto-commit; risky ones (contradicting high-trust memories, destructive ops, sensitive topics) open a Memory PR. |
+| `paranoid` | Gate every write. Nothing enters the brain without approval. |
+
+The mode is stored in `<data_dir>/review_mode.json` and set from the dashboard
+(`POST /api/memory-prs/mode`). A missing or corrupt file falls back to
+`risk_gated` — a bad file can never silently disable gating.
+
+When a write is gated, the tool response carries `memoryPrs` and a
+`memoryPrNotice` telling the agent whether the write is **quarantined until
+decided** or (for destructive writes, which have already been applied)
+**recorded for review** with nothing held.
+
+> **Note:** gating rides on the trace system. Setting `VESTIGE_TRACE_ENABLED=0`
+> disables the black box **and Memory PR gating together** — a Memory PR is an
+> auditable trace artifact, so turning off tracing turns off the gate. Leave
+> tracing on (the default) if you rely on review modes.
+
+---
+
 ## Output Configuration (`vestige.toml`)
 
 > Added in **v2.1.26** (Roadmap Phase 2: Configurable Output).


### PR DESCRIPTION
Advances the last genuinely dead half of #117.

## What changed

- Adds one shared `trace_recorder::read_review_mode(&Storage)` reader. Missing, unreadable, corrupt, or unrecognised `review_mode.json` falls back to `RiskGated`; dashboard and MCP write paths cannot disagree.
- Wires `gate_writes` into the real successful `tools/call` path. Risky writes create Memory PRs and return `memoryPrs` plus a truthful `memoryPrNotice`.
- Preserves precise reporting: normal suppressed writes are `held: true` and quarantined; destructive writes that already happened are `held: false` and explicitly recorded for review.
- Moves dashboard event emission after review gating.

## Current-main integration

This branch is rebased on current `main` after #157. The #158 receipt seam is resolved in the deliberate order:

`record_result` -> attach retrieval receipt -> `gate_writes` -> `emit_tool_event`

That means dashboard listeners receive the same final receipt and review state returned to the calling agent.

## Regression coverage

- `memory_pr_gate_is_wired_into_the_real_tool_path`: a real Paranoid `smart_ingest` opens a pending Memory PR and returns the review metadata.
- `fast_mode_opens_no_memory_pr` and `review_mode_falls_back_to_risk_gated`.
- `destructive_write_is_recorded_for_review_not_reported_as_held`: real post-commit purge reports `held: false` and never claims quarantine.
- `memory_pr_event_precedes_memory_created_event`: `MemoryPrOpened` broadcast precedes `MemoryCreated`.

Refs #117 — pre-execution destructive-mutation interception remains separate and out of scope; this PR wires the post-commit Memory-PR path.

## Validation

- `cargo test -p vestige-mcp --lib server::tests:: -- --test-threads=1` (36 passed)
- `cargo test -p vestige-mcp --lib gate_ -- --test-threads=1` (9 passed)
- `cargo clippy -p vestige-mcp --lib -- -D warnings`
- `rustfmt --edition 2024 --check crates/vestige-mcp/src/server.rs`
- `git diff --check origin/main...HEAD`