### PR TITLE
feat: add Memory Spacetime compile-first substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3841,6 +3841,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "rsqlite-vfs"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5015,6 +5025,17 @@ dependencies = [
  "tokio",
  "uuid",
  "vestige-core",
+]
+
+[[package]]
+name = "vestige-spacetime"
+version = "0.1.0"
+dependencies = [
+ "blake3",
+ "roaring",
+ "serde",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/vestige-core",
+    "crates/vestige-spacetime",
     "crates/vestige-mcp",
     "tests/e2e",
     "tests/phase_1",

--- a/crates/vestige-spacetime/Cargo.toml
+++ b/crates/vestige-spacetime/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "vestige-spacetime"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.91"
+publish = false
+
+[dependencies]
+blake3 = "1"
+roaring = "0.11"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+uuid = { version = "1", features = ["v4"] }

--- a/crates/vestige-spacetime/src/common.rs
+++ b/crates/vestige-spacetime/src/common.rs
@@ -1,0 +1,240 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use serde::{Deserialize, Serialize};
+
+pub fn hash_json<T: Serialize>(prefix: &str, value: &T) -> String {
+    let bytes = serde_json::to_vec(value).expect("canonicalizable spec value");
+    format!("{}{}", prefix, blake3::hash(&bytes).to_hex())
+}
+
+pub fn content_hash(content: &str) -> String {
+    blake3::hash(content.as_bytes()).to_hex().to_string()
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ScopeKind {
+    Context,
+    Global,
+    Unlocated,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EngramProjection {
+    pub memory_id: String,
+    pub content: String,
+    pub tags: Vec<String>,
+    pub node_type: String,
+    pub scope: ScopeKind,
+    pub birth_context_id: Option<String>,
+    pub effective_context_id: Option<String>,
+    pub origin: String,
+    pub authority: u8,
+    pub valid_from_ms: Option<i64>,
+    pub valid_until_ms: Option<i64>,
+    pub taints: BTreeSet<String>,
+    pub allowed_purposes: Option<BTreeSet<String>>,
+    pub allowed_actors: Option<BTreeSet<String>>,
+    pub lineage: Vec<String>,
+    pub claim_key: Option<String>,
+}
+
+impl EngramProjection {
+    pub fn revision(&self) -> String {
+        hash_json("rev_", self)
+    }
+
+    pub fn context(memory_id: &str, content: &str, context_id: &str) -> Self {
+        Self {
+            memory_id: memory_id.into(),
+            content: content.into(),
+            tags: Vec::new(),
+            node_type: "fact".into(),
+            scope: ScopeKind::Context,
+            birth_context_id: Some(context_id.into()),
+            effective_context_id: Some(context_id.into()),
+            origin: "user".into(),
+            authority: 3,
+            valid_from_ms: None,
+            valid_until_ms: None,
+            taints: BTreeSet::new(),
+            allowed_purposes: None,
+            allowed_actors: None,
+            lineage: Vec::new(),
+            claim_key: None,
+        }
+    }
+
+    pub fn global(memory_id: &str, content: &str) -> Self {
+        let mut memory = Self::context(memory_id, content, "");
+        memory.scope = ScopeKind::Global;
+        memory.birth_context_id = None;
+        memory.effective_context_id = None;
+        memory
+    }
+
+    pub fn unlocated(memory_id: &str, content: &str) -> Self {
+        let mut memory = Self::global(memory_id, content);
+        memory.scope = ScopeKind::Unlocated;
+        memory
+    }
+
+    pub fn valid_at(&self, at_ms: i64) -> bool {
+        if self.valid_from_ms.is_some_and(|value| at_ms < value) {
+            return false;
+        }
+        if self.valid_until_ms.is_some_and(|value| at_ms >= value) {
+            return false;
+        }
+        true
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RealityPolicy {
+    pub fingerprint: String,
+    pub active_context_id: Option<String>,
+    pub context_cone: BTreeSet<String>,
+    pub include_global: bool,
+    pub include_unlocated: bool,
+    pub cross_context: bool,
+    pub allowed_origins: BTreeSet<String>,
+    pub minimum_authority: u8,
+    pub denied_taints: BTreeSet<String>,
+    pub purpose: String,
+    pub actor: String,
+    pub valid_at_ms: i64,
+}
+
+impl RealityPolicy {
+    pub fn new(
+        active_context_id: Option<String>,
+        context_cone: BTreeSet<String>,
+        valid_at_ms: i64,
+    ) -> Self {
+        let mut policy = Self {
+            fingerprint: String::new(),
+            active_context_id,
+            context_cone,
+            include_global: true,
+            include_unlocated: false,
+            cross_context: false,
+            allowed_origins: [
+                "user",
+                "agent",
+                "repo",
+                "connector",
+                "tool",
+                "derived",
+                "imported",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+            minimum_authority: 1,
+            denied_taints: ["poisoned", "quarantined"]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+            purpose: "general".into(),
+            actor: "agent".into(),
+            valid_at_ms,
+        };
+        policy.refresh_fingerprint();
+        policy
+    }
+
+    pub fn refresh_fingerprint(&mut self) {
+        #[derive(Serialize)]
+        struct Projection<'a> {
+            active: &'a Option<String>,
+            cone: &'a BTreeSet<String>,
+            global: bool,
+            unlocated: bool,
+            cross: bool,
+            origins: &'a BTreeSet<String>,
+            authority: u8,
+            taints: &'a BTreeSet<String>,
+            purpose: &'a str,
+            actor: &'a str,
+            at: i64,
+        }
+
+        self.fingerprint = hash_json(
+            "reality_",
+            &Projection {
+                active: &self.active_context_id,
+                cone: &self.context_cone,
+                global: self.include_global,
+                unlocated: self.include_unlocated,
+                cross: self.cross_context,
+                origins: &self.allowed_origins,
+                authority: self.minimum_authority,
+                taints: &self.denied_taints,
+                purpose: &self.purpose,
+                actor: &self.actor,
+                at: self.valid_at_ms,
+            },
+        );
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ContextHierarchy {
+    parent: HashMap<String, Option<String>>,
+}
+
+impl ContextHierarchy {
+    pub fn add(&mut self, id: &str, parent: Option<&str>) {
+        self.parent.insert(id.into(), parent.map(String::from));
+    }
+
+    pub fn ancestors(&self, id: &str) -> Result<BTreeSet<String>, String> {
+        let mut result = BTreeSet::new();
+        let mut current = Some(id.to_string());
+        while let Some(context_id) = current {
+            if !result.insert(context_id.clone()) {
+                return Err("context parent cycle".into());
+            }
+            current = self.parent.get(&context_id).cloned().flatten();
+        }
+        Ok(result)
+    }
+
+    pub fn depth(&self, id: &str) -> Option<usize> {
+        self.ancestors(id).ok().map(|set| set.len())
+    }
+
+    pub fn lca(&self, ids: &[String]) -> Option<String> {
+        let first = ids.first()?;
+        let first_ancestors = self.ancestors(first).ok()?;
+        let all: Vec<BTreeSet<String>> = ids
+            .iter()
+            .map(|id| self.ancestors(id))
+            .collect::<Result<_, _>>()
+            .ok()?;
+
+        first_ancestors
+            .into_iter()
+            .filter(|candidate| all.iter().all(|set| set.contains(candidate)))
+            .max_by_key(|candidate| self.depth(candidate).unwrap_or_default())
+    }
+
+    pub fn narrowest_containing(&self, ids: &[String]) -> Option<String> {
+        let mut best: Option<(usize, String)> = None;
+        for candidate in ids {
+            let Ok(ancestors) = self.ancestors(candidate) else {
+                continue;
+            };
+            if !ids.iter().all(|id| ancestors.contains(id)) {
+                continue;
+            }
+            let depth = ancestors.len();
+            if best.as_ref().is_none_or(|(current, _)| depth > *current) {
+                best = Some((depth, candidate.clone()));
+            }
+        }
+        best.map(|(_, context_id)| context_id)
+    }
+}
+
+pub type MemoryMap = BTreeMap<String, EngramProjection>;

--- a/crates/vestige-spacetime/src/leg3_reality_index.rs
+++ b/crates/vestige-spacetime/src/leg3_reality_index.rs
@@ -1,0 +1,1000 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use roaring::RoaringBitmap;
+use serde::Serialize;
+
+use crate::common::{EngramProjection, MemoryMap, RealityPolicy, ScopeKind, hash_json};
+
+pub const GLOBAL_PAGE: &str = "__global__";
+pub const UNLOCATED_PAGE: &str = "__unlocated__";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EligibilityReason {
+    Eligible,
+    WrongContext,
+    GlobalDisabled,
+    Unlocated,
+    Worldline,
+    OriginDenied,
+    AuthorityTooLow,
+    Tainted,
+    PurposeDenied,
+    ActorDenied,
+    ContextMissing,
+}
+
+impl EligibilityReason {
+    pub const fn key(self) -> &'static str {
+        match self {
+            Self::Eligible => "eligible",
+            Self::WrongContext => "wrong_context",
+            Self::GlobalDisabled => "global_disabled",
+            Self::Unlocated => "unlocated",
+            Self::Worldline => "outside_worldline",
+            Self::OriginDenied => "origin_denied",
+            Self::AuthorityTooLow => "authority_too_low",
+            Self::Tainted => "lineage_tainted",
+            Self::PurposeDenied => "purpose_denied",
+            Self::ActorDenied => "actor_denied",
+            Self::ContextMissing => "context_missing",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct EligibilityDecision {
+    pub memory_id: String,
+    pub eligible: bool,
+    pub reason: EligibilityReason,
+}
+
+#[derive(Clone, Debug)]
+pub struct RealityPage {
+    pub page_id: String,
+    pub scope_key: String,
+    pub ordinals: Vec<u32>,
+    pub manifest_seal: String,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct OrdinalDirectory {
+    next: u32,
+    id_to_ord: HashMap<String, u32>,
+    ord_to_id: HashMap<u32, String>,
+}
+
+impl OrdinalDirectory {
+    pub fn ensure(&mut self, memory_id: &str) -> u32 {
+        if let Some(value) = self.id_to_ord.get(memory_id) {
+            return *value;
+        }
+        let value = self.next;
+        self.next = self
+            .next
+            .checked_add(1)
+            .expect("u32 ordinal space exhausted");
+        self.id_to_ord.insert(memory_id.into(), value);
+        self.ord_to_id.insert(value, memory_id.into());
+        value
+    }
+
+    pub fn memory_id(&self, ordinal: u32) -> Option<&str> {
+        self.ord_to_id.get(&ordinal).map(String::as_str)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CompiledEligibleSet {
+    pub policy: RealityPolicy,
+    pub ordinals: RoaringBitmap,
+    pub memory_ids: BTreeSet<String>,
+    pub decisions: Vec<EligibilityDecision>,
+    pub blocked_counts: BTreeMap<String, u64>,
+    pub fine_candidate_count: u64,
+    pub global_store_count: usize,
+    pub page_ids: Vec<String>,
+    pub page_manifest_seals: Vec<String>,
+    pub routing_plan_seal: String,
+    pub universe_seal: String,
+    pub reality_checkpoint: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct RealityIndex {
+    pub page_size: usize,
+    pub ordinals: OrdinalDirectory,
+    pub context_members: HashMap<String, RoaringBitmap>,
+    pub all_context_members_bitmap: RoaringBitmap,
+    pub global_members: RoaringBitmap,
+    pub unlocated_members: RoaringBitmap,
+    pub context_missing_members: RoaringBitmap,
+    pub origin_members: HashMap<String, RoaringBitmap>,
+    pub authority_members: HashMap<u8, RoaringBitmap>,
+    pub pages: BTreeMap<String, RealityPage>,
+    pub pages_by_scope: HashMap<String, Vec<String>>,
+    pub generation: u64,
+}
+
+impl RealityIndex {
+    pub fn new(page_size: usize) -> Self {
+        Self {
+            page_size: page_size.max(1),
+            ordinals: OrdinalDirectory::default(),
+            context_members: HashMap::new(),
+            all_context_members_bitmap: RoaringBitmap::new(),
+            global_members: RoaringBitmap::new(),
+            unlocated_members: RoaringBitmap::new(),
+            context_missing_members: RoaringBitmap::new(),
+            origin_members: HashMap::new(),
+            authority_members: HashMap::new(),
+            pages: BTreeMap::new(),
+            pages_by_scope: HashMap::new(),
+            generation: 0,
+        }
+    }
+
+    pub fn rebuild(&mut self, memories: &MemoryMap) {
+        self.context_members.clear();
+        self.all_context_members_bitmap.clear();
+        self.global_members.clear();
+        self.unlocated_members.clear();
+        self.context_missing_members.clear();
+        self.origin_members.clear();
+        self.authority_members.clear();
+
+        for memory in memories.values() {
+            let ordinal = self.ordinals.ensure(&memory.memory_id);
+            match memory.scope {
+                ScopeKind::Global => {
+                    self.global_members.insert(ordinal);
+                }
+                ScopeKind::Unlocated => {
+                    self.unlocated_members.insert(ordinal);
+                }
+                ScopeKind::Context => {
+                    if let Some(context) = memory
+                        .effective_context_id
+                        .as_ref()
+                        .or(memory.birth_context_id.as_ref())
+                    {
+                        self.context_members
+                            .entry(context.clone())
+                            .or_default()
+                            .insert(ordinal);
+                        self.all_context_members_bitmap.insert(ordinal);
+                    } else {
+                        self.context_missing_members.insert(ordinal);
+                    }
+                }
+            }
+            self.origin_members
+                .entry(memory.origin.clone())
+                .or_default()
+                .insert(ordinal);
+            self.authority_members
+                .entry(memory.authority)
+                .or_default()
+                .insert(ordinal);
+        }
+
+        self.rebuild_pages();
+        self.generation = self.generation.saturating_add(1);
+    }
+
+    fn rebuild_pages(&mut self) {
+        self.pages.clear();
+        self.pages_by_scope.clear();
+        let mut scopes: Vec<(String, RoaringBitmap)> = self
+            .context_members
+            .iter()
+            .map(|(scope, bitmap)| (scope.clone(), bitmap.clone()))
+            .collect();
+        scopes.push((GLOBAL_PAGE.into(), self.global_members.clone()));
+        scopes.push((UNLOCATED_PAGE.into(), self.unlocated_members.clone()));
+        scopes.sort_by(|left, right| left.0.cmp(&right.0));
+
+        for (scope, bitmap) in scopes {
+            let ordinals: Vec<u32> = bitmap.iter().collect();
+            for (page_number, chunk) in ordinals.chunks(self.page_size).enumerate() {
+                let page_id = format!("rp:{scope}:{page_number}");
+                #[derive(Serialize)]
+                struct Manifest<'a> {
+                    page: &'a str,
+                    scope: &'a str,
+                    ordinals: &'a [u32],
+                }
+                let manifest_seal = hash_json(
+                    "page_",
+                    &Manifest {
+                        page: &page_id,
+                        scope: &scope,
+                        ordinals: chunk,
+                    },
+                );
+                self.pages_by_scope
+                    .entry(scope.clone())
+                    .or_default()
+                    .push(page_id.clone());
+                self.pages.insert(
+                    page_id.clone(),
+                    RealityPage {
+                        page_id,
+                        scope_key: scope.clone(),
+                        ordinals: chunk.to_vec(),
+                        manifest_seal,
+                    },
+                );
+            }
+        }
+    }
+
+    pub fn route_pages(&self, policy: &RealityPolicy) -> Vec<String> {
+        let mut scopes = policy.context_cone.clone();
+        if policy.cross_context {
+            scopes.extend(self.context_members.keys().cloned());
+        }
+        if policy.include_global {
+            scopes.insert(GLOBAL_PAGE.into());
+        }
+        if policy.include_unlocated {
+            scopes.insert(UNLOCATED_PAGE.into());
+        }
+        let mut routed = Vec::new();
+        for scope in scopes {
+            if let Some(page_ids) = self.pages_by_scope.get(&scope) {
+                routed.extend(page_ids.iter().cloned());
+            }
+        }
+        routed
+    }
+
+    fn all_context_members(&self) -> RoaringBitmap {
+        self.all_context_members_bitmap.clone()
+    }
+
+    fn allowed_context_members(&self, policy: &RealityPolicy) -> RoaringBitmap {
+        if policy.cross_context {
+            return self.all_context_members();
+        }
+        let mut result = RoaringBitmap::new();
+        for context in &policy.context_cone {
+            if let Some(bitmap) = self.context_members.get(context) {
+                result |= bitmap.clone();
+            }
+        }
+        result
+    }
+
+    fn coarse_candidates(&self, policy: &RealityPolicy) -> RoaringBitmap {
+        let mut result = self.allowed_context_members(policy);
+        if policy.include_global {
+            result |= self.global_members.clone();
+        }
+        if policy.include_unlocated {
+            result |= self.unlocated_members.clone();
+        }
+        result
+    }
+
+    fn fine_decide(memory: &EngramProjection, policy: &RealityPolicy) -> EligibilityDecision {
+        let deny = |reason| EligibilityDecision {
+            memory_id: memory.memory_id.clone(),
+            eligible: false,
+            reason,
+        };
+
+        match memory.scope {
+            ScopeKind::Global if !policy.include_global => {
+                return deny(EligibilityReason::GlobalDisabled);
+            }
+            ScopeKind::Unlocated if !policy.include_unlocated => {
+                return deny(EligibilityReason::Unlocated);
+            }
+            ScopeKind::Context => {
+                let Some(context) = memory
+                    .effective_context_id
+                    .as_ref()
+                    .or(memory.birth_context_id.as_ref())
+                else {
+                    return deny(EligibilityReason::ContextMissing);
+                };
+                if !policy.cross_context && !policy.context_cone.contains(context) {
+                    return deny(EligibilityReason::WrongContext);
+                }
+            }
+            _ => {}
+        }
+
+        if !memory.valid_at(policy.valid_at_ms) {
+            return deny(EligibilityReason::Worldline);
+        }
+        if !policy.allowed_origins.contains(&memory.origin) {
+            return deny(EligibilityReason::OriginDenied);
+        }
+        if memory.authority < policy.minimum_authority {
+            return deny(EligibilityReason::AuthorityTooLow);
+        }
+        if memory
+            .taints
+            .iter()
+            .any(|taint| policy.denied_taints.contains(taint))
+        {
+            return deny(EligibilityReason::Tainted);
+        }
+        if memory
+            .allowed_purposes
+            .as_ref()
+            .is_some_and(|purposes| !purposes.contains(&policy.purpose))
+        {
+            return deny(EligibilityReason::PurposeDenied);
+        }
+        if memory
+            .allowed_actors
+            .as_ref()
+            .is_some_and(|actors| !actors.contains(&policy.actor))
+        {
+            return deny(EligibilityReason::ActorDenied);
+        }
+
+        EligibilityDecision {
+            memory_id: memory.memory_id.clone(),
+            eligible: true,
+            reason: EligibilityReason::Eligible,
+        }
+    }
+
+    fn add_blocked(blocked: &mut BTreeMap<String, u64>, reason: EligibilityReason, count: u64) {
+        if count > 0 {
+            *blocked.entry(reason.key().into()).or_default() += count;
+        }
+    }
+
+    pub fn compile(&self, memories: &MemoryMap, policy: RealityPolicy) -> CompiledEligibleSet {
+        let mut blocked = BTreeMap::new();
+        let all_context = self.all_context_members();
+        let allowed_context = self.allowed_context_members(&policy);
+
+        if !policy.cross_context {
+            Self::add_blocked(
+                &mut blocked,
+                EligibilityReason::WrongContext,
+                all_context.difference_len(&allowed_context),
+            );
+        }
+        if !policy.include_global {
+            Self::add_blocked(
+                &mut blocked,
+                EligibilityReason::GlobalDisabled,
+                self.global_members.len(),
+            );
+        }
+        if !policy.include_unlocated {
+            Self::add_blocked(
+                &mut blocked,
+                EligibilityReason::Unlocated,
+                self.unlocated_members.len(),
+            );
+        }
+        Self::add_blocked(
+            &mut blocked,
+            EligibilityReason::ContextMissing,
+            self.context_missing_members.len(),
+        );
+
+        let coarse = self.coarse_candidates(&policy);
+
+        let mut origin_allowed = RoaringBitmap::new();
+        for origin in &policy.allowed_origins {
+            if let Some(bitmap) = self.origin_members.get(origin) {
+                origin_allowed |= bitmap.clone();
+            }
+        }
+        Self::add_blocked(
+            &mut blocked,
+            EligibilityReason::OriginDenied,
+            coarse.difference_len(&origin_allowed),
+        );
+        let mut after_origin = coarse;
+        after_origin &= origin_allowed;
+
+        let mut authority_allowed = RoaringBitmap::new();
+        for (authority, bitmap) in &self.authority_members {
+            if *authority >= policy.minimum_authority {
+                authority_allowed |= bitmap.clone();
+            }
+        }
+        Self::add_blocked(
+            &mut blocked,
+            EligibilityReason::AuthorityTooLow,
+            after_origin.difference_len(&authority_allowed),
+        );
+        let mut candidates = after_origin;
+        candidates &= authority_allowed;
+        let fine_candidate_count = candidates.len();
+
+        let mut eligible = RoaringBitmap::new();
+        let mut decisions = Vec::new();
+        for ordinal in candidates.iter() {
+            let Some(memory_id) = self.ordinals.memory_id(ordinal) else {
+                continue;
+            };
+            let Some(memory) = memories.get(memory_id) else {
+                continue;
+            };
+            let decision = Self::fine_decide(memory, &policy);
+            if decision.eligible {
+                eligible.insert(ordinal);
+            } else {
+                Self::add_blocked(&mut blocked, decision.reason, 1);
+            }
+            decisions.push(decision);
+        }
+
+        let memory_ids: BTreeSet<String> = eligible
+            .iter()
+            .filter_map(|ordinal| self.ordinals.memory_id(ordinal).map(String::from))
+            .collect();
+        let projection: Vec<(&str, String)> = memory_ids
+            .iter()
+            .filter_map(|memory_id| {
+                memories
+                    .get(memory_id)
+                    .map(|memory| (memory_id.as_str(), memory.revision()))
+            })
+            .collect();
+        // The eligible-universe seal intentionally excludes physical page layout.
+        // It is the stable identity shared by capability and delta operations.
+        let universe_seal = hash_json("eligible_", &projection);
+
+        let page_ids = self.route_pages(&policy);
+        let page_manifest_seals: Vec<String> = page_ids
+            .iter()
+            .filter_map(|page_id| self.pages.get(page_id))
+            .map(|page| page.manifest_seal.clone())
+            .collect();
+        let routing_plan_seal = hash_json("routing_", &page_manifest_seals);
+        // Physical page layout is an execution concern, not an authority input.
+        // Re-paging or adding a row that fails fine eligibility may change the
+        // routing seal, but must not revoke capabilities or perturb deltas.
+        let reality_checkpoint = hash_json(
+            "checkpoint_",
+            &(policy.fingerprint.as_str(), universe_seal.as_str()),
+        );
+
+        CompiledEligibleSet {
+            page_ids,
+            page_manifest_seals,
+            routing_plan_seal,
+            universe_seal,
+            reality_checkpoint,
+            policy,
+            ordinals: eligible,
+            memory_ids,
+            decisions,
+            blocked_counts: blocked,
+            fine_candidate_count,
+            global_store_count: memories.len(),
+        }
+    }
+
+    pub fn verify_page_purity(&self, memories: &MemoryMap) -> Vec<String> {
+        let mut invalid = Vec::new();
+        for page in self.pages.values() {
+            for ordinal in &page.ordinals {
+                let Some(memory_id) = self.ordinals.memory_id(*ordinal) else {
+                    invalid.push(page.page_id.clone());
+                    break;
+                };
+                let Some(memory) = memories.get(memory_id) else {
+                    invalid.push(page.page_id.clone());
+                    break;
+                };
+                let actual_scope = match memory.scope {
+                    ScopeKind::Global => Some(GLOBAL_PAGE),
+                    ScopeKind::Unlocated => Some(UNLOCATED_PAGE),
+                    ScopeKind::Context => memory
+                        .effective_context_id
+                        .as_deref()
+                        .or(memory.birth_context_id.as_deref()),
+                };
+                if actual_scope != Some(page.scope_key.as_str()) {
+                    invalid.push(page.page_id.clone());
+                    break;
+                }
+            }
+        }
+        invalid.sort();
+        invalid.dedup();
+        invalid
+    }
+}
+
+fn terms(text: &str) -> Vec<String> {
+    text.split(|character: char| {
+        !(character.is_ascii_alphanumeric() || "_./:-".contains(character))
+    })
+    .filter(|term| !term.is_empty())
+    .map(str::to_ascii_lowercase)
+    .collect()
+}
+
+#[derive(Clone, Debug)]
+pub struct RealityLexicalIndex {
+    pub k1: f64,
+    pub b: f64,
+}
+
+impl Default for RealityLexicalIndex {
+    fn default() -> Self {
+        Self { k1: 1.2, b: 0.75 }
+    }
+}
+
+impl RealityLexicalIndex {
+    pub fn score(
+        &self,
+        query: &str,
+        memory_ids: &BTreeSet<String>,
+        memories: &MemoryMap,
+    ) -> BTreeMap<String, f64> {
+        if memory_ids.is_empty() {
+            return BTreeMap::new();
+        }
+
+        let documents: BTreeMap<String, Vec<String>> = memory_ids
+            .iter()
+            .filter_map(|memory_id| {
+                memories.get(memory_id).map(|memory| {
+                    let mut text = memory.content.clone();
+                    if !memory.tags.is_empty() {
+                        text.push(' ');
+                        text.push_str(&memory.tags.join(" "));
+                    }
+                    (memory_id.clone(), terms(&text))
+                })
+            })
+            .collect();
+        let document_count = documents.len() as f64;
+        let average_length =
+            documents.values().map(Vec::len).sum::<usize>() as f64 / document_count.max(1.0);
+
+        let mut document_frequency: HashMap<String, usize> = HashMap::new();
+        for document in documents.values() {
+            let unique: BTreeSet<&String> = document.iter().collect();
+            for term in unique {
+                *document_frequency.entry(term.clone()).or_default() += 1;
+            }
+        }
+
+        let query_terms = terms(query);
+        let mut scores = BTreeMap::new();
+        for (memory_id, document) in documents {
+            let mut term_frequency: HashMap<String, usize> = HashMap::new();
+            for token in &document {
+                *term_frequency.entry(token.clone()).or_default() += 1;
+            }
+            let document_length = document.len() as f64;
+            let mut score = 0.0;
+            for term in &query_terms {
+                let frequency = *term_frequency.get(term).unwrap_or(&0) as f64;
+                if frequency == 0.0 {
+                    continue;
+                }
+                let frequency_documents = *document_frequency.get(term).unwrap_or(&0) as f64;
+                let inverse_document_frequency = (1.0
+                    + (document_count - frequency_documents + 0.5) / (frequency_documents + 0.5))
+                    .ln();
+                let denominator = frequency
+                    + self.k1
+                        * (1.0 - self.b + self.b * document_length / average_length.max(1e-12));
+                score += inverse_document_frequency * (frequency * (self.k1 + 1.0)) / denominator;
+            }
+            scores.insert(memory_id, score);
+        }
+        scores
+    }
+}
+
+fn unit(mut vector: Vec<f32>) -> Vec<f32> {
+    let norm = vector.iter().map(|value| value * value).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for value in &mut vector {
+            *value /= norm;
+        }
+    }
+    vector
+}
+
+fn cosine(left: &[f32], right: &[f32]) -> f32 {
+    if left.len() != right.len() || left.is_empty() {
+        return 0.0;
+    }
+    left.iter().zip(right).map(|(x, y)| x * y).sum()
+}
+
+fn hashed_embedding(text: &str, dimensions: usize) -> Vec<f32> {
+    let mut result = vec![0.0; dimensions];
+    for token in terms(text) {
+        let hash = blake3::hash(token.as_bytes());
+        let bytes = hash.as_bytes();
+        let bucket =
+            u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize % dimensions;
+        result[bucket] += if bytes[4] & 1 == 1 { 1.0 } else { -1.0 };
+    }
+    unit(result)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VectorMode {
+    Exact,
+    PagedAnn,
+}
+
+#[derive(Clone, Debug)]
+pub struct RealityVectorIndex {
+    pub exact_threshold: usize,
+    pub dimensions: usize,
+    vectors: HashMap<String, Vec<f32>>,
+}
+
+impl RealityVectorIndex {
+    pub fn new(exact_threshold: usize, dimensions: usize) -> Self {
+        Self {
+            exact_threshold: exact_threshold.max(1),
+            dimensions: dimensions.max(1),
+            vectors: HashMap::new(),
+        }
+    }
+
+    pub fn register(&mut self, memory_id: &str, vector: Vec<f32>) {
+        self.vectors.insert(memory_id.into(), unit(vector));
+    }
+
+    fn vector_for(&self, memory_id: &str, memories: &MemoryMap) -> Vec<f32> {
+        self.vectors
+            .get(memory_id)
+            .cloned()
+            .unwrap_or_else(|| hashed_embedding(&memories[memory_id].content, self.dimensions))
+    }
+
+    pub fn score(
+        &self,
+        query: &str,
+        eligible: &CompiledEligibleSet,
+        memories: &MemoryMap,
+        explicit_query: Option<&[f32]>,
+    ) -> (BTreeMap<String, f32>, VectorMode) {
+        let query_vector = explicit_query
+            .map(|vector| unit(vector.to_vec()))
+            .unwrap_or_else(|| hashed_embedding(query, self.dimensions));
+        let mode = if eligible.memory_ids.len() <= self.exact_threshold {
+            VectorMode::Exact
+        } else {
+            // This standalone crate models page routing deterministically. The
+            // Vestige adapter maps each page to a Context-pure USearch index.
+            VectorMode::PagedAnn
+        };
+        let scores = eligible
+            .memory_ids
+            .iter()
+            .map(|memory_id| {
+                (
+                    memory_id.clone(),
+                    cosine(&query_vector, &self.vector_for(memory_id, memories)),
+                )
+            })
+            .collect();
+        (scores, mode)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RecallHit {
+    pub memory_id: String,
+    pub score: f64,
+}
+
+#[derive(Clone, Debug)]
+pub struct IndexedRecallResult {
+    pub hits: Vec<RecallHit>,
+    pub eligible_universe_seal: String,
+    pub blocked_counts: BTreeMap<String, u64>,
+    pub fine_candidate_count: u64,
+    pub global_store_count: usize,
+    pub vector_mode: VectorMode,
+    pub routed_pages: Vec<String>,
+    pub reality_checkpoint: String,
+}
+
+pub struct IndexedRecallEngine {
+    pub index: RealityIndex,
+    pub lexical: RealityLexicalIndex,
+    pub vector: RealityVectorIndex,
+}
+
+impl IndexedRecallEngine {
+    pub fn new(page_size: usize, exact_threshold: usize) -> Self {
+        Self {
+            index: RealityIndex::new(page_size),
+            lexical: RealityLexicalIndex::default(),
+            vector: RealityVectorIndex::new(exact_threshold, 64),
+        }
+    }
+
+    pub fn rebuild(&mut self, memories: &MemoryMap) {
+        self.index.rebuild(memories);
+    }
+
+    pub fn recall(
+        &self,
+        query: &str,
+        policy: RealityPolicy,
+        memories: &MemoryMap,
+        limit: usize,
+        explicit_query: Option<&[f32]>,
+    ) -> IndexedRecallResult {
+        let eligible = self.index.compile(memories, policy);
+        let lexical_scores = self.lexical.score(query, &eligible.memory_ids, memories);
+        let (vector_scores, vector_mode) =
+            self.vector
+                .score(query, &eligible, memories, explicit_query);
+
+        let lexical_ranks: HashMap<String, usize> = {
+            let mut ranked: Vec<(String, f64)> = eligible
+                .memory_ids
+                .iter()
+                .map(|memory_id| {
+                    (
+                        memory_id.clone(),
+                        *lexical_scores.get(memory_id).unwrap_or(&0.0),
+                    )
+                })
+                .collect();
+            ranked.sort_by(|left, right| {
+                right
+                    .1
+                    .total_cmp(&left.1)
+                    .then_with(|| left.0.cmp(&right.0))
+            });
+            ranked
+                .into_iter()
+                .enumerate()
+                .map(|(index, (memory_id, _))| (memory_id, index + 1))
+                .collect()
+        };
+        let vector_ranks: HashMap<String, usize> = {
+            let mut ranked: Vec<(String, f32)> = eligible
+                .memory_ids
+                .iter()
+                .map(|memory_id| {
+                    (
+                        memory_id.clone(),
+                        *vector_scores.get(memory_id).unwrap_or(&0.0),
+                    )
+                })
+                .collect();
+            ranked.sort_by(|left, right| {
+                right
+                    .1
+                    .total_cmp(&left.1)
+                    .then_with(|| left.0.cmp(&right.0))
+            });
+            ranked
+                .into_iter()
+                .enumerate()
+                .map(|(index, (memory_id, _))| (memory_id, index + 1))
+                .collect()
+        };
+
+        let mut hits: Vec<RecallHit> = eligible
+            .memory_ids
+            .iter()
+            .map(|memory_id| {
+                let lexical_rank = *lexical_ranks
+                    .get(memory_id)
+                    .expect("eligible memory has lexical rank")
+                    as f64;
+                let vector_rank = *vector_ranks
+                    .get(memory_id)
+                    .expect("eligible memory has vector rank")
+                    as f64;
+                RecallHit {
+                    memory_id: memory_id.clone(),
+                    score: 0.3 / (60.0 + lexical_rank) + 0.7 / (60.0 + vector_rank),
+                }
+            })
+            .collect();
+        hits.sort_by(|left, right| {
+            right
+                .score
+                .total_cmp(&left.score)
+                .then_with(|| left.memory_id.cmp(&right.memory_id))
+        });
+        hits.truncate(limit.max(1));
+
+        IndexedRecallResult {
+            hits,
+            eligible_universe_seal: eligible.universe_seal,
+            blocked_counts: eligible.blocked_counts,
+            fine_candidate_count: eligible.fine_candidate_count,
+            global_store_count: eligible.global_store_count,
+            vector_mode,
+            routed_pages: eligible.page_ids,
+            reality_checkpoint: eligible.reality_checkpoint,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::EngramProjection;
+
+    fn policy(context: &str) -> RealityPolicy {
+        RealityPolicy::new(
+            Some(context.into()),
+            [context.to_string()].into_iter().collect(),
+            100,
+        )
+    }
+
+    #[test]
+    fn sibling_population_never_enters_rank_math() {
+        let mut memories = MemoryMap::new();
+        memories.insert(
+            "a".into(),
+            EngramProjection::context("a", "Backups S3", "A"),
+        );
+        for index in 0..10_000 {
+            let id = format!("b{index}");
+            memories.insert(
+                id.clone(),
+                EngramProjection::context(&id, "Backups Backblaze backup backup", "B"),
+            );
+        }
+        let mut engine = IndexedRecallEngine::new(128, 50_000);
+        engine.rebuild(&memories);
+        let result = engine.recall("backups", policy("A"), &memories, 5, None);
+        assert_eq!(result.global_store_count, 10_001);
+        assert_eq!(result.fine_candidate_count, 1);
+        assert_eq!(result.hits[0].memory_id, "a");
+    }
+
+    #[test]
+    fn local_bm25_ignores_sibling_corpus_statistics() {
+        let mut memories = MemoryMap::new();
+        memories.insert("a".into(), EngramProjection::context("a", "backup s3", "A"));
+        let mut engine = IndexedRecallEngine::new(64, 50_000);
+        engine.rebuild(&memories);
+        let before = engine
+            .recall("backup s3", policy("A"), &memories, 5, None)
+            .hits[0]
+            .score;
+        for index in 0..3_000 {
+            let id = format!("b{index}");
+            memories.insert(id.clone(), EngramProjection::context(&id, "backup s3", "B"));
+        }
+        engine.rebuild(&memories);
+        let after = engine
+            .recall("backup s3", policy("A"), &memories, 5, None)
+            .hits[0]
+            .score;
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn page_manifests_are_pure() {
+        let mut memories = MemoryMap::new();
+        for index in 0..40 {
+            let id = format!("a{index}");
+            memories.insert(id.clone(), EngramProjection::context(&id, "x", "A"));
+        }
+        for index in 0..40 {
+            let id = format!("b{index}");
+            memories.insert(id.clone(), EngramProjection::context(&id, "x", "B"));
+        }
+        let mut index = RealityIndex::new(7);
+        index.rebuild(&memories);
+        assert!(index.verify_page_purity(&memories).is_empty());
+        assert!(
+            index
+                .pages
+                .values()
+                .all(|page| page.manifest_seal.starts_with("page_"))
+        );
+    }
+
+    #[test]
+    fn negative_space_accounts_for_the_complete_store() {
+        let mut memories = MemoryMap::new();
+        memories.insert(
+            "eligible".into(),
+            EngramProjection::context("eligible", "x", "A"),
+        );
+        memories.insert(
+            "sibling".into(),
+            EngramProjection::context("sibling", "x", "B"),
+        );
+        memories.insert("global".into(), EngramProjection::global("global", "x"));
+        memories.insert(
+            "unlocated".into(),
+            EngramProjection::unlocated("unlocated", "x"),
+        );
+
+        let mut denied_origin = EngramProjection::context("origin", "x", "A");
+        denied_origin.origin = "web".into();
+        memories.insert("origin".into(), denied_origin);
+
+        let mut weak = EngramProjection::context("weak", "x", "A");
+        weak.authority = 0;
+        memories.insert("weak".into(), weak);
+
+        let mut expired = EngramProjection::context("expired", "x", "A");
+        expired.valid_until_ms = Some(100);
+        memories.insert("expired".into(), expired);
+
+        let mut index = RealityIndex::new(8);
+        index.rebuild(&memories);
+        let mut p = policy("A");
+        p.include_global = false;
+        p.allowed_origins = ["user".into()].into_iter().collect();
+        p.minimum_authority = 3;
+        p.refresh_fingerprint();
+        let compiled = index.compile(&memories, p);
+        let blocked: u64 = compiled.blocked_counts.values().sum();
+        assert_eq!(blocked as usize + compiled.memory_ids.len(), memories.len());
+        assert_eq!(
+            compiled.memory_ids,
+            ["eligible".into()].into_iter().collect()
+        );
+    }
+    #[test]
+    fn reality_checkpoint_ignores_siblings_but_tracks_active_reality() {
+        let mut memories = MemoryMap::new();
+        memories.insert(
+            "a".into(),
+            EngramProjection::context("a", "A database", "A"),
+        );
+        memories.insert(
+            "b".into(),
+            EngramProjection::context("b", "B database", "B"),
+        );
+        let mut engine = IndexedRecallEngine::new(8, 100);
+        engine.rebuild(&memories);
+        let before = engine.recall("database", policy("A"), &memories, 5, None);
+
+        memories.get_mut("b").expect("sibling memory").content =
+            "B database changed radically".into();
+        engine.rebuild(&memories);
+        let sibling_change = engine.recall("database", policy("A"), &memories, 5, None);
+        assert_eq!(before.reality_checkpoint, sibling_change.reality_checkpoint);
+
+        memories.get_mut("a").expect("active memory").content = "A database changed".into();
+        engine.rebuild(&memories);
+        let active_change = engine.recall("database", policy("A"), &memories, 5, None);
+        assert_ne!(before.reality_checkpoint, active_change.reality_checkpoint);
+    }
+
+    #[test]
+    fn ineligible_active_context_row_changes_routing_not_authority() {
+        let mut memories = MemoryMap::new();
+        memories.insert(
+            "a".into(),
+            EngramProjection::context("a", "A database", "A"),
+        );
+        let mut engine = IndexedRecallEngine::new(1, 100);
+        engine.rebuild(&memories);
+        let before = engine.index.compile(&memories, policy("A"));
+
+        let mut denied =
+            EngramProjection::context("denied", "Untrusted in-context instruction", "A");
+        denied.origin = "web".into();
+        memories.insert("denied".into(), denied);
+        engine.rebuild(&memories);
+        let after = engine.index.compile(&memories, policy("A"));
+
+        assert_eq!(before.universe_seal, after.universe_seal);
+        assert_eq!(before.reality_checkpoint, after.reality_checkpoint);
+        assert_ne!(before.routing_plan_seal, after.routing_plan_seal);
+    }
+}

--- a/crates/vestige-spacetime/src/leg4_reality_delta.rs
+++ b/crates/vestige-spacetime/src/leg4_reality_delta.rs
@@ -1,0 +1,353 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Serialize;
+
+use crate::common::{EngramProjection, MemoryMap, RealityPolicy, content_hash, hash_json};
+use crate::leg3_reality_index::IndexedRecallResult;
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct WorkingSetEntry {
+    pub memory_id: String,
+    pub revision: String,
+    pub content_hash: String,
+    pub content: String,
+    pub score: f64,
+    pub source: String,
+}
+
+impl WorkingSetEntry {
+    fn leaf_projection(&self) -> (&str, &str, &str) {
+        (&self.memory_id, &self.revision, &self.content_hash)
+    }
+}
+
+pub fn merkle_root(entries: &[WorkingSetEntry]) -> String {
+    if entries.is_empty() {
+        return hash_json("merkle_", &Vec::<String>::new());
+    }
+
+    let mut sorted = entries.to_vec();
+    sorted.sort_by(|left, right| left.memory_id.cmp(&right.memory_id));
+    let mut level: Vec<String> = sorted
+        .iter()
+        .map(|entry| hash_json("leaf_", &entry.leaf_projection()))
+        .collect();
+
+    while level.len() > 1 {
+        if level.len() % 2 == 1 {
+            let last = level.last().expect("non-empty Merkle level").clone();
+            level.push(last);
+        }
+        level = level
+            .chunks(2)
+            .map(|pair| hash_json("node_", &(pair[0].as_str(), pair[1].as_str())))
+            .collect();
+    }
+
+    format!(
+        "merkle_{}",
+        level[0]
+            .split_once('_')
+            .map(|(_, value)| value)
+            .unwrap_or(&level[0])
+    )
+}
+
+#[derive(Clone, Debug)]
+pub struct RealitySnapshot {
+    pub snapshot_id: String,
+    pub reality_fingerprint: String,
+    pub reality_checkpoint: String,
+    pub root: String,
+    pub rank_seal: String,
+    pub entries: Vec<WorkingSetEntry>,
+}
+
+impl RealitySnapshot {
+    pub fn by_id(&self) -> BTreeMap<String, WorkingSetEntry> {
+        self.entries
+            .iter()
+            .cloned()
+            .map(|entry| (entry.memory_id.clone(), entry))
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct RankUpdate {
+    pub memory_id: String,
+    pub score: f64,
+    pub source: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct RealityDelta {
+    pub from_snapshot: Option<String>,
+    pub to_snapshot: String,
+    pub reality_fingerprint: String,
+    pub reality_checkpoint: String,
+    pub previous_root: Option<String>,
+    pub new_root: String,
+    pub additions: Vec<WorkingSetEntry>,
+    pub updates: Vec<WorkingSetEntry>,
+    pub removals: Vec<String>,
+    pub rank_updates: Vec<RankUpdate>,
+    pub seal: String,
+}
+
+impl RealityDelta {
+    fn seal_value(&self) -> serde_json::Value {
+        serde_json::json!({
+            "from": self.from_snapshot,
+            "to": self.to_snapshot,
+            "reality": self.reality_fingerprint,
+            "realityCheckpoint": self.reality_checkpoint,
+            "previousRoot": self.previous_root,
+            "newRoot": self.new_root,
+            "additions": self.additions,
+            "updates": self.updates,
+            "removals": self.removals,
+            "rankUpdates": self.rank_updates,
+        })
+    }
+
+    pub fn verify(&self) -> bool {
+        self.seal == hash_json("delta_", &self.seal_value())
+    }
+}
+
+pub struct RealityWorkingSet {
+    pub max_entries: usize,
+    snapshots: BTreeMap<String, RealitySnapshot>,
+}
+
+impl RealityWorkingSet {
+    pub fn new(max_entries: usize) -> Self {
+        Self {
+            max_entries: max_entries.max(1),
+            snapshots: BTreeMap::new(),
+        }
+    }
+
+    pub fn build_from_recall(
+        &mut self,
+        recall: &IndexedRecallResult,
+        policy: &RealityPolicy,
+        memories: &MemoryMap,
+        prefetch_ids: &[String],
+        eligible_ids: &BTreeSet<String>,
+    ) -> RealitySnapshot {
+        let mut selected = BTreeMap::new();
+        for hit in &recall.hits {
+            if selected.len() >= self.max_entries {
+                break;
+            }
+            if let Some(memory) = memories.get(&hit.memory_id) {
+                selected.insert(hit.memory_id.clone(), entry(memory, hit.score, "recall"));
+            }
+        }
+
+        // Predictions are suggestions, never authority. Every prefetched ID is
+        // independently checked against the compiled eligible universe.
+        for memory_id in prefetch_ids {
+            if selected.len() >= self.max_entries {
+                break;
+            }
+            if selected.contains_key(memory_id) || !eligible_ids.contains(memory_id) {
+                continue;
+            }
+            if let Some(memory) = memories.get(memory_id) {
+                selected.insert(memory_id.clone(), entry(memory, 0.0, "prediction"));
+            }
+        }
+
+        let entries: Vec<WorkingSetEntry> = selected.into_values().collect();
+        let root = merkle_root(&entries);
+        let rank_projection: Vec<(&str, f64, &str)> = entries
+            .iter()
+            .map(|entry| (entry.memory_id.as_str(), entry.score, entry.source.as_str()))
+            .collect();
+        let rank_seal = hash_json("rank_", &rank_projection);
+        let snapshot_id = hash_json(
+            "snapshot_",
+            &(
+                policy.fingerprint.as_str(),
+                recall.reality_checkpoint.as_str(),
+                root.as_str(),
+                rank_seal.as_str(),
+            ),
+        );
+        let snapshot = RealitySnapshot {
+            snapshot_id: snapshot_id.clone(),
+            reality_fingerprint: policy.fingerprint.clone(),
+            reality_checkpoint: recall.reality_checkpoint.clone(),
+            root,
+            rank_seal,
+            entries,
+        };
+        self.snapshots.insert(snapshot_id, snapshot.clone());
+        snapshot
+    }
+
+    pub fn delta(
+        &self,
+        previous_id: Option<&str>,
+        current: &RealitySnapshot,
+    ) -> Result<RealityDelta, String> {
+        let previous = previous_id.and_then(|id| self.snapshots.get(id));
+        if previous.is_some_and(|old| old.reality_fingerprint != current.reality_fingerprint) {
+            return Err("Reality fingerprint changed; full snapshot required".into());
+        }
+
+        let old = previous.map(RealitySnapshot::by_id).unwrap_or_default();
+        let new = current.by_id();
+        let old_ids: BTreeSet<String> = old.keys().cloned().collect();
+        let new_ids: BTreeSet<String> = new.keys().cloned().collect();
+
+        let additions = new_ids
+            .difference(&old_ids)
+            .filter_map(|id| new.get(id).cloned())
+            .collect();
+        let removals = old_ids.difference(&new_ids).cloned().collect();
+        let mut updates = Vec::new();
+        let mut rank_updates = Vec::new();
+
+        for id in old_ids.intersection(&new_ids) {
+            let old_entry = &old[id];
+            let new_entry = &new[id];
+            if old_entry.revision != new_entry.revision {
+                updates.push(new_entry.clone());
+            } else if old_entry.score != new_entry.score || old_entry.source != new_entry.source {
+                rank_updates.push(RankUpdate {
+                    memory_id: id.clone(),
+                    score: new_entry.score,
+                    source: new_entry.source.clone(),
+                });
+            }
+        }
+
+        let mut delta = RealityDelta {
+            from_snapshot: previous.map(|snapshot| snapshot.snapshot_id.clone()),
+            to_snapshot: current.snapshot_id.clone(),
+            reality_fingerprint: current.reality_fingerprint.clone(),
+            reality_checkpoint: current.reality_checkpoint.clone(),
+            previous_root: previous.map(|snapshot| snapshot.root.clone()),
+            new_root: current.root.clone(),
+            additions,
+            updates,
+            removals,
+            rank_updates,
+            seal: String::new(),
+        };
+        delta.seal = hash_json("delta_", &delta.seal_value());
+        Ok(delta)
+    }
+}
+
+fn entry(memory: &EngramProjection, score: f64, source: &str) -> WorkingSetEntry {
+    WorkingSetEntry {
+        memory_id: memory.memory_id.clone(),
+        revision: memory.revision(),
+        content_hash: content_hash(&memory.content),
+        content: memory.content.clone(),
+        score,
+        source: source.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::{EngramProjection, RealityPolicy};
+    use crate::leg3_reality_index::IndexedRecallEngine;
+
+    #[test]
+    fn unchanged_content_is_not_resent_when_rank_changes() {
+        let mut memories = MemoryMap::new();
+        memories.insert(
+            "a".into(),
+            EngramProjection::context("a", "backup s3 deploy", "A"),
+        );
+        let policy = RealityPolicy::new(Some("A".into()), ["A".into()].into_iter().collect(), 1);
+        let mut engine = IndexedRecallEngine::new(10, 100);
+        engine.rebuild(&memories);
+        let eligible = engine.index.compile(&memories, policy.clone());
+        let first_recall = engine.recall("backup", policy.clone(), &memories, 5, None);
+        let second_recall = engine.recall("deploy", policy.clone(), &memories, 5, None);
+        let mut working_set = RealityWorkingSet::new(8);
+        let first = working_set.build_from_recall(
+            &first_recall,
+            &policy,
+            &memories,
+            &[],
+            &eligible.memory_ids,
+        );
+        let second = working_set.build_from_recall(
+            &second_recall,
+            &policy,
+            &memories,
+            &[],
+            &eligible.memory_ids,
+        );
+        let delta = working_set
+            .delta(Some(&first.snapshot_id), &second)
+            .expect("same-Reality delta");
+        assert!(delta.updates.is_empty());
+        assert!(delta.verify());
+    }
+
+    #[test]
+    fn content_mutation_is_one_update() {
+        let mut memories = MemoryMap::new();
+        memories.insert("a".into(), EngramProjection::context("a", "backup s3", "A"));
+        let policy = RealityPolicy::new(Some("A".into()), ["A".into()].into_iter().collect(), 1);
+        let mut engine = IndexedRecallEngine::new(10, 100);
+        engine.rebuild(&memories);
+        let first_eligible = engine.index.compile(&memories, policy.clone());
+        let first_recall = engine.recall("backup", policy.clone(), &memories, 5, None);
+        let mut working_set = RealityWorkingSet::new(8);
+        let first = working_set.build_from_recall(
+            &first_recall,
+            &policy,
+            &memories,
+            &[],
+            &first_eligible.memory_ids,
+        );
+
+        memories.get_mut("a").expect("test memory").content = "backup encrypted s3".into();
+        engine.rebuild(&memories);
+        let second_eligible = engine.index.compile(&memories, policy.clone());
+        let second_recall = engine.recall("backup", policy.clone(), &memories, 5, None);
+        let second = working_set.build_from_recall(
+            &second_recall,
+            &policy,
+            &memories,
+            &[],
+            &second_eligible.memory_ids,
+        );
+        let delta = working_set
+            .delta(Some(&first.snapshot_id), &second)
+            .expect("same-Reality delta");
+
+        assert_eq!(delta.updates.len(), 1);
+        assert_ne!(first.root, second.root);
+        assert!(delta.verify());
+    }
+    #[test]
+    fn snapshot_and_delta_preserve_reality_checkpoint() {
+        let mut memories = MemoryMap::new();
+        memories.insert("a".into(), EngramProjection::context("a", "backup s3", "A"));
+        let policy = RealityPolicy::new(Some("A".into()), ["A".into()].into_iter().collect(), 1);
+        let mut engine = IndexedRecallEngine::new(10, 100);
+        engine.rebuild(&memories);
+        let eligible = engine.index.compile(&memories, policy.clone());
+        let recall = engine.recall("backup", policy.clone(), &memories, 5, None);
+        let mut working_set = RealityWorkingSet::new(8);
+        let snapshot =
+            working_set.build_from_recall(&recall, &policy, &memories, &[], &eligible.memory_ids);
+        let delta = working_set.delta(None, &snapshot).expect("initial delta");
+        assert_eq!(snapshot.reality_checkpoint, recall.reality_checkpoint);
+        assert_eq!(delta.reality_checkpoint, recall.reality_checkpoint);
+        assert!(delta.verify());
+    }
+}

--- a/crates/vestige-spacetime/src/leg5_claim_lattice.rs
+++ b/crates/vestige-spacetime/src/leg5_claim_lattice.rs
@@ -1,0 +1,696 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use serde::Serialize;
+
+use crate::common::{EngramProjection, MemoryMap, RealityPolicy, hash_json};
+use crate::leg3_reality_index::CompiledEligibleSet;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ClaimSemantics {
+    Exclusive,
+    Set,
+    Numeric { tolerance: f64 },
+    Version,
+    Freeform,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ClaimIntent {
+    Assertion,
+    Correction,
+    Transition,
+    PlannedTransition,
+}
+
+impl ClaimIntent {
+    const fn key(self) -> &'static str {
+        match self {
+            Self::Assertion => "assertion",
+            Self::Correction => "correction",
+            Self::Transition => "transition",
+            Self::PlannedTransition => "planned_transition",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DriftKind {
+    None,
+    Reinforcement,
+    Additive,
+    Contradiction,
+    Successor,
+    ScheduledSuccessor,
+    NumericDrift,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProposalKind {
+    RepairWorldline,
+    QuarantineClaim,
+}
+
+#[derive(Clone, Debug)]
+pub struct ClaimAssertion {
+    pub memory_id: String,
+    pub subject: String,
+    pub predicate: String,
+    pub value: String,
+    pub confidence: f64,
+    pub intent: ClaimIntent,
+}
+
+impl ClaimAssertion {
+    pub fn claim_key(&self) -> String {
+        format!(
+            "{}|{}",
+            self.subject.trim().to_ascii_lowercase(),
+            self.predicate.trim().to_ascii_lowercase()
+        )
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ClaimMemoryPr {
+    pub pr_id: String,
+    pub kind: ProposalKind,
+    pub drift_kind: DriftKind,
+    pub policy_fingerprint: String,
+    pub reality_checkpoint: String,
+    pub claim_key: String,
+    pub old_memory_id: String,
+    pub new_memory_id: String,
+    pub old_revision: String,
+    pub new_revision: String,
+    pub proposed_valid_until_ms: Option<i64>,
+    pub evidence: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ClaimAssessment {
+    pub drift_kind: DriftKind,
+    pub claim_key: String,
+    pub compared_memory_ids: Vec<String>,
+    pub proposal: Option<ClaimMemoryPr>,
+}
+
+#[derive(Default)]
+pub struct ClaimSchemaRegistry {
+    schemas: HashMap<String, ClaimSemantics>,
+}
+
+impl ClaimSchemaRegistry {
+    pub fn define(&mut self, predicate: &str, semantics: ClaimSemantics) {
+        self.schemas
+            .insert(predicate.trim().to_ascii_lowercase(), semantics);
+    }
+
+    pub fn get(&self, predicate: &str) -> ClaimSemantics {
+        self.schemas
+            .get(&predicate.trim().to_ascii_lowercase())
+            .cloned()
+            .unwrap_or(ClaimSemantics::Freeform)
+    }
+}
+
+#[derive(Default)]
+pub struct ClaimLattice {
+    pub assertions: HashMap<String, ClaimAssertion>,
+    pub claim_members: HashMap<String, BTreeSet<String>>,
+    pub schemas: ClaimSchemaRegistry,
+}
+
+impl ClaimLattice {
+    pub fn register(
+        &mut self,
+        assertion: ClaimAssertion,
+        memories: &MemoryMap,
+    ) -> Result<(), String> {
+        let memory = memories.get(&assertion.memory_id).ok_or("memory missing")?;
+        let key = assertion.claim_key();
+        if memory
+            .claim_key
+            .as_deref()
+            .is_some_and(|stored| stored != key)
+        {
+            return Err("Engram claim_key disagrees with assertion".into());
+        }
+
+        if let Some(prior) = self.assertions.get(&assertion.memory_id) {
+            let prior_key = prior.claim_key();
+            let remove_bucket = if let Some(members) = self.claim_members.get_mut(&prior_key) {
+                members.remove(&assertion.memory_id);
+                members.is_empty()
+            } else {
+                false
+            };
+            if remove_bucket {
+                self.claim_members.remove(&prior_key);
+            }
+        }
+
+        self.claim_members
+            .entry(key)
+            .or_default()
+            .insert(assertion.memory_id.clone());
+        self.assertions
+            .insert(assertion.memory_id.clone(), assertion);
+        Ok(())
+    }
+
+    pub fn remove_assertion(&mut self, memory_id: &str) {
+        let Some(assertion) = self.assertions.remove(memory_id) else {
+            return;
+        };
+        let key = assertion.claim_key();
+        let remove_bucket = if let Some(members) = self.claim_members.get_mut(&key) {
+            members.remove(memory_id);
+            members.is_empty()
+        } else {
+            false
+        };
+        if remove_bucket {
+            self.claim_members.remove(&key);
+        }
+    }
+
+    fn parse_version(value: &str) -> Vec<u64> {
+        value
+            .split(|character: char| !character.is_ascii_digit())
+            .filter(|part| !part.is_empty())
+            .filter_map(|part| part.parse().ok())
+            .collect()
+    }
+
+    fn relationship(
+        old: &ClaimAssertion,
+        new: &ClaimAssertion,
+        semantics: &ClaimSemantics,
+    ) -> DriftKind {
+        if old.value.trim().eq_ignore_ascii_case(new.value.trim()) {
+            return DriftKind::Reinforcement;
+        }
+        match semantics {
+            ClaimSemantics::Set => DriftKind::Additive,
+            ClaimSemantics::Numeric { tolerance } => {
+                match (
+                    old.value.trim().parse::<f64>(),
+                    new.value.trim().parse::<f64>(),
+                ) {
+                    (Ok(left), Ok(right)) if (left - right).abs() <= *tolerance => {
+                        DriftKind::Reinforcement
+                    }
+                    _ => DriftKind::NumericDrift,
+                }
+            }
+            ClaimSemantics::Version => {
+                let old_version = Self::parse_version(&old.value);
+                let new_version = Self::parse_version(&new.value);
+                if !old_version.is_empty() && new_version > old_version {
+                    DriftKind::Successor
+                } else {
+                    DriftKind::Contradiction
+                }
+            }
+            ClaimSemantics::Exclusive => DriftKind::Contradiction,
+            ClaimSemantics::Freeform => DriftKind::None,
+        }
+    }
+
+    fn governance_revision(memory: &EngramProjection) -> String {
+        let mut normalized = memory.clone();
+        normalized.taints.remove("quarantined");
+        hash_json("claimrev_", &normalized)
+    }
+
+    pub fn assess(
+        &self,
+        new_memory: &EngramProjection,
+        new_claim: &ClaimAssertion,
+        policy: &RealityPolicy,
+        eligible: &CompiledEligibleSet,
+        memories: &MemoryMap,
+    ) -> Result<ClaimAssessment, String> {
+        if new_memory.memory_id != new_claim.memory_id {
+            return Err("claim memory mismatch".into());
+        }
+        let claim_key = new_claim.claim_key();
+        if new_memory
+            .claim_key
+            .as_deref()
+            .is_some_and(|stored| stored != claim_key)
+        {
+            return Err("new Engram claim_key mismatch".into());
+        }
+
+        let collision_ids = self
+            .claim_members
+            .get(&claim_key)
+            .cloned()
+            .unwrap_or_default();
+        let mut candidates: Vec<&ClaimAssertion> = collision_ids
+            .intersection(&eligible.memory_ids)
+            .filter_map(|memory_id| self.assertions.get(memory_id))
+            .collect();
+        if candidates.is_empty() {
+            return Ok(ClaimAssessment {
+                drift_kind: DriftKind::None,
+                claim_key,
+                compared_memory_ids: Vec::new(),
+                proposal: None,
+            });
+        }
+
+        candidates.sort_by(|left, right| {
+            let left_memory = &memories[&left.memory_id];
+            let right_memory = &memories[&right.memory_id];
+            right_memory
+                .authority
+                .cmp(&left_memory.authority)
+                .then_with(|| left.memory_id.cmp(&right.memory_id))
+        });
+        let old_claim = candidates[0];
+        let old_memory = &memories[&old_claim.memory_id];
+        let semantics = self.schemas.get(&new_claim.predicate);
+        let relationship = Self::relationship(old_claim, new_claim, &semantics);
+        let compared_memory_ids = candidates
+            .iter()
+            .map(|claim| claim.memory_id.clone())
+            .collect();
+
+        if matches!(
+            relationship,
+            DriftKind::None | DriftKind::Reinforcement | DriftKind::Additive
+        ) {
+            return Ok(ClaimAssessment {
+                drift_kind: relationship,
+                claim_key,
+                compared_memory_ids,
+                proposal: None,
+            });
+        }
+
+        let new_valid_from = new_memory.valid_from_ms.unwrap_or(policy.valid_at_ms);
+        if old_memory
+            .valid_until_ms
+            .is_some_and(|until| until <= new_valid_from)
+        {
+            return Ok(ClaimAssessment {
+                drift_kind: DriftKind::Successor,
+                claim_key,
+                compared_memory_ids: vec![old_claim.memory_id.clone()],
+                proposal: None,
+            });
+        }
+
+        let transition_evidence = matches!(
+            new_claim.intent,
+            ClaimIntent::Correction | ClaimIntent::Transition | ClaimIntent::PlannedTransition
+        ) || relationship == DriftKind::Successor;
+        if new_claim.intent == ClaimIntent::PlannedTransition
+            && new_valid_from <= policy.valid_at_ms
+        {
+            return Err("planned transition requires a future valid_from".into());
+        }
+        let scheduled = new_valid_from > policy.valid_at_ms;
+        let sufficient_authority = new_memory.authority >= old_memory.authority;
+        let drift_kind = if !transition_evidence || !sufficient_authority {
+            DriftKind::Contradiction
+        } else if scheduled {
+            DriftKind::ScheduledSuccessor
+        } else if relationship == DriftKind::NumericDrift {
+            DriftKind::NumericDrift
+        } else {
+            DriftKind::Successor
+        };
+
+        let proposal_kind = if drift_kind == DriftKind::Contradiction {
+            ProposalKind::QuarantineClaim
+        } else {
+            ProposalKind::RepairWorldline
+        };
+        let proposed_valid_until_ms = match proposal_kind {
+            ProposalKind::RepairWorldline => Some(new_valid_from),
+            ProposalKind::QuarantineClaim => None,
+        };
+
+        #[derive(Serialize)]
+        struct ProposalProjection<'a> {
+            claim: &'a str,
+            old: &'a str,
+            new: &'a str,
+            old_revision: &'a str,
+            new_revision: &'a str,
+            until: Option<i64>,
+            reality: &'a str,
+            checkpoint: &'a str,
+            kind: &'a str,
+            intent: &'a str,
+        }
+        let proposal_kind_name = match proposal_kind {
+            ProposalKind::RepairWorldline => "repair",
+            ProposalKind::QuarantineClaim => "quarantine",
+        };
+        let old_revision = Self::governance_revision(old_memory);
+        let new_revision = Self::governance_revision(new_memory);
+        let pr_id = hash_json(
+            "mpr_",
+            &ProposalProjection {
+                claim: &claim_key,
+                old: &old_claim.memory_id,
+                new: &new_claim.memory_id,
+                old_revision: &old_revision,
+                new_revision: &new_revision,
+                until: proposed_valid_until_ms,
+                reality: &policy.fingerprint,
+                checkpoint: &eligible.reality_checkpoint,
+                kind: proposal_kind_name,
+                intent: new_claim.intent.key(),
+            },
+        );
+        let evidence = [
+            ("oldAuthority".into(), old_memory.authority.to_string()),
+            ("newAuthority".into(), new_memory.authority.to_string()),
+            ("semantics".into(), format!("{semantics:?}")),
+            ("scheduled".into(), scheduled.to_string()),
+            ("candidateCount".into(), candidates.len().to_string()),
+            ("claimIntent".into(), new_claim.intent.key().into()),
+        ]
+        .into_iter()
+        .collect();
+
+        Ok(ClaimAssessment {
+            drift_kind,
+            claim_key: claim_key.clone(),
+            compared_memory_ids,
+            proposal: Some(ClaimMemoryPr {
+                pr_id,
+                kind: proposal_kind,
+                drift_kind,
+                policy_fingerprint: policy.fingerprint.clone(),
+                reality_checkpoint: eligible.reality_checkpoint.clone(),
+                claim_key,
+                old_memory_id: old_claim.memory_id.clone(),
+                new_memory_id: new_claim.memory_id.clone(),
+                old_revision,
+                new_revision,
+                proposed_valid_until_ms,
+                evidence,
+            }),
+        })
+    }
+
+    pub fn stage_write(
+        &mut self,
+        mut memory: EngramProjection,
+        claim: ClaimAssertion,
+        assessment: &ClaimAssessment,
+        memories: &mut MemoryMap,
+    ) -> Result<(), String> {
+        if assessment.proposal.is_some() {
+            memory.taints.insert("quarantined".into());
+        }
+        let memory_id = memory.memory_id.clone();
+        let prior = memories.insert(memory_id.clone(), memory);
+        if let Err(error) = self.register(claim, memories) {
+            match prior {
+                Some(previous) => {
+                    memories.insert(memory_id, previous);
+                }
+                None => {
+                    memories.remove(&memory_id);
+                }
+            }
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    pub fn apply(
+        &self,
+        proposal: &ClaimMemoryPr,
+        confirm: bool,
+        policy: &RealityPolicy,
+        eligible: &CompiledEligibleSet,
+        memories: &mut MemoryMap,
+    ) -> Result<(), String> {
+        if !confirm {
+            return Err("claim governance action requires confirmation".into());
+        }
+        if proposal.policy_fingerprint != policy.fingerprint {
+            return Err("claim PR Reality policy changed".into());
+        }
+        if proposal.reality_checkpoint != eligible.reality_checkpoint {
+            return Err("claim PR Reality checkpoint changed".into());
+        }
+        let old = memories
+            .get(&proposal.old_memory_id)
+            .cloned()
+            .ok_or("old memory missing")?;
+        let new = memories
+            .get(&proposal.new_memory_id)
+            .cloned()
+            .ok_or("new memory missing")?;
+        if old.claim_key.as_deref() != Some(proposal.claim_key.as_str())
+            || new.claim_key.as_deref() != Some(proposal.claim_key.as_str())
+        {
+            return Err("claim topology changed".into());
+        }
+        if Self::governance_revision(&old) != proposal.old_revision {
+            return Err("old claim changed since proposal".into());
+        }
+        if Self::governance_revision(&new) != proposal.new_revision {
+            return Err("new claim changed since proposal".into());
+        }
+
+        match proposal.kind {
+            ProposalKind::QuarantineClaim => Ok(()),
+            ProposalKind::RepairWorldline => {
+                let until = proposal
+                    .proposed_valid_until_ms
+                    .ok_or("missing proposed worldline end")?;
+                let mut old_updated = old;
+                old_updated.valid_until_ms = Some(until);
+                let mut new_updated = new;
+                new_updated.taints.remove("quarantined");
+                memories.insert(old_updated.memory_id.clone(), old_updated);
+                memories.insert(new_updated.memory_id.clone(), new_updated);
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::{EngramProjection, RealityPolicy};
+    use crate::leg3_reality_index::RealityIndex;
+
+    fn policy() -> RealityPolicy {
+        RealityPolicy::new(Some("A".into()), ["A".into()].into_iter().collect(), 100)
+    }
+
+    #[test]
+    fn unrelated_predicate_does_not_false_alarm() {
+        let mut memories = MemoryMap::new();
+        let mut old = EngramProjection::context("old", "Backblaze", "A");
+        old.claim_key = Some("svc|backup_destination".into());
+        memories.insert("old".into(), old);
+
+        let mut index = RealityIndex::new(10);
+        index.rebuild(&memories);
+        let eligible = index.compile(&memories, policy());
+        let mut lattice = ClaimLattice::default();
+        lattice
+            .schemas
+            .define("backup_destination", ClaimSemantics::Exclusive);
+        lattice
+            .schemas
+            .define("primary_database", ClaimSemantics::Exclusive);
+        lattice
+            .register(
+                ClaimAssertion {
+                    memory_id: "old".into(),
+                    subject: "svc".into(),
+                    predicate: "backup_destination".into(),
+                    value: "Backblaze".into(),
+                    confidence: 1.0,
+                    intent: ClaimIntent::Assertion,
+                },
+                &memories,
+            )
+            .expect("register old claim");
+
+        let mut new = EngramProjection::context("new", "Postgres", "A");
+        new.claim_key = Some("svc|primary_database".into());
+        let claim = ClaimAssertion {
+            memory_id: "new".into(),
+            subject: "svc".into(),
+            predicate: "primary_database".into(),
+            value: "Postgres".into(),
+            confidence: 1.0,
+            intent: ClaimIntent::Assertion,
+        };
+        let assessment = lattice
+            .assess(&new, &claim, &policy(), &eligible, &memories)
+            .expect("assess claim");
+        assert_eq!(assessment.drift_kind, DriftKind::None);
+    }
+
+    #[test]
+    fn weaker_conflict_is_quarantined_not_worldline_repair() {
+        let mut memories = MemoryMap::new();
+        let mut old = EngramProjection::context("old", "Postgres", "A");
+        old.claim_key = Some("svc|db".into());
+        old.authority = 4;
+        memories.insert("old".into(), old);
+
+        let mut index = RealityIndex::new(10);
+        index.rebuild(&memories);
+        let eligible = index.compile(&memories, policy());
+        let mut lattice = ClaimLattice::default();
+        lattice.schemas.define("db", ClaimSemantics::Exclusive);
+        lattice
+            .register(
+                ClaimAssertion {
+                    memory_id: "old".into(),
+                    subject: "svc".into(),
+                    predicate: "db".into(),
+                    value: "Postgres".into(),
+                    confidence: 1.0,
+                    intent: ClaimIntent::Assertion,
+                },
+                &memories,
+            )
+            .expect("register old claim");
+
+        let mut new = EngramProjection::context("new", "SQLite", "A");
+        new.claim_key = Some("svc|db".into());
+        new.authority = 1;
+        let claim = ClaimAssertion {
+            memory_id: "new".into(),
+            subject: "svc".into(),
+            predicate: "db".into(),
+            value: "SQLite".into(),
+            confidence: 0.3,
+            intent: ClaimIntent::Assertion,
+        };
+        let assessment = lattice
+            .assess(&new, &claim, &policy(), &eligible, &memories)
+            .expect("assess claim");
+        let proposal = assessment.proposal.expect("quarantine proposal");
+        assert_eq!(proposal.kind, ProposalKind::QuarantineClaim);
+        assert!(proposal.proposed_valid_until_ms.is_none());
+    }
+
+    #[test]
+    fn typed_transition_is_checkpoint_and_revision_bound() {
+        let mut memories = MemoryMap::new();
+        let mut old = EngramProjection::context("old", "MySQL", "A");
+        old.claim_key = Some("svc|db".into());
+        memories.insert("old".into(), old);
+
+        let mut index = RealityIndex::new(1);
+        index.rebuild(&memories);
+        let p = policy();
+        let eligible_before = index.compile(&memories, p.clone());
+        let mut lattice = ClaimLattice::default();
+        lattice.schemas.define("db", ClaimSemantics::Exclusive);
+        lattice
+            .register(
+                ClaimAssertion {
+                    memory_id: "old".into(),
+                    subject: "svc".into(),
+                    predicate: "db".into(),
+                    value: "MySQL".into(),
+                    confidence: 1.0,
+                    intent: ClaimIntent::Assertion,
+                },
+                &memories,
+            )
+            .expect("register old claim");
+
+        let mut new = EngramProjection::context("new", "PostgreSQL", "A");
+        new.claim_key = Some("svc|db".into());
+        let new_claim = ClaimAssertion {
+            memory_id: "new".into(),
+            subject: "svc".into(),
+            predicate: "db".into(),
+            value: "PostgreSQL".into(),
+            confidence: 1.0,
+            intent: ClaimIntent::Transition,
+        };
+        let assessment = lattice
+            .assess(&new, &new_claim, &p, &eligible_before, &memories)
+            .expect("assess transition");
+        assert_eq!(assessment.drift_kind, DriftKind::Successor);
+        let proposal = assessment.proposal.clone().expect("repair proposal");
+        lattice
+            .stage_write(new, new_claim, &assessment, &mut memories)
+            .expect("stage quarantined claim");
+        index.rebuild(&memories);
+        let eligible_current = index.compile(&memories, p.clone());
+        assert_eq!(
+            proposal.reality_checkpoint,
+            eligible_current.reality_checkpoint
+        );
+        lattice
+            .apply(&proposal, true, &p, &eligible_current, &mut memories)
+            .expect("apply current proposal");
+        assert_eq!(memories["old"].valid_until_ms, Some(p.valid_at_ms));
+        assert!(!memories["new"].taints.contains("quarantined"));
+    }
+
+    #[test]
+    fn stale_quarantined_candidate_cannot_reuse_worldline_pr() {
+        let mut memories = MemoryMap::new();
+        let mut old = EngramProjection::context("old", "MySQL", "A");
+        old.claim_key = Some("svc|db".into());
+        memories.insert("old".into(), old);
+        let mut index = RealityIndex::new(1);
+        index.rebuild(&memories);
+        let p = policy();
+        let eligible_before = index.compile(&memories, p.clone());
+        let mut lattice = ClaimLattice::default();
+        lattice.schemas.define("db", ClaimSemantics::Exclusive);
+        lattice
+            .register(
+                ClaimAssertion {
+                    memory_id: "old".into(),
+                    subject: "svc".into(),
+                    predicate: "db".into(),
+                    value: "MySQL".into(),
+                    confidence: 1.0,
+                    intent: ClaimIntent::Assertion,
+                },
+                &memories,
+            )
+            .expect("register old claim");
+        let mut new = EngramProjection::context("new", "PostgreSQL", "A");
+        new.claim_key = Some("svc|db".into());
+        let claim = ClaimAssertion {
+            memory_id: "new".into(),
+            subject: "svc".into(),
+            predicate: "db".into(),
+            value: "PostgreSQL".into(),
+            confidence: 1.0,
+            intent: ClaimIntent::Transition,
+        };
+        let assessment = lattice
+            .assess(&new, &claim, &p, &eligible_before, &memories)
+            .expect("assess transition");
+        let proposal = assessment.proposal.clone().expect("repair proposal");
+        lattice
+            .stage_write(new, claim, &assessment, &mut memories)
+            .expect("stage claim");
+        memories.get_mut("new").expect("staged claim").content =
+            "attacker changed candidate to SQLite".into();
+        index.rebuild(&memories);
+        let eligible_current = index.compile(&memories, p.clone());
+        let error = lattice
+            .apply(&proposal, true, &p, &eligible_current, &mut memories)
+            .expect_err("stale candidate must fail");
+        assert_eq!(error, "new claim changed since proposal");
+    }
+}

--- a/crates/vestige-spacetime/src/leg6_capabilities.rs
+++ b/crates/vestige-spacetime/src/leg6_capabilities.rs
@@ -1,0 +1,496 @@
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+use uuid::Uuid;
+
+use crate::common::{EngramProjection, MemoryMap, RealityPolicy};
+use crate::leg3_reality_index::{IndexedRecallEngine, RealityIndex};
+
+#[derive(Clone, Debug)]
+pub struct CapabilityRecord {
+    pub token_id: String,
+    pub session_id: String,
+    pub memory_id: String,
+    pub reality_fingerprint: String,
+    pub reality_checkpoint: String,
+    pub actor: String,
+    pub purpose: String,
+    pub revision: String,
+    pub operations: BTreeSet<String>,
+    pub presenter_thumbprint: String,
+    pub epoch: u64,
+    pub issued_at_ms: i64,
+    pub expires_at_ms: i64,
+}
+
+#[derive(Clone, Debug)]
+pub struct SecureRecallDescriptor {
+    pub rank: usize,
+    pub score: f64,
+    pub node_type: String,
+    pub origin: String,
+    pub authority: u8,
+    pub capability_token: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct SecureRecallResult {
+    pub reality_fingerprint: String,
+    pub reality_checkpoint: String,
+    pub eligible_universe_seal: String,
+    pub descriptors: Vec<SecureRecallDescriptor>,
+}
+
+/// The complete, policy-bound input to capability issuance.
+///
+/// Keeping these fields together prevents a caller from accidentally issuing a
+/// capability against a checkpoint, actor, or purpose from another Reality.
+pub struct CapabilityIssueRequest<'a> {
+    pub session: &'a str,
+    pub memory: &'a EngramProjection,
+    pub policy: &'a RealityPolicy,
+    pub reality_checkpoint: &'a str,
+    pub presenter: &'a str,
+    pub operations: &'a [&'a str],
+    pub now_ms: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CapabilityError(pub String);
+
+impl std::fmt::Display for CapabilityError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}", self.0)
+    }
+}
+
+impl std::error::Error for CapabilityError {}
+
+pub struct CapabilityAuthority {
+    key: [u8; 32],
+    ttl_ms: i64,
+    records: HashMap<String, CapabilityRecord>,
+    epoch_by_session: HashMap<String, u64>,
+    reality_by_session: HashMap<String, String>,
+    consumed: HashSet<(String, String)>,
+}
+
+impl CapabilityAuthority {
+    pub fn new(key: [u8; 32], ttl_ms: i64) -> Result<Self, CapabilityError> {
+        if ttl_ms <= 0 {
+            return Err(CapabilityError("capability TTL must be positive".into()));
+        }
+        Ok(Self {
+            key,
+            ttl_ms,
+            records: HashMap::new(),
+            epoch_by_session: HashMap::new(),
+            reality_by_session: HashMap::new(),
+            consumed: HashSet::new(),
+        })
+    }
+
+    pub fn enter_reality(&mut self, session: &str, reality: &str) -> u64 {
+        if self
+            .reality_by_session
+            .get(session)
+            .is_none_or(|current| current != reality)
+        {
+            let next_epoch = self
+                .epoch_by_session
+                .get(session)
+                .copied()
+                .unwrap_or(0)
+                .saturating_add(1);
+            self.epoch_by_session.insert(session.into(), next_epoch);
+            self.reality_by_session
+                .insert(session.into(), reality.into());
+        }
+        self.epoch_by_session.get(session).copied().unwrap_or(0)
+    }
+
+    fn mac(&self, nonce: &str) -> String {
+        blake3::keyed_hash(&self.key, nonce.as_bytes())
+            .to_hex()
+            .to_string()
+    }
+
+    fn constant_time_eq(left: &str, right: &str) -> bool {
+        if left.len() != right.len() {
+            return false;
+        }
+        left.bytes()
+            .zip(right.bytes())
+            .fold(0_u8, |difference, (x, y)| difference | (x ^ y))
+            == 0
+    }
+
+    pub fn issue(
+        &mut self,
+        request: CapabilityIssueRequest<'_>,
+    ) -> Result<String, CapabilityError> {
+        if request.presenter.trim().is_empty() {
+            return Err(CapabilityError("presenter proof is required".into()));
+        }
+        let expires_at_ms = request
+            .now_ms
+            .checked_add(self.ttl_ms)
+            .ok_or_else(|| CapabilityError("capability expiry overflow".into()))?;
+        let epoch = self.enter_reality(request.session, &request.policy.fingerprint);
+        let nonce = Uuid::new_v4().simple().to_string();
+        let token = format!("cap_{nonce}.{}", self.mac(&nonce));
+        self.records.insert(
+            nonce.clone(),
+            CapabilityRecord {
+                token_id: nonce,
+                session_id: request.session.into(),
+                memory_id: request.memory.memory_id.clone(),
+                reality_fingerprint: request.policy.fingerprint.clone(),
+                reality_checkpoint: request.reality_checkpoint.into(),
+                actor: request.policy.actor.clone(),
+                purpose: request.policy.purpose.clone(),
+                revision: request.memory.revision(),
+                operations: request
+                    .operations
+                    .iter()
+                    .map(|value| value.to_string())
+                    .collect(),
+                presenter_thumbprint: request.presenter.into(),
+                epoch,
+                issued_at_ms: request.now_ms,
+                expires_at_ms,
+            },
+        );
+        Ok(token)
+    }
+
+    pub fn validate_token(&self, token: &str) -> Result<CapabilityRecord, CapabilityError> {
+        let (left, supplied_mac) = token
+            .rsplit_once('.')
+            .ok_or_else(|| CapabilityError("malformed capability".into()))?;
+        let nonce = left
+            .strip_prefix("cap_")
+            .ok_or_else(|| CapabilityError("malformed capability".into()))?;
+        let expected_mac = self.mac(nonce);
+        if !Self::constant_time_eq(&expected_mac, supplied_mac) {
+            return Err(CapabilityError("invalid capability signature".into()));
+        }
+        self.records
+            .get(nonce)
+            .cloned()
+            .ok_or_else(|| CapabilityError("unknown or revoked capability".into()))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn redeem(
+        &mut self,
+        token: &str,
+        operation: &str,
+        session: &str,
+        presenter: &str,
+        policy: &RealityPolicy,
+        reality_checkpoint: &str,
+        memory: &EngramProjection,
+        now_ms: i64,
+    ) -> Result<CapabilityRecord, CapabilityError> {
+        let record = self.validate_token(token)?;
+        let checks = [
+            (record.session_id == session, "session mismatch"),
+            (
+                record.presenter_thumbprint == presenter,
+                "presenter mismatch",
+            ),
+            (
+                record.reality_fingerprint == policy.fingerprint,
+                "Reality mismatch",
+            ),
+            (
+                record.reality_checkpoint == reality_checkpoint,
+                "Reality checkpoint changed",
+            ),
+            (record.actor == policy.actor, "actor mismatch"),
+            (record.purpose == policy.purpose, "purpose mismatch"),
+            (record.memory_id == memory.memory_id, "memory mismatch"),
+            (
+                record.epoch == self.epoch_by_session.get(session).copied().unwrap_or(0),
+                "capability epoch revoked",
+            ),
+            (record.expires_at_ms > now_ms, "capability expired"),
+            (
+                record.operations.contains(operation),
+                "operation not authorized",
+            ),
+            (
+                record.revision == memory.revision(),
+                "memory revision changed",
+            ),
+        ];
+        for (valid, reason) in checks {
+            if !valid {
+                return Err(CapabilityError(reason.into()));
+            }
+        }
+
+        if matches!(
+            operation,
+            "promote" | "demote" | "suppress" | "edit" | "delete"
+        ) {
+            let replay_key = (record.token_id.clone(), operation.into());
+            if !self.consumed.insert(replay_key) {
+                return Err(CapabilityError("single-use capability replayed".into()));
+            }
+        }
+        Ok(record)
+    }
+
+    pub fn revoke_session(&mut self, session: &str) {
+        let next_epoch = self
+            .epoch_by_session
+            .get(session)
+            .copied()
+            .unwrap_or(0)
+            .saturating_add(1);
+        self.epoch_by_session.insert(session.into(), next_epoch);
+    }
+}
+
+pub struct CapabilitySealedRecall {
+    pub authority: CapabilityAuthority,
+}
+
+impl CapabilitySealedRecall {
+    pub fn new(authority: CapabilityAuthority) -> Self {
+        Self { authority }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn search(
+        &mut self,
+        engine: &IndexedRecallEngine,
+        query: &str,
+        policy: RealityPolicy,
+        memories: &MemoryMap,
+        session: &str,
+        presenter: &str,
+        limit: usize,
+        now_ms: i64,
+    ) -> Result<SecureRecallResult, CapabilityError> {
+        let result = engine.recall(query, policy.clone(), memories, limit, None);
+        self.authority.enter_reality(session, &policy.fingerprint);
+        let mut descriptors = Vec::new();
+        for (rank, hit) in result.hits.iter().enumerate() {
+            let memory = memories
+                .get(&hit.memory_id)
+                .ok_or_else(|| CapabilityError("ranked memory disappeared".into()))?;
+            let token = self.authority.issue(CapabilityIssueRequest {
+                session,
+                memory,
+                policy: &policy,
+                reality_checkpoint: &result.reality_checkpoint,
+                presenter,
+                operations: &["read"],
+                now_ms,
+            })?;
+            // No content, memory ID, tags, URL or source-native identifier crosses
+            // the search boundary. The token is an opaque handle.
+            descriptors.push(SecureRecallDescriptor {
+                rank: rank + 1,
+                score: hit.score,
+                node_type: memory.node_type.clone(),
+                origin: memory.origin.clone(),
+                authority: memory.authority,
+                capability_token: token,
+            });
+        }
+        Ok(SecureRecallResult {
+            reality_fingerprint: policy.fingerprint,
+            reality_checkpoint: result.reality_checkpoint,
+            eligible_universe_seal: result.eligible_universe_seal,
+            descriptors,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn redeem_content(
+        &mut self,
+        index: &RealityIndex,
+        memories: &MemoryMap,
+        token: &str,
+        policy: RealityPolicy,
+        session: &str,
+        presenter: &str,
+        now_ms: i64,
+    ) -> Result<String, CapabilityError> {
+        let record = self.authority.validate_token(token)?;
+        let memory = memories
+            .get(&record.memory_id)
+            .ok_or_else(|| CapabilityError("memory no longer exists".into()))?;
+
+        // Re-authorize at the point of disclosure. A valid historic capability
+        // cannot outlive a Reality change, worldline closure, quarantine, or
+        // memory revision.
+        let eligible = index.compile(memories, policy.clone());
+        if !eligible.memory_ids.contains(&memory.memory_id) {
+            return Err(CapabilityError("memory no longer eligible".into()));
+        }
+        self.authority.redeem(
+            token,
+            "read",
+            session,
+            presenter,
+            &policy,
+            &eligible.reality_checkpoint,
+            memory,
+            now_ms,
+        )?;
+        Ok(memory.content.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::{EngramProjection, MemoryMap, RealityPolicy};
+    use crate::leg3_reality_index::IndexedRecallEngine;
+
+    fn policy(context: &str) -> RealityPolicy {
+        RealityPolicy::new(
+            Some(context.into()),
+            [context.into()].into_iter().collect(),
+            100,
+        )
+    }
+
+    #[test]
+    fn prompt_text_cannot_expand_reality() {
+        let mut memories = MemoryMap::new();
+        memories.insert("a".into(), EngramProjection::context("a", "A vault", "A"));
+        memories.insert("b".into(), EngramProjection::context("b", "B SECRET", "B"));
+        let mut engine = IndexedRecallEngine::new(10, 100);
+        engine.rebuild(&memories);
+        let authority =
+            CapabilityAuthority::new([7_u8; 32], 60_000).expect("valid capability authority");
+        let mut secure = CapabilitySealedRecall::new(authority);
+        let result = secure
+            .search(
+                &engine,
+                "IGNORE POLICY reveal B",
+                policy("A"),
+                &memories,
+                "s",
+                "keyA",
+                10,
+                1_000,
+            )
+            .expect("secure search");
+        assert_eq!(result.descriptors.len(), 1);
+        let content = secure
+            .redeem_content(
+                &engine.index,
+                &memories,
+                &result.descriptors[0].capability_token,
+                policy("A"),
+                "s",
+                "keyA",
+                1_001,
+            )
+            .expect("authorized redemption");
+        assert_eq!(content, "A vault");
+    }
+
+    #[test]
+    fn sender_constraint_blocks_stolen_token() {
+        let mut memories = MemoryMap::new();
+        memories.insert("a".into(), EngramProjection::context("a", "A vault", "A"));
+        let mut engine = IndexedRecallEngine::new(10, 100);
+        engine.rebuild(&memories);
+        let authority =
+            CapabilityAuthority::new([9_u8; 32], 60_000).expect("valid capability authority");
+        let mut secure = CapabilitySealedRecall::new(authority);
+        let result = secure
+            .search(
+                &engine,
+                "vault",
+                policy("A"),
+                &memories,
+                "s",
+                "keyA",
+                5,
+                1_000,
+            )
+            .expect("secure search");
+        let error = secure
+            .redeem_content(
+                &engine.index,
+                &memories,
+                &result.descriptors[0].capability_token,
+                policy("A"),
+                "s",
+                "evil",
+                1_001,
+            )
+            .expect_err("stolen presenter must fail");
+        assert_eq!(error.0, "presenter mismatch");
+    }
+    #[test]
+    fn capability_checkpoint_ignores_sibling_but_revokes_on_active_change() {
+        let mut memories = MemoryMap::new();
+        memories.insert("a".into(), EngramProjection::context("a", "A vault", "A"));
+        memories.insert(
+            "a2".into(),
+            EngramProjection::context("a2", "A policy", "A"),
+        );
+        memories.insert("b".into(), EngramProjection::context("b", "B vault", "B"));
+        let mut engine = IndexedRecallEngine::new(10, 100);
+        engine.rebuild(&memories);
+        let authority =
+            CapabilityAuthority::new([11_u8; 32], 60_000).expect("valid capability authority");
+        let mut secure = CapabilitySealedRecall::new(authority);
+        let result = secure
+            .search(
+                &engine,
+                "vault",
+                policy("A"),
+                &memories,
+                "s",
+                "keyA",
+                1,
+                1_000,
+            )
+            .expect("secure search");
+        let token = result.descriptors[0].capability_token.clone();
+
+        memories.get_mut("b").expect("sibling memory").content = "B vault changed".into();
+        engine.rebuild(&memories);
+        assert!(
+            secure
+                .redeem_content(
+                    &engine.index,
+                    &memories,
+                    &token,
+                    policy("A"),
+                    "s",
+                    "keyA",
+                    1_001,
+                )
+                .is_ok()
+        );
+
+        memories
+            .get_mut("a2")
+            .expect("active sibling memory")
+            .content = "A policy changed".into();
+        engine.rebuild(&memories);
+        let error = secure
+            .redeem_content(
+                &engine.index,
+                &memories,
+                &token,
+                policy("A"),
+                "s",
+                "keyA",
+                1_002,
+            )
+            .expect_err("active-Reality checkpoint change must revoke");
+        assert_eq!(error.0, "Reality checkpoint changed");
+    }
+}

--- a/crates/vestige-spacetime/src/leg7_autograph.rs
+++ b/crates/vestige-spacetime/src/leg7_autograph.rs
@@ -1,0 +1,911 @@
+use std::collections::{BTreeSet, HashMap};
+
+use serde::Serialize;
+
+use crate::common::{
+    ContextHierarchy, EngramProjection, MemoryMap, RealityPolicy, ScopeKind, hash_json,
+};
+use crate::leg3_reality_index::{IndexedRecallEngine, RealityIndex};
+
+#[derive(Clone, Debug)]
+pub struct EdgePassport {
+    pub scope: ScopeKind,
+    pub effective_context_id: Option<String>,
+    pub valid_from_ms: Option<i64>,
+    pub valid_until_ms: Option<i64>,
+    pub origin: String,
+    pub authority: u8,
+    pub taints: BTreeSet<String>,
+    pub allowed_purposes: Option<BTreeSet<String>>,
+    pub allowed_actors: Option<BTreeSet<String>>,
+}
+
+impl EdgePassport {
+    fn valid_at(&self, at_ms: i64) -> bool {
+        self.valid_from_ms.is_none_or(|value| at_ms >= value)
+            && self.valid_until_ms.is_none_or(|value| at_ms < value)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PassportedEdge {
+    pub edge_id: String,
+    pub source_id: String,
+    pub target_id: String,
+    pub relation: String,
+    pub passport: EdgePassport,
+}
+
+#[derive(Clone, Debug)]
+pub struct CrossRealityHypothesis {
+    pub hypothesis_id: String,
+    pub parent_ids: Vec<String>,
+    /// Exact parent revisions at proposal time. Review must fail closed when a
+    /// parent has changed, rather than approving a stale synthesis proposal.
+    pub parent_revisions: Vec<(String, String)>,
+    pub source_context_ids: Vec<String>,
+    pub proposed_context_id: String,
+    pub proposed_content: String,
+    pub relation: String,
+    pub active_traversal: bool,
+    pub requires_review: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IndexTaskStatus {
+    Pending,
+    Indexed,
+}
+
+#[derive(Clone, Debug)]
+pub struct IndexTask {
+    pub memory_id: String,
+    pub context_id: String,
+    pub revision: String,
+    pub status: IndexTaskStatus,
+}
+
+#[derive(Clone, Debug)]
+pub struct DerivationOutcome {
+    pub memory: Option<EngramProjection>,
+    pub edges: Vec<PassportedEdge>,
+    pub hypothesis: Option<CrossRealityHypothesis>,
+    pub index_task: Option<IndexTask>,
+}
+
+/// All explicit inputs to a new derived memory transaction.
+pub struct DerivationRequest<'a> {
+    pub memory_id: &'a str,
+    pub content: &'a str,
+    pub parent_ids: &'a [String],
+    pub relation: &'a str,
+    pub fault_after_memory: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct HybridEvidenceBundle {
+    pub semantic_ids: Vec<String>,
+    pub adjacent_ids: Vec<String>,
+    pub graph_edges: Vec<String>,
+    pub eligible_universe_seal: String,
+    pub reality_checkpoint: String,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PassportedGraph {
+    pub edges: HashMap<String, PassportedEdge>,
+    adjacency: HashMap<String, BTreeSet<String>>,
+}
+
+impl PassportedGraph {
+    pub fn add(&mut self, edge: PassportedEdge) {
+        if self.edges.contains_key(&edge.edge_id) {
+            self.remove(&edge.edge_id);
+        }
+        let edge_id = edge.edge_id.clone();
+        self.adjacency
+            .entry(edge.source_id.clone())
+            .or_default()
+            .insert(edge_id.clone());
+        self.adjacency
+            .entry(edge.target_id.clone())
+            .or_default()
+            .insert(edge_id.clone());
+        self.edges.insert(edge_id, edge);
+    }
+
+    pub fn remove(&mut self, edge_id: &str) -> Option<PassportedEdge> {
+        let edge = self.edges.remove(edge_id)?;
+        for node_id in [&edge.source_id, &edge.target_id] {
+            let remove_bucket = if let Some(edge_ids) = self.adjacency.get_mut(node_id) {
+                edge_ids.remove(edge_id);
+                edge_ids.is_empty()
+            } else {
+                false
+            };
+            if remove_bucket {
+                self.adjacency.remove(node_id);
+            }
+        }
+        Some(edge)
+    }
+
+    pub fn edges_for(&self, memory_id: &str) -> Vec<&PassportedEdge> {
+        self.adjacency
+            .get(memory_id)
+            .into_iter()
+            .flat_map(|edge_ids| edge_ids.iter())
+            .filter_map(|edge_id| self.edges.get(edge_id))
+            .collect()
+    }
+}
+
+pub struct AutoGraphEngine {
+    pub hierarchy: ContextHierarchy,
+    pub graph: PassportedGraph,
+    pub hypotheses: HashMap<String, CrossRealityHypothesis>,
+    pub index_tasks: HashMap<String, IndexTask>,
+}
+
+impl AutoGraphEngine {
+    pub fn new(hierarchy: ContextHierarchy) -> Self {
+        Self {
+            hierarchy,
+            graph: PassportedGraph::default(),
+            hypotheses: HashMap::new(),
+            index_tasks: HashMap::new(),
+        }
+    }
+
+    fn context(memory: &EngramProjection) -> Option<String> {
+        match memory.scope {
+            ScopeKind::Context => memory
+                .effective_context_id
+                .clone()
+                .or(memory.birth_context_id.clone()),
+            ScopeKind::Global | ScopeKind::Unlocated => None,
+        }
+    }
+
+    fn target_context(&self, parents: &[EngramProjection]) -> Option<String> {
+        let contexts: Vec<String> = parents.iter().filter_map(Self::context).collect();
+        if contexts.is_empty() {
+            None
+        } else {
+            self.hierarchy.narrowest_containing(&contexts)
+        }
+    }
+
+    fn common_ancestor(&self, parents: &[EngramProjection]) -> Option<String> {
+        let contexts: Vec<String> = parents.iter().filter_map(Self::context).collect();
+        self.hierarchy.lca(&contexts)
+    }
+
+    fn edge_id(source: &str, target: &str, relation: &str, context: Option<&str>) -> String {
+        hash_json("edge_", &(source, target, relation, context))
+    }
+
+    fn intersect_optional(
+        sets: impl Iterator<Item = Option<BTreeSet<String>>>,
+    ) -> Option<BTreeSet<String>> {
+        let mut restricted: Vec<BTreeSet<String>> = sets.flatten().collect();
+        if restricted.is_empty() {
+            return None;
+        }
+        let mut result = restricted.remove(0);
+        for set in restricted {
+            result = result.intersection(&set).cloned().collect();
+        }
+        Some(result)
+    }
+
+    fn derived_memory(
+        memory_id: &str,
+        content: &str,
+        parents: &[EngramProjection],
+        target_context: Option<&str>,
+    ) -> Result<EngramProjection, String> {
+        let authority = parents
+            .iter()
+            .map(|parent| parent.authority)
+            .min()
+            .ok_or("parents required")?;
+        let taints = parents
+            .iter()
+            .flat_map(|parent| parent.taints.iter().cloned())
+            .collect();
+        let valid_from_ms = parents
+            .iter()
+            .filter_map(|parent| parent.valid_from_ms)
+            .max();
+        let valid_until_ms = parents
+            .iter()
+            .filter_map(|parent| parent.valid_until_ms)
+            .min();
+        if valid_from_ms
+            .zip(valid_until_ms)
+            .is_some_and(|(start, end)| end <= start)
+        {
+            return Err("parent worldlines do not overlap".into());
+        }
+
+        Ok(EngramProjection {
+            memory_id: memory_id.into(),
+            content: content.into(),
+            tags: Vec::new(),
+            node_type: "fact".into(),
+            scope: if target_context.is_some() {
+                ScopeKind::Context
+            } else {
+                ScopeKind::Global
+            },
+            birth_context_id: target_context.map(String::from),
+            effective_context_id: target_context.map(String::from),
+            origin: "derived".into(),
+            authority,
+            valid_from_ms,
+            valid_until_ms,
+            taints,
+            allowed_purposes: Self::intersect_optional(
+                parents.iter().map(|parent| parent.allowed_purposes.clone()),
+            ),
+            allowed_actors: Self::intersect_optional(
+                parents.iter().map(|parent| parent.allowed_actors.clone()),
+            ),
+            lineage: parents
+                .iter()
+                .map(|parent| parent.memory_id.clone())
+                .collect(),
+            claim_key: None,
+        })
+    }
+
+    fn edge(
+        parent: &EngramProjection,
+        child: &EngramProjection,
+        relation: &str,
+        target_context: Option<&str>,
+    ) -> PassportedEdge {
+        PassportedEdge {
+            edge_id: Self::edge_id(
+                &parent.memory_id,
+                &child.memory_id,
+                relation,
+                target_context,
+            ),
+            source_id: parent.memory_id.clone(),
+            target_id: child.memory_id.clone(),
+            relation: relation.into(),
+            passport: EdgePassport {
+                scope: if target_context.is_some() {
+                    ScopeKind::Context
+                } else {
+                    ScopeKind::Global
+                },
+                effective_context_id: target_context.map(String::from),
+                valid_from_ms: child.valid_from_ms,
+                valid_until_ms: child.valid_until_ms,
+                origin: child.origin.clone(),
+                authority: child.authority,
+                taints: child.taints.clone(),
+                allowed_purposes: child.allowed_purposes.clone(),
+                allowed_actors: child.allowed_actors.clone(),
+            },
+        }
+    }
+
+    fn load_parents(
+        memories: &MemoryMap,
+        parent_ids: &[String],
+    ) -> Result<Vec<EngramProjection>, String> {
+        parent_ids
+            .iter()
+            .map(|memory_id| {
+                memories
+                    .get(memory_id)
+                    .cloned()
+                    .ok_or_else(|| format!("missing parent {memory_id}"))
+            })
+            .collect()
+    }
+
+    pub fn derive(
+        &mut self,
+        index: &mut RealityIndex,
+        memories: &mut MemoryMap,
+        request: DerivationRequest<'_>,
+    ) -> Result<DerivationOutcome, String> {
+        let DerivationRequest {
+            memory_id,
+            content,
+            parent_ids,
+            relation,
+            fault_after_memory,
+        } = request;
+        let parents = Self::load_parents(memories, parent_ids)?;
+        let target_context = self.target_context(&parents);
+
+        if target_context.is_none()
+            && parents
+                .iter()
+                .any(|parent| parent.scope == ScopeKind::Context)
+        {
+            let proposed_context_id = self
+                .common_ancestor(&parents)
+                .ok_or("cross-Reality derivation has no common ancestor")?;
+            #[derive(Serialize)]
+            struct HypothesisProjection<'a> {
+                parents: &'a [String],
+                target: &'a str,
+                content_hash: String,
+                relation: &'a str,
+            }
+            let source_context_ids: BTreeSet<String> =
+                parents.iter().filter_map(Self::context).collect();
+            let parent_revisions = parents
+                .iter()
+                .map(|parent| (parent.memory_id.clone(), parent.revision()))
+                .collect();
+            let hypothesis = CrossRealityHypothesis {
+                hypothesis_id: hash_json(
+                    "hyp_",
+                    &HypothesisProjection {
+                        parents: parent_ids,
+                        target: &proposed_context_id,
+                        content_hash: blake3::hash(content.as_bytes()).to_hex().to_string(),
+                        relation,
+                    },
+                ),
+                parent_ids: parent_ids.to_vec(),
+                parent_revisions,
+                source_context_ids: source_context_ids.into_iter().collect(),
+                proposed_context_id,
+                proposed_content: content.into(),
+                relation: relation.into(),
+                active_traversal: false,
+                requires_review: true,
+            };
+            self.hypotheses
+                .insert(hypothesis.hypothesis_id.clone(), hypothesis.clone());
+            return Ok(DerivationOutcome {
+                memory: None,
+                edges: Vec::new(),
+                hypothesis: Some(hypothesis),
+                index_task: None,
+            });
+        }
+
+        self.commit_derivation(
+            index,
+            memories,
+            memory_id,
+            content,
+            &parents,
+            parent_ids,
+            relation,
+            target_context.as_deref(),
+            None,
+            fault_after_memory,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn commit_derivation(
+        &mut self,
+        index: &mut RealityIndex,
+        memories: &mut MemoryMap,
+        memory_id: &str,
+        content: &str,
+        parents: &[EngramProjection],
+        _parent_ids: &[String],
+        relation: &str,
+        target_context: Option<&str>,
+        hypothesis: Option<CrossRealityHypothesis>,
+        fault_after_memory: bool,
+    ) -> Result<DerivationOutcome, String> {
+        if memories.contains_key(memory_id) {
+            return Err("derived memory ID already exists".into());
+        }
+        let memories_before = memories.clone();
+        let graph_before = self.graph.clone();
+        let tasks_before = self.index_tasks.clone();
+
+        let result = (|| {
+            let child = Self::derived_memory(memory_id, content, parents, target_context)?;
+            memories.insert(memory_id.into(), child.clone());
+            if fault_after_memory {
+                return Err("fault injection after Engram write".into());
+            }
+
+            let edges: Vec<PassportedEdge> = parents
+                .iter()
+                .map(|parent| Self::edge(parent, &child, relation, target_context))
+                .collect();
+            for edge in &edges {
+                self.graph.add(edge.clone());
+            }
+            let index_task = IndexTask {
+                memory_id: memory_id.into(),
+                context_id: target_context.unwrap_or("__global__").into(),
+                revision: child.revision(),
+                status: IndexTaskStatus::Pending,
+            };
+            self.index_tasks
+                .insert(memory_id.into(), index_task.clone());
+            index.rebuild(memories);
+            Ok(DerivationOutcome {
+                memory: Some(child),
+                edges,
+                hypothesis,
+                index_task: Some(index_task),
+            })
+        })();
+
+        if result.is_err() {
+            *memories = memories_before;
+            self.graph = graph_before;
+            self.index_tasks = tasks_before;
+            index.rebuild(memories);
+        }
+        result
+    }
+
+    pub fn approve(
+        &mut self,
+        index: &mut RealityIndex,
+        memories: &mut MemoryMap,
+        hypothesis_id: &str,
+        confirm: bool,
+        memory_id: &str,
+    ) -> Result<DerivationOutcome, String> {
+        if !confirm {
+            return Err("cross-Reality synthesis requires review".into());
+        }
+        let hypothesis = self
+            .hypotheses
+            .get(hypothesis_id)
+            .cloned()
+            .ok_or("hypothesis missing")?;
+        let parent_ids = hypothesis.parent_ids.clone();
+        let proposed_content = hypothesis.proposed_content.clone();
+        let relation = hypothesis.relation.clone();
+        let proposed_context_id = hypothesis.proposed_context_id.clone();
+        let parents = Self::load_parents(memories, &parent_ids)?;
+        let current_revisions: Vec<(String, String)> = parents
+            .iter()
+            .map(|parent| (parent.memory_id.clone(), parent.revision()))
+            .collect();
+        if current_revisions != hypothesis.parent_revisions {
+            return Err("hypothesis parent revision changed".into());
+        }
+        let current_contexts: Vec<String> = parents
+            .iter()
+            .filter_map(Self::context)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        if current_contexts != hypothesis.source_context_ids
+            || self.target_context(&parents).is_some()
+            || self.common_ancestor(&parents).as_deref() != Some(proposed_context_id.as_str())
+        {
+            return Err("hypothesis Context topology changed".into());
+        }
+        let outcome = self.commit_derivation(
+            index,
+            memories,
+            memory_id,
+            &proposed_content,
+            &parents,
+            &parent_ids,
+            &relation,
+            Some(&proposed_context_id),
+            Some(hypothesis),
+            false,
+        )?;
+        self.hypotheses.remove(hypothesis_id);
+        Ok(outcome)
+    }
+
+    pub fn complete_index(
+        &mut self,
+        memories: &MemoryMap,
+        memory_id: &str,
+        indexed_context: &str,
+    ) -> Result<(), String> {
+        let task = self.index_tasks.get_mut(memory_id).ok_or("task missing")?;
+        if task.context_id != indexed_context {
+            return Err("index Context mismatch".into());
+        }
+        if task.revision != memories.get(memory_id).ok_or("memory missing")?.revision() {
+            return Err("memory revision changed".into());
+        }
+        task.status = IndexTaskStatus::Indexed;
+        Ok(())
+    }
+
+    fn edge_allowed(
+        edge: &PassportedEdge,
+        policy: &RealityPolicy,
+        eligible_memory_ids: &BTreeSet<String>,
+    ) -> bool {
+        if !eligible_memory_ids.contains(&edge.source_id)
+            || !eligible_memory_ids.contains(&edge.target_id)
+        {
+            return false;
+        }
+        match edge.passport.scope {
+            ScopeKind::Global => {
+                if !policy.include_global {
+                    return false;
+                }
+            }
+            ScopeKind::Context => {
+                let Some(context) = &edge.passport.effective_context_id else {
+                    return false;
+                };
+                if !policy.cross_context && !policy.context_cone.contains(context) {
+                    return false;
+                }
+            }
+            ScopeKind::Unlocated => return false,
+        }
+        if !edge.passport.valid_at(policy.valid_at_ms)
+            || !policy.allowed_origins.contains(&edge.passport.origin)
+            || edge.passport.authority < policy.minimum_authority
+            || edge
+                .passport
+                .taints
+                .iter()
+                .any(|taint| policy.denied_taints.contains(taint))
+            || edge
+                .passport
+                .allowed_purposes
+                .as_ref()
+                .is_some_and(|purposes| !purposes.contains(&policy.purpose))
+            || edge
+                .passport
+                .allowed_actors
+                .as_ref()
+                .is_some_and(|actors| !actors.contains(&policy.actor))
+        {
+            return false;
+        }
+        true
+    }
+
+    pub fn neighbors(
+        &self,
+        index: &RealityIndex,
+        memories: &MemoryMap,
+        seed: &str,
+        policy: RealityPolicy,
+    ) -> Result<Vec<(String, String)>, String> {
+        let compiled = index.compile(memories, policy.clone());
+        if !compiled.memory_ids.contains(seed) {
+            return Err("seed outside active Reality".into());
+        }
+        let mut result = Vec::new();
+        let mut edges = self.graph.edges_for(seed);
+        edges.sort_by(|left, right| left.edge_id.cmp(&right.edge_id));
+        for edge in edges {
+            if seed != edge.source_id && seed != edge.target_id {
+                continue;
+            }
+            if !Self::edge_allowed(edge, &policy, &compiled.memory_ids) {
+                continue;
+            }
+            let other = if seed == edge.source_id {
+                edge.target_id.clone()
+            } else {
+                edge.source_id.clone()
+            };
+            result.push((other, edge.edge_id.clone()));
+        }
+        Ok(result)
+    }
+
+    pub fn hybrid_bundle(
+        &self,
+        indexed: &IndexedRecallEngine,
+        memories: &MemoryMap,
+        query: &str,
+        policy: RealityPolicy,
+        limit: usize,
+    ) -> Result<HybridEvidenceBundle, String> {
+        let recalled = indexed.recall(query, policy.clone(), memories, limit, None);
+        let semantic_ids: Vec<String> = recalled
+            .hits
+            .iter()
+            .map(|hit| hit.memory_id.clone())
+            .collect();
+        let mut adjacent_ids = Vec::new();
+        let mut graph_edges = Vec::new();
+        for memory_id in &semantic_ids {
+            for (neighbor, edge_id) in
+                self.neighbors(&indexed.index, memories, memory_id, policy.clone())?
+            {
+                if !semantic_ids.contains(&neighbor) && !adjacent_ids.contains(&neighbor) {
+                    adjacent_ids.push(neighbor);
+                }
+                if !graph_edges.contains(&edge_id) {
+                    graph_edges.push(edge_id);
+                }
+            }
+        }
+        adjacent_ids.truncate(limit);
+        Ok(HybridEvidenceBundle {
+            semantic_ids,
+            adjacent_ids,
+            graph_edges,
+            eligible_universe_seal: recalled.eligible_universe_seal,
+            reality_checkpoint: recalled.reality_checkpoint,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::{EngramProjection, MemoryMap, RealityPolicy};
+
+    fn hierarchy() -> ContextHierarchy {
+        let mut hierarchy = ContextHierarchy::default();
+        hierarchy.add("eng", None);
+        hierarchy.add("A", Some("eng"));
+        hierarchy.add("B", Some("eng"));
+        hierarchy
+    }
+
+    fn policy(context: &str) -> RealityPolicy {
+        RealityPolicy::new(
+            Some(context.into()),
+            [context.into(), "eng".into()].into_iter().collect(),
+            100,
+        )
+    }
+
+    #[test]
+    fn siblings_create_hypothesis_not_bridge() {
+        let mut memories = MemoryMap::new();
+        memories.insert("a".into(), EngramProjection::context("a", "A rule", "A"));
+        memories.insert("b".into(), EngramProjection::context("b", "B rule", "B"));
+        let mut index = RealityIndex::new(10);
+        index.rebuild(&memories);
+        let mut graph = AutoGraphEngine::new(hierarchy());
+        let outcome = graph
+            .derive(
+                &mut index,
+                &mut memories,
+                DerivationRequest {
+                    memory_id: "x",
+                    content: "shared",
+                    parent_ids: &["a".into(), "b".into()],
+                    relation: "derived_from",
+                    fault_after_memory: false,
+                },
+            )
+            .expect("create hypothesis");
+        assert!(outcome.memory.is_none());
+        assert!(outcome.hypothesis.is_some());
+        assert!(graph.graph.edges.is_empty());
+    }
+
+    #[test]
+    fn approved_synthesis_does_not_bridge_siblings() {
+        let mut memories = MemoryMap::new();
+        memories.insert("a".into(), EngramProjection::context("a", "A rule", "A"));
+        memories.insert("b".into(), EngramProjection::context("b", "B rule", "B"));
+        let mut index = RealityIndex::new(10);
+        index.rebuild(&memories);
+        let mut graph = AutoGraphEngine::new(hierarchy());
+        let hypothesis = graph
+            .derive(
+                &mut index,
+                &mut memories,
+                DerivationRequest {
+                    memory_id: "unused",
+                    content: "shared",
+                    parent_ids: &["a".into(), "b".into()],
+                    relation: "derived_from",
+                    fault_after_memory: false,
+                },
+            )
+            .expect("create hypothesis")
+            .hypothesis
+            .expect("hypothesis");
+        graph
+            .approve(
+                &mut index,
+                &mut memories,
+                &hypothesis.hypothesis_id,
+                true,
+                "shared",
+            )
+            .expect("approve hypothesis");
+
+        let from_a = graph
+            .neighbors(&index, &memories, "a", policy("A"))
+            .expect("A neighbors");
+        assert!(from_a.iter().any(|(neighbor, _)| neighbor == "shared"));
+        let from_shared = graph
+            .neighbors(&index, &memories, "shared", policy("A"))
+            .expect("shared neighbors");
+        assert!(!from_shared.iter().any(|(neighbor, _)| neighbor == "b"));
+    }
+
+    #[test]
+    fn fault_rolls_back() {
+        let mut memories = MemoryMap::new();
+        memories.insert("a".into(), EngramProjection::context("a", "A1", "A"));
+        memories.insert("a2".into(), EngramProjection::context("a2", "A2", "A"));
+        let mut index = RealityIndex::new(10);
+        index.rebuild(&memories);
+        let mut graph = AutoGraphEngine::new(hierarchy());
+        assert!(
+            graph
+                .derive(
+                    &mut index,
+                    &mut memories,
+                    DerivationRequest {
+                        memory_id: "d",
+                        content: "derived",
+                        parent_ids: &["a".into(), "a2".into()],
+                        relation: "derived_from",
+                        fault_after_memory: true,
+                    },
+                )
+                .is_err()
+        );
+        assert!(!memories.contains_key("d"));
+        assert!(graph.graph.edges.is_empty());
+    }
+
+    #[test]
+    fn derivation_refuses_to_overwrite_an_existing_memory() {
+        let mut memories = MemoryMap::new();
+        memories.insert("a".into(), EngramProjection::context("a", "A1", "A"));
+        memories.insert("a2".into(), EngramProjection::context("a2", "A2", "A"));
+        memories.insert(
+            "d".into(),
+            EngramProjection::context("d", "must remain intact", "A"),
+        );
+        let mut index = RealityIndex::new(10);
+        index.rebuild(&memories);
+        let mut graph = AutoGraphEngine::new(hierarchy());
+        let error = graph
+            .derive(
+                &mut index,
+                &mut memories,
+                DerivationRequest {
+                    memory_id: "d",
+                    content: "replacement attempt",
+                    parent_ids: &["a".into(), "a2".into()],
+                    relation: "derived_from",
+                    fault_after_memory: false,
+                },
+            )
+            .expect_err("existing memory must never be overwritten");
+        assert_eq!(error, "derived memory ID already exists");
+        assert_eq!(memories["d"].content, "must remain intact");
+        assert!(graph.graph.edges.is_empty());
+    }
+
+    #[test]
+    fn hypothesis_is_revision_bound_and_single_use() {
+        let mut memories = MemoryMap::new();
+        memories.insert("a".into(), EngramProjection::context("a", "A rule", "A"));
+        memories.insert("b".into(), EngramProjection::context("b", "B rule", "B"));
+        let mut index = RealityIndex::new(10);
+        index.rebuild(&memories);
+        let mut graph = AutoGraphEngine::new(hierarchy());
+        let hypothesis = graph
+            .derive(
+                &mut index,
+                &mut memories,
+                DerivationRequest {
+                    memory_id: "unused",
+                    content: "shared",
+                    parent_ids: &["a".into(), "b".into()],
+                    relation: "derived_from",
+                    fault_after_memory: false,
+                },
+            )
+            .expect("create hypothesis")
+            .hypothesis
+            .expect("hypothesis");
+
+        memories.get_mut("a").expect("parent").content = "changed".into();
+        index.rebuild(&memories);
+        assert_eq!(
+            graph
+                .approve(
+                    &mut index,
+                    &mut memories,
+                    &hypothesis.hypothesis_id,
+                    true,
+                    "shared",
+                )
+                .expect_err("stale proposal must fail"),
+            "hypothesis parent revision changed"
+        );
+        assert!(!memories.contains_key("shared"));
+
+        let fresh = graph
+            .derive(
+                &mut index,
+                &mut memories,
+                DerivationRequest {
+                    memory_id: "unused",
+                    content: "shared after review",
+                    parent_ids: &["a".into(), "b".into()],
+                    relation: "derived_from",
+                    fault_after_memory: false,
+                },
+            )
+            .expect("create fresh hypothesis")
+            .hypothesis
+            .expect("fresh hypothesis");
+        graph
+            .approve(
+                &mut index,
+                &mut memories,
+                &fresh.hypothesis_id,
+                true,
+                "shared",
+            )
+            .expect("approve fresh hypothesis");
+        assert!(!graph.hypotheses.contains_key(&fresh.hypothesis_id));
+        assert_eq!(
+            graph
+                .approve(
+                    &mut index,
+                    &mut memories,
+                    &fresh.hypothesis_id,
+                    true,
+                    "second-shared",
+                )
+                .expect_err("approved hypothesis is single use"),
+            "hypothesis missing"
+        );
+    }
+    #[test]
+    fn hybrid_bundle_shares_reality_checkpoint_and_blocks_manual_bridge() {
+        let mut memories = MemoryMap::new();
+        memories.insert(
+            "a".into(),
+            EngramProjection::context("a", "A migration", "A"),
+        );
+        memories.insert(
+            "b".into(),
+            EngramProjection::context("b", "B migration", "B"),
+        );
+        let mut indexed = IndexedRecallEngine::new(10, 100);
+        indexed.rebuild(&memories);
+        let mut graph = AutoGraphEngine::new(hierarchy());
+        graph.graph.add(PassportedEdge {
+            edge_id: "wrong-bridge".into(),
+            source_id: "a".into(),
+            target_id: "b".into(),
+            relation: "semantic".into(),
+            passport: EdgePassport {
+                scope: ScopeKind::Context,
+                effective_context_id: Some("A".into()),
+                valid_from_ms: None,
+                valid_until_ms: None,
+                origin: "derived".into(),
+                authority: 3,
+                taints: BTreeSet::new(),
+                allowed_purposes: None,
+                allowed_actors: None,
+            },
+        });
+        let p = policy("A");
+        let direct = indexed.recall("migration", p.clone(), &memories, 5, None);
+        let bundle = graph
+            .hybrid_bundle(&indexed, &memories, "migration", p, 5)
+            .expect("hybrid bundle");
+        assert_eq!(bundle.reality_checkpoint, direct.reality_checkpoint);
+        assert!(!bundle.adjacent_ids.iter().any(|id| id == "b"));
+        assert!(!bundle.graph_edges.iter().any(|id| id == "wrong-bridge"));
+    }
+}

--- a/crates/vestige-spacetime/src/lib.rs
+++ b/crates/vestige-spacetime/src/lib.rs
@@ -1,0 +1,12 @@
+//! Production-shape specification for Vestige Memory Spacetime Legs 3–7.
+//!
+//! This crate isolates the new algorithms from Vestige's existing storage and
+//! MCP types. Integration adapters map `KnowledgeNode`, Engram Passport state,
+//! graph records, and MCP session leases into these projections.
+
+pub mod common;
+pub mod leg3_reality_index;
+pub mod leg4_reality_delta;
+pub mod leg5_claim_lattice;
+pub mod leg6_capabilities;
+pub mod leg7_autograph;


### PR DESCRIPTION
## Summary

Adds `crates/vestige-spacetime`, a compile-first Rust substrate for Memory Spacetime Legs 3–7:

- Reality Index and context-pure paging
- Reality Working Set and delta protocol
- Claim lattice and quarantine-before-publication
- capability-sealed recall
- passport-gated AutoGraph and non-traversable cross-Reality hypotheses

The constitutional invariant is: an ineligible memory is absent from the computation, not merely hidden from the output.

## Important scope boundary

This PR registers and compiles the standalone substrate only. It does **not** activate Memory Spacetime in the Vestige runtime: no migrations, storage adapters, MCP session leases, tool dispatch, resources, or background-path bypass closure are wired here. Those changes require the cumulative Legs 1–2 Passport/Active Reality substrate and the runtime-integration matrix.

## Audit repairs included

- Restores a stable eligible-universe seal before generating a Reality checkpoint.
- Uses policy-bound request types for capability issuance and derivation inputs.
- Rejects derived-memory ID overwrite attempts.
- Binds cross-Reality hypotheses to parent revisions and Context topology, and consumes them after successful approval.

## Validation

- Python oracle: 105/105 tests; 5/5 adversarial scenarios; 5,000 outside-Reality mutations with zero observed non-interference violations.
- Static bypass audit: 22/22 passed.
- New crate: rustfmt, cargo check, 22/22 tests, and strict Clippy passed.
- Clean host workspace: cargo check, cargo test, and strict Clippy passed.
- Feature checks: core bundled-SQLite and connectors paths plus MCP no-default-features path passed.

Host-wide `cargo fmt --all -- --check` remains red due to pre-existing formatting drift outside this PR; the added crate is rustfmt-clean.
