### PR TITLE
feat: isolate memory retrieval by project scope

### DIFF
--- a/crates/vestige-core/src/lib.rs
+++ b/crates/vestige-core/src/lib.rs
@@ -190,6 +190,7 @@ pub use storage::{
     ConnectorCursor,
     ConsolidationHistoryRecord,
     CounterfactualReplayResult,
+    DEFAULT_MEMORY_SCOPE,
     Domain,
     DreamHistoryRecord,
     DurableCounterfactualReplay,

--- a/crates/vestige-core/src/storage/memory_store.rs
+++ b/crates/vestige-core/src/storage/memory_store.rs
@@ -56,6 +56,7 @@ impl From<crate::storage::StorageError> for MemoryStoreError {
             S::Database(e) => MemoryStoreError::Backend(e.to_string()),
             S::Io(e) => MemoryStoreError::Backend(e.to_string()),
             S::InvalidTimestamp(s) => MemoryStoreError::Backend(format!("invalid timestamp: {s}")),
+            S::InvalidScope(s) => MemoryStoreError::InvalidInput(s),
             S::Init(s) => MemoryStoreError::Init(s),
             S::SecretDetected { kinds } => MemoryStoreError::SecretDetected(kinds.join(", ")),
         }

--- a/crates/vestige-core/src/storage/migrations.rs
+++ b/crates/vestige-core/src/storage/migrations.rs
@@ -134,6 +134,11 @@ pub const MIGRATIONS: &[Migration] = &[
         description: "DSSE receipt binding: persist the signed redaction-safe decision projection alongside immutable envelopes",
         up: MIGRATION_V26_UP,
     },
+    Migration {
+        version: 27,
+        description: "Project scopes: normalize legacy scope values to the safe user namespace",
+        up: MIGRATION_V27_UP,
+    },
 ];
 
 /// A database migration
@@ -1597,6 +1602,20 @@ const MIGRATION_V26_UP: &str = r#"
 UPDATE schema_version SET version = 26, applied_at = datetime('now');
 "#;
 
