### PR TITLE
fix(npm): recover CLI after pnpm skips postinstall

### DIFF
--- a/packages/vestige-mcp-npm/.npmignore
+++ b/packages/vestige-mcp-npm/.npmignore
@@ -14,3 +14,4 @@ bin/*.zip
 # Dev files
 *.log
 .DS_Store
+tests/

--- a/packages/vestige-mcp-npm/bin/run-binary.js
+++ b/packages/vestige-mcp-npm/bin/run-binary.js
@@ -1,0 +1,55 @@
+const { spawn, spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function installBinary() {
+  const installerPath = path.join(__dirname, '..', 'scripts', 'postinstall.js');
+  const result = spawnSync(process.execPath, [installerPath], {
+    encoding: 'utf8',
+  });
+
+  // An MCP server must reserve stdout for protocol messages. Keep the delayed
+  // installation progress on stderr even when the first invoked command is
+  // vestige-mcp.
+  if (result.stdout) process.stderr.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+
+  if (result.error) {
+    throw new Error(`Failed to install Vestige binary: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(`Vestige binary installation exited with status ${result.status}`);
+  }
+}
+
+function runBinary(name, displayName, args) {
+  const binaryName = os.platform() === 'win32' ? `${name}.exe` : name;
+  const binaryPath = path.join(__dirname, binaryName);
+
+  if (!fs.existsSync(binaryPath)) {
+    try {
+      installBinary();
+    } catch (err) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+  }
+
+  if (!fs.existsSync(binaryPath)) {
+    console.error(`Error: ${displayName} binary not found.`);
+    console.error(`Expected at: ${binaryPath}`);
+    console.error('');
+    console.error('Try reinstalling: npm install -g vestige-mcp-server');
+    process.exit(1);
+  }
+
+  const child = spawn(binaryPath, args, { stdio: 'inherit' });
+  child.on('error', (err) => {
+    console.error(`Failed to start ${displayName}:`, err.message);
+    process.exit(1);
+  });
+  child.on('exit', (code) => process.exit(code ?? 0));
+}
+
+module.exports = { runBinary };

--- a/packages/vestige-mcp-npm/bin/vestige-mcp.js
+++ b/packages/vestige-mcp-npm/bin/vestige-mcp.js
@@ -1,31 +1,5 @@
 #!/usr/bin/env node
 
-const { spawn } = require('child_process');
-const path = require('path');
-const fs = require('fs');
-const os = require('os');
+const { runBinary } = require('./run-binary');
 
-const platform = os.platform();
-const binaryName = platform === 'win32' ? 'vestige-mcp.exe' : 'vestige-mcp';
-const binaryPath = path.join(__dirname, binaryName);
-
-if (!fs.existsSync(binaryPath)) {
-  console.error('Error: vestige-mcp binary not found.');
-  console.error(`Expected at: ${binaryPath}`);
-  console.error('');
-  console.error('Try reinstalling: npm install -g vestige-mcp-server');
-  process.exit(1);
-}
-
-const child = spawn(binaryPath, process.argv.slice(2), {
-  stdio: 'inherit',
-});
-
-child.on('error', (err) => {
-  console.error('Failed to start vestige-mcp:', err.message);
-  process.exit(1);
-});
-
-child.on('exit', (code) => {
-  process.exit(code ?? 0);
-});
+runBinary('vestige-mcp', 'vestige-mcp', process.argv.slice(2));

--- a/packages/vestige-mcp-npm/bin/vestige-restore.js
+++ b/packages/vestige-mcp-npm/bin/vestige-restore.js
@@ -1,31 +1,5 @@
 #!/usr/bin/env node
 
-const { spawn } = require('child_process');
-const path = require('path');
-const fs = require('fs');
-const os = require('os');
+const { runBinary } = require('./run-binary');
 
-const platform = os.platform();
-const binaryName = platform === 'win32' ? 'vestige-restore.exe' : 'vestige-restore';
-const binaryPath = path.join(__dirname, binaryName);
-
-if (!fs.existsSync(binaryPath)) {
-  console.error('Error: vestige-restore binary not found.');
-  console.error(`Expected at: ${binaryPath}`);
-  console.error('');
-  console.error('Try reinstalling: npm install -g vestige-mcp-server');
-  process.exit(1);
-}
-
-const child = spawn(binaryPath, process.argv.slice(2), {
-  stdio: 'inherit',
-});
-
-child.on('error', (err) => {
-  console.error('Failed to start vestige-restore:', err.message);
-  process.exit(1);
-});
-
-child.on('exit', (code) => {
-  process.exit(code ?? 0);
-});
+runBinary('vestige-restore', 'vestige-restore', process.argv.slice(2));

--- a/packages/vestige-mcp-npm/bin/vestige.js
+++ b/packages/vestige-mcp-npm/bin/vestige.js
@@ -1,31 +1,5 @@
 #!/usr/bin/env node
 
-const { spawn } = require('child_process');
-const path = require('path');
-const fs = require('fs');
-const os = require('os');
+const { runBinary } = require('./run-binary');
 
-const platform = os.platform();
-const binaryName = platform === 'win32' ? 'vestige.exe' : 'vestige';
-const binaryPath = path.join(__dirname, binaryName);
-
-if (!fs.existsSync(binaryPath)) {
-  console.error('Error: vestige CLI binary not found.');
-  console.error(`Expected at: ${binaryPath}`);
-  console.error('');
-  console.error('Try reinstalling: npm install -g vestige-mcp-server');
-  process.exit(1);
-}
-
-const child = spawn(binaryPath, process.argv.slice(2), {
-  stdio: 'inherit',
-});
-
-child.on('error', (err) => {
-  console.error('Failed to start vestige:', err.message);
-  process.exit(1);
-});
-
-child.on('exit', (code) => {
-  process.exit(code ?? 0);
-});
+runBinary('vestige', 'vestige CLI', process.argv.slice(2));

--- a/packages/vestige-mcp-npm/package.json
+++ b/packages/vestige-mcp-npm/package.json
@@ -9,7 +9,8 @@
     "vestige-restore": "bin/vestige-restore.js"
   },
   "scripts": {
-    "postinstall": "node scripts/postinstall.js"
+    "postinstall": "node scripts/postinstall.js",
+    "test:pnpm-global-install": "node --test tests/pnpm-global-install.test.js"
   },
   "keywords": [
     "mcp",

--- a/packages/vestige-mcp-npm/tests/pnpm-global-install.test.js
+++ b/packages/vestige-mcp-npm/tests/pnpm-global-install.test.js
@@ -1,0 +1,80 @@
+const assert = require('assert/strict');
+const { execFileSync, spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const test = require('node:test');
+
+const packageDir = path.resolve(__dirname, '..');
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, { encoding: 'utf8', ...options });
+}
+
+test('a pnpm global install exposes commands when lifecycle scripts are ignored', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vestige-pnpm-global-'));
+  const archiveDir = path.join(tempDir, 'archive');
+  const extractedDir = path.join(tempDir, 'extracted');
+  const globalDir = path.join(tempDir, 'global');
+  const globalBinDir = path.join(tempDir, 'bin');
+  fs.mkdirSync(archiveDir);
+  fs.mkdirSync(extractedDir);
+  fs.mkdirSync(globalBinDir);
+
+  try {
+    const pack = JSON.parse(run('npm', ['pack', '--pack-destination', archiveDir, '--json'], { cwd: packageDir }));
+    const packageArchive = path.join(archiveDir, pack[0].filename);
+    run('tar', ['-xzf', packageArchive, '-C', extractedDir]);
+
+    // Replace the release downloader in the packed fixture. This lets the
+    // smoke test cover the pnpm topology without depending on GitHub assets.
+    const fixtureInstaller = path.join(extractedDir, 'package', 'scripts', 'postinstall.js');
+    fs.writeFileSync(
+      fixtureInstaller,
+      `const fs = require('fs');\n` +
+        `const path = require('path');\n` +
+        `const binDir = path.join(__dirname, '..', 'bin');\n` +
+        `for (const name of ['vestige', 'vestige-mcp', 'vestige-restore']) {\n` +
+        `  const binary = path.join(binDir, name);\n` +
+        `  fs.writeFileSync(binary, '#!/bin/sh\\necho "fixture ' + name + ' $@"\\n');\n` +
+        `  fs.chmodSync(binary, 0o755);\n` +
+        `}\n` +
+        `process.stdout.write('fixture installer ran\\n');\n`
+    );
+    const fixtureArchive = path.join(tempDir, 'vestige-mcp-server-fixture.tgz');
+    run('tar', ['-czf', fixtureArchive, '-C', extractedDir, 'package']);
+
+    const env = { ...process.env, PATH: `${globalBinDir}${path.delimiter}${process.env.PATH}` };
+    const install = spawnSync(
+      'pnpm',
+      [
+        'add',
+        '--global',
+        '--ignore-scripts',
+        '--global-dir',
+        globalDir,
+        '--global-bin-dir',
+        globalBinDir,
+        fixtureArchive,
+      ],
+      { encoding: 'utf8', env }
+    );
+    assert.equal(install.status, 0, install.stderr || install.stdout);
+
+    const cliPath = path.join(globalBinDir, 'vestige');
+    const mcpPath = path.join(globalBinDir, 'vestige-mcp');
+    assert.ok(fs.existsSync(cliPath), 'pnpm should link the vestige CLI');
+    assert.ok(fs.existsSync(mcpPath), 'pnpm should link the vestige-mcp CLI');
+
+    const cli = spawnSync(cliPath, ['--version'], { encoding: 'utf8', env });
+    assert.equal(cli.status, 0, cli.stderr);
+    assert.equal(cli.stdout, 'fixture vestige --version\n');
+    assert.match(cli.stderr, /fixture installer ran/);
+
+    const mcp = spawnSync(mcpPath, ['--version'], { encoding: 'utf8', env });
+    assert.equal(mcp.status, 0, mcp.stderr);
+    assert.equal(mcp.stdout, 'fixture vestige-mcp --version\n');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- lazily run the existing verified binary downloader when a linked CLI shim finds no native binary
- preserve MCP protocol stdout by sending delayed installation progress to stderr
- add a packed-artifact pnpm global-install smoke test with lifecycle scripts disabled

## Root cause

pnpm can create global command shims while suppressing package lifecycle scripts. Vestige previously downloaded its native binaries only in `postinstall`, so the shims pointed at files that did not exist.

## Validation

- `pnpm --dir packages/vestige-mcp-npm run test:pnpm-global-install`
- `npm pack --dry-run --json` (verified the fallback helper is published and tests are excluded)
- `cargo test --package vestige-mcp`
- `cargo check --package vestige-mcp`

Closes #151