+/// V27: `scope` was introduced as dormant schema in V4.  Existing rows should
+/// remain visible through the legacy `user` namespace once retrieval starts
+/// enforcing that column.  Treat missing or blank values as that namespace
+/// rather than making old memories disappear or fall into every project.
+const MIGRATION_V27_UP: &str = r#"
+UPDATE knowledge_nodes
+SET scope = 'user'
+WHERE scope IS NULL OR trim(scope) = '';
+
+CREATE INDEX IF NOT EXISTS idx_nodes_scope ON knowledge_nodes(scope);
+
+UPDATE schema_version SET version = 27, applied_at = datetime('now');
+"#;
+
 const MIGRATION_V26_ALTER_COLUMNS: &[&str] = &[r#"
 ALTER TABLE receipt_envelopes ADD COLUMN projection_json TEXT CHECK (
     projection_json IS NULL OR json_valid(projection_json)
@@ -2462,6 +2481,29 @@ mod tests {
             .expect("inspect V26 column");
         assert_eq!(columns, 1);
         assert_eq!(apply_migrations(&conn).expect("V26 replay is a no-op"), 0);
+    }
+
+    #[test]
+    fn v27_preserves_legacy_rows_in_the_user_scope() {
+        let conn = rusqlite::Connection::open_in_memory().expect("open in-memory");
+        apply_migrations_through(&conn, 26);
+        conn.execute(
+            "INSERT INTO knowledge_nodes (id, content, node_type, created_at, updated_at, last_accessed, scope)
+             VALUES ('null-scope', 'legacy', 'fact', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', NULL),
+                    ('blank-scope', 'legacy', 'fact', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', '   ') ",
+            [],
+        )
+        .expect("seed legacy scopes");
+
+        apply_migrations(&conn).expect("apply V27");
+        let scopes: Vec<String> = conn
+            .prepare("SELECT scope FROM knowledge_nodes ORDER BY id")
+            .expect("prepare scope query")
+            .query_map([], |row| row.get(0))
+            .expect("read scopes")
+            .collect::<rusqlite::Result<_>>()
+            .expect("collect scopes");
+        assert_eq!(scopes, vec!["user", "user"]);
     }
 
     #[test]

--- a/crates/vestige-core/src/storage/migrations.rs
+++ b/crates/vestige-core/src/storage/migrations.rs
@@ -2264,7 +2264,7 @@ mod tests {
         assert_eq!(cursor_row_count(&conn), 2);
 
         let applied = apply_migrations(&conn).expect("V20+ apply on a V19 database");
-        assert_eq!(applied, 7, "V20 through V26 should apply on a V19 database");
+        assert_eq!(applied, 8, "V20 through V27 should apply on a V19 database");
         assert_eq!(
             get_current_version(&conn).expect("version"),
             MIGRATIONS.last().unwrap().version
@@ -2276,16 +2276,16 @@ mod tests {
         );
     }
 
-    /// Fresh database: all migrations apply cleanly through V26 and the cursor
+    /// Fresh database: all migrations apply cleanly through V27 and the cursor
     /// table exists and is empty (nothing to clear, no error).
     #[test]
     fn v20_applies_cleanly_on_a_fresh_database() {
         let conn = rusqlite::Connection::open_in_memory().expect("open in-memory");
-        apply_migrations(&conn).expect("fresh migrations succeed through V26");
+        apply_migrations(&conn).expect("fresh migrations succeed through V27");
         assert_eq!(
             get_current_version(&conn).expect("version"),
-            26,
-            "latest migration must be V26"
+            27,
+            "latest migration must be V27"
         );
         assert_eq!(cursor_row_count(&conn), 0);
     }
@@ -2470,7 +2470,7 @@ mod tests {
         )
         .expect("mark V25 fixture current");
 
-        assert_eq!(apply_migrations(&conn).expect("apply V26"), 1);
+        assert_eq!(apply_migrations(&conn).expect("apply V26 and V27"), 2);
         let columns: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM pragma_table_info('receipt_envelopes')
@@ -2480,7 +2480,7 @@ mod tests {
             )
             .expect("inspect V26 column");
         assert_eq!(columns, 1);
-        assert_eq!(apply_migrations(&conn).expect("V26 replay is a no-op"), 0);
+        assert_eq!(apply_migrations(&conn).expect("V27 replay is a no-op"), 0);
     }
 
     #[test]

--- a/crates/vestige-core/src/storage/mod.rs
+++ b/crates/vestige-core/src/storage/mod.rs
@@ -50,10 +50,10 @@ pub use replay_store::{
 pub use sqlite::{
     CompositionEventRecord, CompositionMemberRecord, CompositionNeighborRecord,
     CompositionOutcomeRecord, ConnectionRecord, ConnectorCursor, ConsolidationHistoryRecord,
-    DreamHistoryRecord, FilePortableSyncBackend, InsightRecord, IntentionRecord,
-    NeverComposedCandidate, PortableSyncBackend, PortableSyncReport, ReconcileReport, Result,
-    SmartIngestResult, SourceUpsertOutcome, SourceUpsertResult, SqliteMemoryStore,
-    StateTransitionRecord, StorageError,
+    DEFAULT_MEMORY_SCOPE, DreamHistoryRecord, FilePortableSyncBackend, InsightRecord,
+    IntentionRecord, NeverComposedCandidate, PortableSyncBackend, PortableSyncReport,
+    ReconcileReport, Result, SmartIngestResult, SourceUpsertOutcome, SourceUpsertResult,
+    SqliteMemoryStore, StateTransitionRecord, StorageError,
 };
 pub use synaptic_store::{
     DurableSynapticCapture, DurableSynapticPairReceipt, SYNAPTIC_CAPTURE_ALGORITHM_V1,

--- a/crates/vestige-core/src/storage/sqlite.rs
+++ b/crates/vestige-core/src/storage/sqlite.rs
@@ -72,10 +72,17 @@ pub enum StorageError {
         "Refused to store probable credential(s): {kinds:?}. Secret bytes were not stored, logged, or returned. Redact the value or use an explicit allow-secrets override only when intentional."
     )]
     SecretDetected { kinds: Vec<String> },
+    /// A project namespace must be a short, non-empty identifier.
+    #[error("Invalid memory scope: {0}")]
+    InvalidScope(String),
 }
 
 /// Storage result type
 pub type Result<T> = std::result::Result<T, StorageError>;
+
+/// Namespace used by existing, unscoped callers and by rows written before
+/// project scopes were exposed. Scoped callers must opt into a different value.
+pub const DEFAULT_MEMORY_SCOPE: &str = "user";
 
 /// Environment variable selecting the SQLite commit-durability policy.
 pub const VESTIGE_SQLITE_DURABILITY_ENV: &str = "VESTIGE_SQLITE_DURABILITY";
@@ -515,10 +522,11 @@ impl SqliteMemoryStore {
     fn regular_ingest_result(
         &self,
         input: IngestInput,
+        scope: &str,
         reason: impl Into<String>,
         policy: SecretPolicy,
     ) -> Result<SmartIngestResult> {
-        let node = self.ingest_with_secret_policy(input, policy)?;
+        let node = self.ingest_in_scope_with_secret_policy(input, scope, policy)?;
         Ok(SmartIngestResult {
             decision: "create".to_string(),
             node,
@@ -1287,6 +1295,22 @@ impl SqliteMemoryStore {
         }
     }
 
+    /// Normalize a caller-provided project namespace before it reaches storage.
+    /// Namespaces are identifiers, not user content: blank, oversized, and
+    /// control-character values make audit and operator tooling ambiguous.
+    fn normalize_scope(scope: &str) -> Result<&str> {
+        let normalized = scope.trim();
+        if normalized.is_empty()
+            || normalized.len() > 200
+            || normalized.chars().any(char::is_control)
+        {
+            return Err(StorageError::InvalidScope(
+                "expected a non-empty identifier of at most 200 visible characters".to_string(),
+            ));
+        }
+        Ok(normalized)
+    }
+
     fn enforce_secret_policy_for_record(
         record: &crate::storage::memory_store::MemoryRecord,
         policy: SecretPolicy,
@@ -1386,7 +1410,7 @@ impl SqliteMemoryStore {
 
     /// Ingest a new memory, rejecting likely credentials by default.
     pub fn ingest(&self, input: IngestInput) -> Result<KnowledgeNode> {
-        self.ingest_with_secret_policy(input, SecretPolicy::Reject)
+        self.ingest_in_scope_with_secret_policy(input, DEFAULT_MEMORY_SCOPE, SecretPolicy::Reject)
     }
 
     /// Ingest a new memory using an explicit credential-storage policy.
@@ -1399,12 +1423,27 @@ impl SqliteMemoryStore {
         input: IngestInput,
         policy: SecretPolicy,
     ) -> Result<KnowledgeNode> {
-        Self::enforce_secret_policy_for_input(&input, policy)?;
-        self.ingest_unchecked(input)
+        self.ingest_in_scope_with_secret_policy(input, DEFAULT_MEMORY_SCOPE, policy)
     }
 
-    /// Raw insert after a caller has completed the credential preflight.
-    fn ingest_unchecked(&self, input: IngestInput) -> Result<KnowledgeNode> {
+    /// Ingest a memory into a named project namespace.
+    pub fn ingest_in_scope(&self, input: IngestInput, scope: &str) -> Result<KnowledgeNode> {
+        self.ingest_in_scope_with_secret_policy(input, scope, SecretPolicy::Reject)
+    }
+
+    /// Ingest a memory into a named project namespace with an explicit secret policy.
+    pub fn ingest_in_scope_with_secret_policy(
+        &self,
+        input: IngestInput,
+        scope: &str,
+        policy: SecretPolicy,
+    ) -> Result<KnowledgeNode> {
+        Self::enforce_secret_policy_for_input(&input, policy)?;
+        self.ingest_unchecked_in_scope(input, Self::normalize_scope(scope)?)
+    }
+
+    /// Raw scoped insert after a caller has completed the credential preflight.
+    fn ingest_unchecked_in_scope(&self, input: IngestInput, scope: &str) -> Result<KnowledgeNode> {
         let now = Utc::now();
         let id = Uuid::new_v4().to_string();
 
@@ -1445,7 +1484,7 @@ impl SqliteMemoryStore {
                     sentiment_score, sentiment_magnitude, next_review, scheduled_days,
                     source, tags, valid_from, valid_until, has_embedding, embedding_model,
                     domains, domain_scores,
-                    source_system, source_id, source_url, source_updated_at,
+                    scope, source_system, source_id, source_url, source_updated_at,
                     content_hash, synced_at, source_project, source_type, source_author
                 ) VALUES (
                     ?1, ?2, ?3, ?4, ?5, ?6,
@@ -1454,8 +1493,8 @@ impl SqliteMemoryStore {
                     ?15, ?16, ?17, ?18,
                     ?19, ?20, ?21, ?22, ?23, ?24,
                     '[]', '{}',
-                    ?25, ?26, ?27, ?28,
-                    ?29, ?30, ?31, ?32, ?33
+                    ?25, ?26, ?27, ?28, ?29,
+                    ?30, ?31, ?32, ?33, ?34
                 )",
                 params![
                     id,
@@ -1485,6 +1524,7 @@ impl SqliteMemoryStore {
                     valid_until_str,
                     0,
                     Option::<String>::None,
+                    scope,
                     env.source_system,
                     env.source_id,
                     env.source_url,
@@ -1518,7 +1558,21 @@ impl SqliteMemoryStore {
     /// This solves the "bad vs good similar memory" problem.
     #[cfg(all(feature = "embeddings", feature = "vector-search"))]
     pub fn smart_ingest(&self, input: IngestInput) -> Result<SmartIngestResult> {
-        self.smart_ingest_with_secret_policy(input, SecretPolicy::Reject)
+        self.smart_ingest_in_scope_with_secret_policy(
+            input,
+            DEFAULT_MEMORY_SCOPE,
+            SecretPolicy::Reject,
+        )
+    }
+
+    /// Smart-ingest a memory while considering candidates only from the same namespace.
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    pub fn smart_ingest_in_scope(
+        &self,
+        input: IngestInput,
+        scope: &str,
+    ) -> Result<SmartIngestResult> {
+        self.smart_ingest_in_scope_with_secret_policy(input, scope, SecretPolicy::Reject)
     }
 
     /// Smart ingest with an explicit credential-storage policy.
@@ -1528,7 +1582,18 @@ impl SqliteMemoryStore {
         input: IngestInput,
         policy: SecretPolicy,
     ) -> Result<SmartIngestResult> {
-        self.smart_ingest_excluding_with_secret_policy(input, &[], policy)
+        self.smart_ingest_in_scope_with_secret_policy(input, DEFAULT_MEMORY_SCOPE, policy)
+    }
+
+    /// Smart-ingest a memory into a named project namespace with an explicit secret policy.
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    pub fn smart_ingest_in_scope_with_secret_policy(
+        &self,
+        input: IngestInput,
+        scope: &str,
+        policy: SecretPolicy,
+    ) -> Result<SmartIngestResult> {
+        self.smart_ingest_excluding_in_scope_with_secret_policy(input, scope, &[], policy)
     }
 
     /// Smart ingest with caller-provided candidate exclusions.
@@ -1542,8 +1607,9 @@ impl SqliteMemoryStore {
         input: IngestInput,
         excluded_node_ids: &[String],
     ) -> Result<SmartIngestResult> {
-        self.smart_ingest_excluding_with_secret_policy(
+        self.smart_ingest_excluding_in_scope_with_secret_policy(
             input,
+            DEFAULT_MEMORY_SCOPE,
             excluded_node_ids,
             SecretPolicy::Reject,
         )
@@ -1559,16 +1625,37 @@ impl SqliteMemoryStore {
         excluded_node_ids: &[String],
         policy: SecretPolicy,
     ) -> Result<SmartIngestResult> {
+        self.smart_ingest_excluding_in_scope_with_secret_policy(
+            input,
+            DEFAULT_MEMORY_SCOPE,
+            excluded_node_ids,
+            policy,
+        )
+    }
+
+    /// Scoped smart-ingest with candidate exclusions and an explicit secret policy.
+    /// Candidate selection is scope-bound before the prediction-error gate runs,
+    /// preventing similarly-worded memories in another project from merging.
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    pub fn smart_ingest_excluding_in_scope_with_secret_policy(
+        &self,
+        input: IngestInput,
+        scope: &str,
+        excluded_node_ids: &[String],
+        policy: SecretPolicy,
+    ) -> Result<SmartIngestResult> {
         use crate::advanced::prediction_error::{
             CandidateMemory, GateDecision, PredictionErrorGate, UpdateType,
         };
 
         Self::enforce_secret_policy_for_input(&input, policy)?;
+        let scope = Self::normalize_scope(scope)?;
 
         // Generate embedding for new content
         if !self.embedding_service.is_ready() {
             return self.regular_ingest_result(
                 input,
+                scope,
                 "Embeddings not available, falling back to regular ingest",
                 policy,
             );
@@ -1577,6 +1664,7 @@ impl SqliteMemoryStore {
         if !self.vector_search_available() {
             return self.regular_ingest_result(
                 input,
+                scope,
                 "Vector search unavailable, falling back to regular ingest",
                 policy,
             );
@@ -1594,6 +1682,9 @@ impl SqliteMemoryStore {
         let mut candidates: Vec<CandidateMemory> = Vec::new();
         for (node_id, _similarity) in similar.iter() {
             if excluded_node_ids.iter().any(|id| id == node_id) {
+                continue;
+            }
+            if !self.node_is_in_scope(node_id, scope)? {
                 continue;
             }
             if let Some(node) = self.get_node(node_id)? {
@@ -1630,7 +1721,7 @@ impl SqliteMemoryStore {
                 ..
             } => {
                 // Create new memory
-                let node = self.ingest_with_secret_policy(input, policy)?;
+                let node = self.ingest_in_scope_with_secret_policy(input, scope, policy)?;
                 Ok(SmartIngestResult {
                     decision: "create".to_string(),
                     node,
@@ -1784,7 +1875,7 @@ impl SqliteMemoryStore {
                 self.demote_memory(&old_memory_id)?;
 
                 // Create the new improved memory
-                let node = self.ingest(input)?;
+                let node = self.ingest_in_scope_with_secret_policy(input, scope, policy)?;
 
                 Ok(SmartIngestResult {
                     decision: "supersede".to_string(),
@@ -1804,7 +1895,7 @@ impl SqliteMemoryStore {
                 strategy,
             } => {
                 // For now, create new and link to existing
-                let node = self.ingest(input)?;
+                let node = self.ingest_in_scope_with_secret_policy(input, scope, policy)?;
 
                 Ok(SmartIngestResult {
                     decision: "merge".to_string(),
@@ -2006,6 +2097,26 @@ impl SqliteMemoryStore {
         Ok(node)
     }
 
+    /// Return whether a node belongs to a namespace. NULL and blank historic
+    /// values are treated as `user`, matching V27's compatibility migration.
+    pub fn node_is_in_scope(&self, id: &str, scope: &str) -> Result<bool> {
+        let scope = Self::normalize_scope(scope)?;
+        let reader = self
+            .reader
+            .lock()
+            .map_err(|_| StorageError::Init("Reader lock poisoned".into()))?;
+        let present: Option<i32> = reader
+            .query_row(
+                "SELECT 1 FROM knowledge_nodes
+                 WHERE id = ?1
+                   AND COALESCE(NULLIF(trim(scope), ''), 'user') = ?2",
+                params![id, scope],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(present.is_some())
+    }
+
     /// Parse a stored timestamp into a UTC `DateTime`.
     ///
     /// The canonical on-disk format is RFC 3339 (every Rust writer in this
@@ -2166,6 +2277,14 @@ impl SqliteMemoryStore {
 
     /// Recall memories matching a query
     pub fn recall(&self, input: RecallInput) -> Result<Vec<KnowledgeNode>> {
+        self.recall_in_scope(input, DEFAULT_MEMORY_SCOPE)
+    }
+
+    /// Recall only memories from one namespace. This is intentionally the
+    /// safe default for all core recall: callers that need a project must name
+    /// it, and cross-project retrieval is an explicit higher-level operation.
+    pub fn recall_in_scope(&self, input: RecallInput, scope: &str) -> Result<Vec<KnowledgeNode>> {
+        let scope = Self::normalize_scope(scope)?;
         let nodes = match input.search_mode {
             SearchMode::Keyword => {
                 self.keyword_search(&input.query, input.limit, input.min_retention)?
@@ -2192,6 +2311,15 @@ impl SqliteMemoryStore {
         // was correct or useful. Preserve the telemetry without changing its
         // ranking or FSRS state; callers must send explicit positive feedback
         // to reinforce a memory.
+        let nodes: Vec<KnowledgeNode> = nodes
+            .into_iter()
+            .filter_map(|node| match self.node_is_in_scope(&node.id, scope) {
+                Ok(true) => Some(Ok(node)),
+                Ok(false) => None,
+                Err(error) => Some(Err(error)),
+            })
+            .collect::<Result<Vec<_>>>()?;
+
         let ids: Vec<&str> = nodes.iter().map(|n| n.id.as_str()).collect();
         let _ = self.record_batch_retrieval(&ids); // Ignore errors, don't fail recall
 

--- a/crates/vestige-mcp/src/tools/search_unified.rs
+++ b/crates/vestige-mcp/src/tools/search_unified.rs
@@ -22,8 +22,8 @@ use tokio::sync::Mutex;
 
 use crate::cognitive::CognitiveEngine;
 use vestige_core::{
-    CompetitionCandidate, EncodingContext, MemoryLifecycle, MemorySnapshot, MemoryState,
-    OutputConfig, Storage, TopicalContext,
+    CompetitionCandidate, DEFAULT_MEMORY_SCOPE, EncodingContext, MemoryLifecycle, MemorySnapshot,
+    MemoryState, OutputConfig, Storage, TopicalContext,
 };
 
 /// Input schema for unified search tool
@@ -98,6 +98,15 @@ pub fn schema() -> Value {
                 "type": "string",
                 "description": "Optional tag-prefix filter. When set, only results carrying at least one tag whose value starts with this prefix are returned (case-sensitive). Example: tag_prefix=\"meeting:\" matches memories tagged 'meeting:standup', 'meeting:1-on-1', etc. Applied as a post-filter; combine with a larger 'limit' if you expect heavy thinning."
             },
+            "scope": {
+                "type": "string",
+                "description": "Project namespace to search. Defaults to the legacy 'user' namespace, so project memories never bleed into an unscoped recall."
+            },
+            "includeCrossScope": {
+                "type": "boolean",
+                "description": "Search across all project namespaces. Defaults to false; set only when cross-project retrieval is intentional.",
+                "default": false
+            },
             "source_system": {
                 "type": "string",
                 "description": "Investigation filter (#57): only memories ingested from this external system, e.g. 'github' or 'redmine'. Post-filter — non-connector memories are excluded. Combine with a larger 'limit' if thinning is heavy."
@@ -161,6 +170,8 @@ struct SearchArgs {
     concrete: Option<bool>,
     #[serde(alias = "tag_prefix")]
     tag_prefix: Option<String>,
+    scope: Option<String>,
+    include_cross_scope: Option<bool>,
     // #57 Phase 4 — source-aware investigation filters (all post-filters).
     #[serde(alias = "source_system")]
     source_system: Option<String>,
@@ -245,6 +256,7 @@ pub async fn execute(
     // #57 Phase 4 — parse the source-aware investigation filter once (shared by
     // both the concrete and hybrid paths). Hard-errors on malformed input.
     let source_filter = SourceFilter::from_args(&args)?;
+    let scope_filter = ScopeFilter::from_args(&args)?;
 
     let concrete = args
         .concrete
@@ -254,7 +266,10 @@ pub async fn execute(
         // pool so the post-filter has enough headroom to still return ~limit
         // results after thinning. Cap at the same upper bound the underlying
         // SQL path uses elsewhere (100).
-        let concrete_fetch_limit = if args.tag_prefix.is_some() || source_filter.is_active() {
+        let concrete_fetch_limit = if args.tag_prefix.is_some()
+            || source_filter.is_active()
+            || scope_filter.is_restrictive()
+        {
             (limit * 3).min(100)
         } else {
             limit
@@ -270,6 +285,7 @@ pub async fn execute(
 
         // Apply post-filters before formatting the response. Retrieval
         // telemetry is recorded later, after the final budget selection.
+        let results = filter_results_to_scope(storage, results, &scope_filter)?;
         let filtered_results: Vec<&vestige_core::SearchResult> = results
             .iter()
             .filter(|r| match args.tag_prefix.as_deref() {
@@ -326,6 +342,8 @@ pub async fn execute(
             "concrete": true,
             "detailLevel": detail_level,
             "profile": output_config.profile.as_str(),
+            "scope": scope_filter.scope,
+            "includeCrossScope": scope_filter.include_cross_scope,
             "total": formatted.len(),
             "results": formatted,
         });
@@ -376,6 +394,9 @@ pub async fn execute(
         std::collections::HashSet::new();
     let mut keyword_priority_results: Vec<vestige_core::SearchResult> = Vec::new();
     for r in keyword_first_results {
+        if !scope_filter.matches(storage, &r.node.id)? {
+            continue;
+        }
         if r.keyword_score.unwrap_or(0.0) >= keyword_priority_threshold
             && r.node.retention_strength >= min_retention
         {
@@ -395,7 +416,10 @@ pub async fn execute(
     // When a tag_prefix OR source filter is requested, double the overfetch
     // (capped at the same 100 ceiling) so the post-filter has enough headroom
     // to still return ~limit results after thinning.
-    let post_filter_multiplier = if args.tag_prefix.is_some() || source_filter.is_active() {
+    let post_filter_multiplier = if args.tag_prefix.is_some()
+        || source_filter.is_active()
+        || scope_filter.is_restrictive()
+    {
         2
     } else {
         1
@@ -414,6 +438,7 @@ pub async fn execute(
         .map_err(|e| e.to_string())?;
 
     // Filter by min_retention and min_similarity first (cheap filters)
+    let results = filter_results_to_scope(storage, results, &scope_filter)?;
     let mut filtered_results: Vec<_> = results
         .into_iter()
         .filter(|r| {
@@ -843,6 +868,8 @@ pub async fn execute(
         "retrievalMode": retrieval_mode,
         "detailLevel": detail_level,
         "profile": output_config.profile.as_str(),
+        "scope": scope_filter.scope,
+        "includeCrossScope": scope_filter.include_cross_scope,
         "total": formatted.len(),
         "results": formatted,
     });
@@ -929,6 +956,65 @@ fn is_literal_query(query: &str) -> bool {
 /// prefix-search should normalize tags at ingest time.
 fn tags_match_prefix(tags: &[String], prefix: &str) -> bool {
     tags.iter().any(|t| t.starts_with(prefix))
+}
+
+/// Retrieval namespace policy. Every ordinary query is scoped, including a
+/// query that omits `scope`: old clients continue to see their legacy `user`
+/// memories while project memories stay isolated until explicitly named.
+#[derive(Debug, Clone)]
+struct ScopeFilter {
+    scope: String,
+    include_cross_scope: bool,
+}
+
+impl ScopeFilter {
+    fn from_args(args: &SearchArgs) -> Result<Self, String> {
+        let scope = args
+            .scope
+            .as_deref()
+            .unwrap_or(DEFAULT_MEMORY_SCOPE)
+            .trim()
+            .to_string();
+        if scope.is_empty() || scope.len() > 200 || scope.chars().any(char::is_control) {
+            return Err(
+                "Invalid scope: expected a non-empty identifier of at most 200 visible characters"
+                    .to_string(),
+            );
+        }
+        Ok(Self {
+            scope,
+            include_cross_scope: args.include_cross_scope.unwrap_or(false),
+        })
+    }
+
+    fn is_restrictive(&self) -> bool {
+        !self.include_cross_scope
+    }
+
+    fn matches(&self, storage: &Storage, node_id: &str) -> Result<bool, String> {
+        if self.include_cross_scope {
+            Ok(true)
+        } else {
+            storage
+                .node_is_in_scope(node_id, &self.scope)
+                .map_err(|error| error.to_string())
+        }
+    }
+}
+
+fn filter_results_to_scope(
+    storage: &Storage,
+    results: Vec<vestige_core::SearchResult>,
+    scope_filter: &ScopeFilter,
+) -> Result<Vec<vestige_core::SearchResult>, String> {
+    results
+        .into_iter()
+        .try_fold(Vec::new(), |mut kept, result| {
+            if scope_filter.matches(storage, &result.node.id)? {
+                kept.push(result);
+            }
+            Ok(kept)
+        })
 }
 
 /// Validity filter for source-aware search (#57 Phase 4).
@@ -1302,6 +1388,89 @@ mod tests {
         };
         let node = storage.ingest(input).unwrap();
         node.id
+    }
+
+    #[tokio::test]
+    async fn project_scope_prevents_cross_project_retrieval_by_default() {
+        let (storage, _dir) = test_storage().await;
+        let web = storage
+            .ingest_in_scope(
+                IngestInput {
+                    content: "backup retention is six daily snapshots for the web app".to_string(),
+                    node_type: "fact".to_string(),
+                    ..Default::default()
+                },
+                "web-app",
+            )
+            .unwrap();
+        let photo = storage
+            .ingest_in_scope(
+                IngestInput {
+                    content: "backup retention is twelve originals for the photo manager"
+                        .to_string(),
+                    node_type: "fact".to_string(),
+                    ..Default::default()
+                },
+                "photo-manager",
+            )
+            .unwrap();
+
+        let config = OutputConfig::default();
+        let scoped = execute(
+            &storage,
+            &test_cognitive(),
+            &config,
+            Some(serde_json::json!({
+                "query": "backup retention",
+                "concrete": true,
+                "scope": "web-app",
+            })),
+        )
+        .await
+        .expect("scoped recall succeeds");
+        let scoped_ids: Vec<&str> = scoped["results"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|result| result["id"].as_str())
+            .collect();
+        assert!(scoped_ids.contains(&web.id.as_str()));
+        assert!(!scoped_ids.contains(&photo.id.as_str()));
+
+        let default_scope = execute(
+            &storage,
+            &test_cognitive(),
+            &config,
+            Some(serde_json::json!({ "query": "backup retention", "concrete": true })),
+        )
+        .await
+        .expect("default scoped recall succeeds");
+        assert_eq!(default_scope["scope"], DEFAULT_MEMORY_SCOPE);
+        assert_eq!(
+            default_scope["total"], 0,
+            "unscoped recall must not bleed projects"
+        );
+
+        let cross_scope = execute(
+            &storage,
+            &test_cognitive(),
+            &config,
+            Some(serde_json::json!({
+                "query": "backup retention",
+                "concrete": true,
+                "includeCrossScope": true,
+            })),
+        )
+        .await
+        .expect("explicit cross-scope recall succeeds");
+        let cross_ids: Vec<&str> = cross_scope["results"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|result| result["id"].as_str())
+            .collect();
+        assert!(cross_ids.contains(&web.id.as_str()));
+        assert!(cross_ids.contains(&photo.id.as_str()));
     }
 
     // ========================================================================

--- a/crates/vestige-mcp/src/tools/smart_ingest.rs
+++ b/crates/vestige-mcp/src/tools/smart_ingest.rs
@@ -22,9 +22,9 @@ use tokio::sync::Mutex;
 
 use crate::cognitive::CognitiveEngine;
 use vestige_core::{
-    ContentType, ImportanceContext, IngestInput, SecretPolicy, Storage, StorageError,
-    SynapticCapturePolicy, SynapticImportanceEvent, SynapticIngestRequest, SynapticSignalSnapshot,
-    SynapticTag, SynapticTaggingConfig, scan_secrets,
+    ContentType, DEFAULT_MEMORY_SCOPE, ImportanceContext, IngestInput, SecretPolicy, Storage,
+    StorageError, SynapticCapturePolicy, SynapticImportanceEvent, SynapticIngestRequest,
+    SynapticSignalSnapshot, SynapticTag, SynapticTaggingConfig, scan_secrets,
 };
 
 /// Input schema for smart_ingest tool
@@ -53,6 +53,10 @@ pub fn schema() -> Value {
             "source": {
                 "type": "string",
                 "description": "Source or reference for this knowledge"
+            },
+            "scope": {
+                "type": "string",
+                "description": "Project namespace for this memory. Defaults to 'user' for backward compatibility. Recall searches this namespace unless includeCrossScope=true."
             },
             "forceCreate": {
                 "type": "boolean",
@@ -95,6 +99,10 @@ pub fn schema() -> Value {
                             "type": "string",
                             "description": "Source reference"
                         },
+                        "scope": {
+                            "type": "string",
+                            "description": "Project namespace for this item. Overrides the batch scope when supplied."
+                        },
                         "forceCreate": {
                             "type": "boolean",
                             "description": "Force creation of this item even if similar content exists",
@@ -121,6 +129,7 @@ struct SmartIngestArgs {
     node_type: Option<String>,
     tags: Option<Vec<String>>,
     source: Option<String>,
+    scope: Option<String>,
     force_create: Option<bool>,
     allow_secrets: Option<bool>,
     batch_merge_policy: Option<String>,
@@ -136,6 +145,7 @@ struct BatchItem {
     #[serde(alias = "node_type")]
     node_type: Option<String>,
     source: Option<String>,
+    scope: Option<String>,
     force_create: Option<bool>,
     allow_secrets: Option<bool>,
 }
@@ -149,6 +159,9 @@ pub async fn execute(
         Some(v) => serde_json::from_value(v).map_err(|e| format!("Invalid arguments: {}", e))?,
         None => return Err("Missing arguments".to_string()),
     };
+    let scope = args
+        .scope
+        .unwrap_or_else(|| DEFAULT_MEMORY_SCOPE.to_string());
 
     // Detect mode: batch (items present) vs single (content present)
     if let Some(items) = args.items {
@@ -173,7 +186,15 @@ pub async fn execute(
             Some(explicit) => explicit,
             None => default_force_create,
         };
-        return execute_batch(storage, cognitive, items, global_force, &batch_merge_policy).await;
+        return execute_batch(
+            storage,
+            cognitive,
+            items,
+            global_force,
+            &batch_merge_policy,
+            &scope,
+        )
+        .await;
     }
 
     // Single mode: content is required
@@ -261,7 +282,7 @@ pub async fn execute(
     // Check if force_create is enabled
     if args.force_create.unwrap_or(false) {
         let node = storage
-            .ingest_with_secret_policy(input, secret_policy)
+            .ingest_in_scope_with_secret_policy(input, &scope, secret_policy)
             .map_err(|e| e.to_string())?;
         let node_id = node.id.clone();
         let node_content = node.content.clone();
@@ -283,6 +304,7 @@ pub async fn execute(
             "success": true,
             "decision": "create",
             "nodeId": node_id,
+            "scope": scope,
             "message": "Memory created (force_create=true)",
             "hasEmbedding": has_embedding,
             "predictionError": 1.0,
@@ -296,7 +318,7 @@ pub async fn execute(
     #[cfg(all(feature = "embeddings", feature = "vector-search"))]
     {
         let result = storage
-            .smart_ingest_with_secret_policy(input, secret_policy)
+            .smart_ingest_in_scope_with_secret_policy(input, &scope, secret_policy)
             .map_err(|e| e.to_string())?;
         let node_id = result.node.id.clone();
         let node_content = result.node.content.clone();
@@ -328,6 +350,7 @@ pub async fn execute(
             "success": true,
             "decision": result.decision,
             "nodeId": node_id,
+            "scope": scope,
             "message": format!("Smart ingest complete: {}", result.reason),
             "hasEmbedding": has_embedding,
             "similarity": result.similarity,
@@ -355,7 +378,7 @@ pub async fn execute(
     #[cfg(not(all(feature = "embeddings", feature = "vector-search")))]
     {
         let node = storage
-            .ingest_with_secret_policy(input, secret_policy)
+            .ingest_in_scope_with_secret_policy(input, &scope, secret_policy)
             .map_err(|e| e.to_string())?;
         let node_id = node.id.clone();
         let node_content = node.content.clone();
@@ -375,6 +398,7 @@ pub async fn execute(
             "success": true,
             "decision": "create",
             "nodeId": node_id,
+            "scope": scope,
             "message": "Memory created (smart ingest requires embeddings feature)",
             "hasEmbedding": false,
             "predictionError": 1.0,
@@ -396,6 +420,7 @@ async fn execute_batch(
     items: Vec<BatchItem>,
     global_force_create: bool,
     batch_merge_policy: &str,
+    default_scope: &str,
 ) -> Result<Value, String> {
     if items.is_empty() {
         return Err("Items array cannot be empty".to_string());
@@ -415,6 +440,10 @@ async fn execute_batch(
     let mut batch_created_node_ids: Vec<String> = Vec::new();
 
     for (i, item) in items.into_iter().enumerate() {
+        let scope = item
+            .scope
+            .clone()
+            .unwrap_or_else(|| default_scope.to_string());
         // Skip empty content
         if item.content.trim().is_empty() {
             results.push(serde_json::json!({
@@ -506,7 +535,7 @@ async fn execute_batch(
         // Check force_create: global flag OR per-item flag
         let item_force = global_force_create || item_force_create;
         if item_force {
-            match storage.ingest_with_secret_policy(input, secret_policy) {
+            match storage.ingest_in_scope_with_secret_policy(input, &scope, secret_policy) {
                 Ok(node) => {
                     let node_id = node.id.clone();
                     let node_content = node.content.clone();
@@ -529,6 +558,7 @@ async fn execute_batch(
                         "status": "saved",
                         "decision": "create",
                         "nodeId": node_id,
+                        "scope": scope,
                         "importanceScore": importance_composite,
                         "synapticCapture": synaptic_capture,
                         "reason": "Forced creation - skipped similarity check"
@@ -548,8 +578,9 @@ async fn execute_batch(
 
         #[cfg(all(feature = "embeddings", feature = "vector-search"))]
         {
-            match storage.smart_ingest_excluding_with_secret_policy(
+            match storage.smart_ingest_excluding_in_scope_with_secret_policy(
                 input,
+                &scope,
                 &batch_created_node_ids,
                 secret_policy,
             ) {
@@ -593,6 +624,7 @@ async fn execute_batch(
                         "status": "saved",
                         "decision": result.decision,
                         "nodeId": node_id,
+                        "scope": scope,
                         "similarity": result.similarity,
                         "predictionError": result.prediction_error,
                         "supersededId": result.superseded_id,
@@ -617,7 +649,7 @@ async fn execute_batch(
 
         #[cfg(not(all(feature = "embeddings", feature = "vector-search")))]
         {
-            match storage.ingest_with_secret_policy(input, secret_policy) {
+            match storage.ingest_in_scope_with_secret_policy(input, &scope, secret_policy) {
                 Ok(node) => {
                     let node_id = node.id.clone();
                     let node_content = node.content.clone();
@@ -640,6 +672,7 @@ async fn execute_batch(
                         "status": "saved",
                         "decision": "create",
                         "nodeId": node_id,
+                        "scope": scope,
                         "importanceScore": importance_composite,
                         "synapticCapture": synaptic_capture,
                         "reason": "Embeddings not available - used regular ingest"
@@ -959,6 +992,27 @@ mod tests {
                     .unwrap()
                     .contains("Embeddings not available")
         );
+    }
+
+    #[tokio::test]
+    async fn smart_ingest_persists_the_requested_project_scope() {
+        let (storage, _dir) = test_storage().await;
+        let result = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "content": "The web-app backup worker keeps six daily snapshots.",
+                "scope": "web-app",
+                "forceCreate": true,
+            })),
+        )
+        .await
+        .expect("scoped ingest succeeds");
+
+        let id = result["nodeId"].as_str().expect("node id");
+        assert_eq!(result["scope"], "web-app");
+        assert!(storage.node_is_in_scope(id, "web-app").unwrap());
+        assert!(!storage.node_is_in_scope(id, DEFAULT_MEMORY_SCOPE).unwrap());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Implements the project-scopes slice of #156 only.

Part of #156 — project-scope relevance-isolation slice; does not close the remaining validity, tag, or hygiene work.

## What changed

- Adds first-class project scopes to `smart_ingest`, including batch-item overrides.
- Persists scoped nodes and confines prediction-error candidates plus every smart-ingest create/supersede/merge/fallback write to that scope.
- Makes ordinary core and MCP recall default to the legacy `user` scope; named scope lookup is explicit.
- Allows cross-project results only through explicit `includeCrossScope: true`.
- Adds V27 migration: legacy `NULL` or blank scopes normalize to `user`.
- Rejects blank, control-character, and oversized scopes; scope SQL uses bound parameters.

## Compatibility and boundaries

This is relevance isolation, not authentication or an ACL boundary. A client that sets `includeCrossScope: true` intentionally receives results across scopes.

Known caller gaps: CLI/codebase/direct storage callers and source-sync/connector writers do not yet supply a project scope and therefore remain in `user`; old nonblank `session` or `agent` rows require an explicit scope query. Scope filtering is post-candidate, so a heavily mixed corpus can return fewer than the requested number of in-scope results, but it must not return cross-scope results by default.

## Intentionally deferred from #156

- explicit validity inputs, conservative `as of` parsing, and validity-aware recall ranking
- tag rename/merge tooling
- complete hygiene statistics and tooling
- broader documentation/examples and additional caller adoption

## Verification

- `cargo test -p vestige-mcp smart_ingest_persists_the_requested_project_scope --quiet`
- `cargo test -p vestige-mcp project_scope_prevents_cross_project_retrieval_by_default --quiet`
- `cargo test -p vestige-core v27_preserves_legacy_rows_in_the_user_scope --no-default-features --quiet`
- `cargo clippy -p vestige-core -p vestige-mcp --all-targets -- -D warnings`
- `git diff --check`

`origin/main` was refreshed immediately before publication; this branch was already based on it with no rebase or conflict required.