### PR TITLE
feat: add bitemporal validity to smart ingest

### DIFF
--- a/crates/vestige-core/src/storage/migrations.rs
+++ b/crates/vestige-core/src/storage/migrations.rs
@@ -1633,6 +1633,34 @@ ALTER TABLE receipt_envelopes ADD COLUMN projection_json TEXT CHECK (
 /// bricked the DB permanently). VACUUM (V7) cannot run inside a transaction,
 /// so it runs after the transaction commits.
 pub fn apply_migrations(conn: &rusqlite::Connection) -> rusqlite::Result<u32> {
+    // A fresh local database can be opened simultaneously by two processes at
+    // startup. Individual migration transactions already take the writer lock
+    // and re-check the version, but SQLite can still return BUSY while a peer
+    // is switching journal modes for the V7 page-size migration. Retrying the
+    // complete, idempotent runner makes that startup race converge instead of
+    // surfacing a transient lock to one of the openers.
+    const MAX_BUSY_RETRIES: u8 = 40;
+    let mut attempts = 0_u8;
+
+    loop {
+        match apply_migrations_once(conn) {
+            Ok(applied) => return Ok(applied),
+            Err(rusqlite::Error::SqliteFailure(error, _))
+                if matches!(
+                    error.code,
+                    rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+                ) && attempts < MAX_BUSY_RETRIES =>
+            {
+                attempts += 1;
+                let delay_ms = 25_u64.saturating_mul(1_u64 << attempts.min(4));
+                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn apply_migrations_once(conn: &rusqlite::Connection) -> rusqlite::Result<u32> {
     let initial_version = get_current_version(conn)?;
     let mut applied = 0;
 

--- a/crates/vestige-core/src/storage/sqlite.rs
+++ b/crates/vestige-core/src/storage/sqlite.rs
@@ -84,6 +84,51 @@ pub type Result<T> = std::result::Result<T, StorageError>;
 /// project scopes were exposed. Scoped callers must opt into a different value.
 pub const DEFAULT_MEMORY_SCOPE: &str = "user";
 
+fn temporal_candidate_is_eligible(
+    incoming_from: Option<DateTime<Utc>>,
+    incoming_until: Option<DateTime<Utc>>,
+    existing_from: Option<DateTime<Utc>>,
+    existing_is_current: bool,
+    now: DateTime<Utc>,
+) -> bool {
+    let incoming_is_older = match (incoming_from, existing_from) {
+        (Some(incoming), Some(existing)) => incoming < existing,
+        _ => false,
+    };
+    let incoming_is_expired = incoming_until.is_some_and(|until| until < now);
+    !incoming_is_older && !(incoming_is_expired && existing_is_current)
+}
+
+#[cfg(test)]
+mod temporal_candidate_tests {
+    use super::temporal_candidate_is_eligible;
+    use chrono::{Duration, Utc};
+
+    #[test]
+    fn older_dated_summary_cannot_mutate_newer_current_policy() {
+        let now = Utc::now();
+        assert!(!temporal_candidate_is_eligible(
+            Some(now - Duration::days(365)),
+            Some(now - Duration::days(180)),
+            Some(now - Duration::days(30)),
+            true,
+            now,
+        ));
+    }
+
+    #[test]
+    fn newer_policy_remains_eligible_to_replace_an_older_fact() {
+        let now = Utc::now();
+        assert!(temporal_candidate_is_eligible(
+            Some(now),
+            None,
+            Some(now - Duration::days(30)),
+            true,
+            now,
+        ));
+    }
+}
+
 /// Environment variable selecting the SQLite commit-durability policy.
 pub const VESTIGE_SQLITE_DURABILITY_ENV: &str = "VESTIGE_SQLITE_DURABILITY";
 
@@ -1688,6 +1733,18 @@ impl SqliteMemoryStore {
                 continue;
             }
             if let Some(node) = self.get_node(node_id)? {
+                // A historical snapshot must never mutate, reinforce, or demote
+                // a fact whose validity starts later. Likewise, an already
+                // expired input cannot supersede a currently-valid policy.
+                if !temporal_candidate_is_eligible(
+                    input.valid_from,
+                    input.valid_until,
+                    node.valid_from,
+                    node.is_currently_valid(),
+                    Utc::now(),
+                ) {
+                    continue;
+                }
                 // Get embedding for this node
                 if let Some(emb) = self.get_node_embedding(node_id)? {
                     // Check if this memory was previously demoted (low retrieval strength)
@@ -1749,6 +1806,13 @@ impl SqliteMemoryStore {
             } => {
                 match update_type {
                     UpdateType::Reinforce => {
+                        if input.valid_from.is_some() || input.valid_until.is_some() {
+                            self.update_node_validity(
+                                &target_id,
+                                input.valid_from,
+                                input.valid_until,
+                            )?;
+                        }
                         // Just strengthen the existing memory
                         self.strengthen_on_access(&target_id)?;
                         let node = self
@@ -1786,6 +1850,13 @@ impl SqliteMemoryStore {
                             &merged_content,
                             policy,
                         )?;
+                        if input.valid_from.is_some() || input.valid_until.is_some() {
+                            self.update_node_validity(
+                                &target_id,
+                                input.valid_from,
+                                input.valid_until,
+                            )?;
+                        }
                         self.strengthen_on_access(&target_id)?;
 
                         let node = self
@@ -1816,6 +1887,13 @@ impl SqliteMemoryStore {
                             &input.content,
                             policy,
                         )?;
+                        if input.valid_from.is_some() || input.valid_until.is_some() {
+                            self.update_node_validity(
+                                &target_id,
+                                input.valid_from,
+                                input.valid_until,
+                            )?;
+                        }
                         let node = self
                             .get_node(&target_id)?
                             .ok_or_else(|| StorageError::NotFound(target_id.clone()))?;
@@ -1847,6 +1925,13 @@ impl SqliteMemoryStore {
                             &merged_content,
                             policy,
                         )?;
+                        if input.valid_from.is_some() || input.valid_until.is_some() {
+                            self.update_node_validity(
+                                &target_id,
+                                input.valid_from,
+                                input.valid_until,
+                            )?;
+                        }
                         let node = self
                             .get_node(&target_id)?
                             .ok_or_else(|| StorageError::NotFound(target_id.clone()))?;
@@ -1871,7 +1956,13 @@ impl SqliteMemoryStore {
                 supersede_reason,
                 prediction_error,
             } => {
-                // Demote the old memory and create new
+                // Close the old fact's world-time interval before demoting it.
+                // A dated replacement takes effect at its declared start;
+                // otherwise the supersession becomes effective now.
+                self.close_node_validity(
+                    &old_memory_id,
+                    input.valid_from.unwrap_or_else(Utc::now),
+                )?;
                 self.demote_memory(&old_memory_id)?;
 
                 // Create the new improved memory
@@ -1987,6 +2078,49 @@ impl SqliteMemoryStore {
     ) -> Result<()> {
         Self::enforce_secret_policy_for_content(new_content, policy)?;
         self.update_node_content_unchecked(id, new_content)
+    }
+
+    /// Replace a node's declared world-time interval without changing its
+    /// project namespace or transaction-time history.
+    pub fn update_node_validity(
+        &self,
+        id: &str,
+        valid_from: Option<DateTime<Utc>>,
+        valid_until: Option<DateTime<Utc>>,
+    ) -> Result<()> {
+        if let (Some(from), Some(until)) = (valid_from, valid_until)
+            && until <= from
+        {
+            return Err(StorageError::InvalidTimestamp(
+                "valid_until must be after valid_from".to_string(),
+            ));
+        }
+        let writer = self
+            .writer
+            .lock()
+            .map_err(|_| StorageError::Init("Writer lock poisoned".into()))?;
+        writer.execute(
+            "UPDATE knowledge_nodes SET valid_from = ?1, valid_until = ?2, updated_at = ?3 WHERE id = ?4",
+            params![
+                valid_from.map(|value| value.to_rfc3339()),
+                valid_until.map(|value| value.to_rfc3339()),
+                Utc::now().to_rfc3339(),
+                id
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn close_node_validity(&self, id: &str, valid_until: DateTime<Utc>) -> Result<()> {
+        let writer = self
+            .writer
+            .lock()
+            .map_err(|_| StorageError::Init("Writer lock poisoned".into()))?;
+        writer.execute(
+            "UPDATE knowledge_nodes SET valid_until = ?1, updated_at = ?2 WHERE id = ?3",
+            params![valid_until.to_rfc3339(), Utc::now().to_rfc3339(), id],
+        )?;
+        Ok(())
     }
 
     fn update_node_content_unchecked(&self, id: &str, new_content: &str) -> Result<()> {

--- a/crates/vestige-mcp/src/tools/search_unified.rs
+++ b/crates/vestige-mcp/src/tools/search_unified.rs
@@ -14,7 +14,7 @@
 //!   6. Predictive memory recording
 //!   7. Reconsolidation (mark labile)
 
-use chrono::Utc;
+use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use serde::Deserialize;
 use serde_json::Value;
 use std::sync::Arc;
@@ -107,6 +107,10 @@ pub fn schema() -> Value {
                 "description": "Search across all project namespaces. Defaults to false; set only when cross-project retrieval is intentional.",
                 "default": false
             },
+            "validAt": {
+                "type": "string",
+                "description": "Return only facts valid at this time. Accepts 'now', RFC3339, or YYYY-MM-DD. When omitted, expired/future facts remain auditable but are conservatively downranked."
+            },
             "source_system": {
                 "type": "string",
                 "description": "Investigation filter (#57): only memories ingested from this external system, e.g. 'github' or 'redmine'. Post-filter — non-connector memories are excluded. Combine with a larger 'limit' if thinning is heavy."
@@ -172,6 +176,7 @@ struct SearchArgs {
     tag_prefix: Option<String>,
     scope: Option<String>,
     include_cross_scope: Option<bool>,
+    valid_at: Option<String>,
     // #57 Phase 4 — source-aware investigation filters (all post-filters).
     #[serde(alias = "source_system")]
     source_system: Option<String>,
@@ -189,6 +194,39 @@ struct SearchArgs {
     source_updated_before: Option<String>,
     #[serde(alias = "source_status")]
     source_status: Option<String>,
+}
+
+fn parse_valid_at(raw: Option<&str>) -> Result<Option<DateTime<Utc>>, String> {
+    let Some(raw) = raw else { return Ok(None) };
+    if raw == "now" {
+        return Ok(Some(Utc::now()));
+    }
+    if raw.trim() != raw || raw.is_empty() {
+        return Err(
+            "Invalid validAt: expected 'now', RFC3339, or YYYY-MM-DD without surrounding whitespace"
+                .to_string(),
+        );
+    }
+    if let Ok(timestamp) = DateTime::parse_from_rfc3339(raw) {
+        return Ok(Some(timestamp.with_timezone(&Utc)));
+    }
+    if let Ok(date) = NaiveDate::parse_from_str(raw, "%Y-%m-%d") {
+        return Ok(Some(Utc.from_utc_datetime(
+            &date.and_hms_opt(0, 0, 0).expect("midnight is valid"),
+        )));
+    }
+    Err("Invalid validAt: expected 'now', RFC3339, or YYYY-MM-DD".to_string())
+}
+
+fn apply_default_validity_penalty(
+    result: &mut vestige_core::SearchResult,
+    valid_at: Option<DateTime<Utc>>,
+) {
+    if valid_at.is_none() && !result.node.is_currently_valid() {
+        // Historical and future facts remain available for audit, but should
+        // not outrank a current policy on relevance alone.
+        result.combined_score *= 0.1;
+    }
 }
 
 /// Execute unified search with 7-stage cognitive pipeline.
@@ -257,6 +295,7 @@ pub async fn execute(
     // both the concrete and hybrid paths). Hard-errors on malformed input.
     let source_filter = SourceFilter::from_args(&args)?;
     let scope_filter = ScopeFilter::from_args(&args)?;
+    let valid_at = parse_valid_at(args.valid_at.as_deref())?;
 
     let concrete = args
         .concrete
@@ -285,7 +324,15 @@ pub async fn execute(
 
         // Apply post-filters before formatting the response. Retrieval
         // telemetry is recorded later, after the final budget selection.
-        let results = filter_results_to_scope(storage, results, &scope_filter)?;
+        let mut results = filter_results_to_scope(storage, results, &scope_filter)?;
+        for result in &mut results {
+            apply_default_validity_penalty(result, valid_at);
+        }
+        results.sort_by(|a, b| {
+            b.combined_score
+                .partial_cmp(&a.combined_score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         let filtered_results: Vec<&vestige_core::SearchResult> = results
             .iter()
             .filter(|r| match args.tag_prefix.as_deref() {
@@ -293,6 +340,7 @@ pub async fn execute(
                 None => true,
             })
             .filter(|r| node_matches_source(&r.node, &source_filter))
+            .filter(|r| valid_at.is_none_or(|at| r.node.is_valid_at(at)))
             .take(limit as usize)
             .collect();
 
@@ -344,6 +392,7 @@ pub async fn execute(
             "profile": output_config.profile.as_str(),
             "scope": scope_filter.scope,
             "includeCrossScope": scope_filter.include_cross_scope,
+            "validAt": valid_at.map(|at| at.to_rfc3339()),
             "total": formatted.len(),
             "results": formatted,
         });
@@ -395,6 +444,9 @@ pub async fn execute(
     let mut keyword_priority_results: Vec<vestige_core::SearchResult> = Vec::new();
     for r in keyword_first_results {
         if !scope_filter.matches(storage, &r.node.id)? {
+            continue;
+        }
+        if valid_at.is_some_and(|at| !r.node.is_valid_at(at)) {
             continue;
         }
         if r.keyword_score.unwrap_or(0.0) >= keyword_priority_threshold
@@ -466,11 +518,19 @@ pub async fn execute(
     if source_filter.is_active() {
         filtered_results.retain(|r| node_matches_source(&r.node, &source_filter));
     }
+    if let Some(at) = valid_at {
+        filtered_results.retain(|result| result.node.is_valid_at(at));
+    }
+    for result in &mut filtered_results {
+        apply_default_validity_penalty(result, valid_at);
+    }
 
     // ====================================================================
     // Dedup: merge Stage 0 keyword-priority results into Stage 1 results
     // ====================================================================
-    for kp in &keyword_priority_results {
+    for keyword_priority in &keyword_priority_results {
+        let mut kp = keyword_priority.clone();
+        apply_default_validity_penalty(&mut kp, valid_at);
         // Respect tag_prefix here too — Stage 0 ran without it and can
         // re-introduce filtered-out memories on the "new result" branch.
         if let Some(prefix) = args.tag_prefix.as_deref()
@@ -480,6 +540,9 @@ pub async fn execute(
         }
         // Respect the source filter on re-inject for the same reason.
         if source_filter.is_active() && !node_matches_source(&kp.node, &source_filter) {
+            continue;
+        }
+        if valid_at.is_some_and(|at| !kp.node.is_valid_at(at)) {
             continue;
         }
         if let Some(existing) = filtered_results
@@ -495,7 +558,7 @@ pub async fn execute(
             }
         } else {
             // New result from Stage 0 not in Stage 1 — add it
-            filtered_results.push(kp.clone());
+            filtered_results.push(kp);
         }
     }
 
@@ -583,7 +646,7 @@ pub async fn execute(
             let validity = cog.temporal_searcher.validity_boost(
                 result.node.valid_from,
                 result.node.valid_until,
-                None,
+                valid_at,
             );
             // Blend: 85% relevance + 15% temporal signal
             let temporal_factor = recency * validity;
@@ -870,6 +933,7 @@ pub async fn execute(
         "profile": output_config.profile.as_str(),
         "scope": scope_filter.scope,
         "includeCrossScope": scope_filter.include_cross_scope,
+        "validAt": valid_at.map(|at| at.to_rfc3339()),
         "total": formatted.len(),
         "results": formatted,
     });
@@ -1281,6 +1345,8 @@ fn format_search_result(r: &vestige_core::SearchResult, detail_level: &str) -> V
                 "retentionStrength": r.node.retention_strength,
                 "createdAt": r.node.created_at.to_rfc3339(),
                 "updatedAt": r.node.updated_at.to_rfc3339(),
+                "validFrom": r.node.valid_from.map(|dt| dt.to_rfc3339()),
+                "validUntil": r.node.valid_until.map(|dt| dt.to_rfc3339()),
             });
             attach_source_record(&mut v, &r.node);
             v
@@ -1388,6 +1454,90 @@ mod tests {
         };
         let node = storage.ingest(input).unwrap();
         node.id
+    }
+
+    #[tokio::test]
+    async fn valid_at_returns_the_fact_true_at_that_time() {
+        let (storage, _dir) = test_storage().await;
+        let historical = storage
+            .ingest(IngestInput {
+                content: "deployment policy requires one approver".to_string(),
+                valid_from: Some("2025-01-01T00:00:00Z".parse().unwrap()),
+                valid_until: Some("2026-01-01T00:00:00Z".parse().unwrap()),
+                ..Default::default()
+            })
+            .unwrap();
+        let current = storage
+            .ingest(IngestInput {
+                content: "deployment policy requires two approvers".to_string(),
+                valid_from: Some("2026-01-01T00:00:00Z".parse().unwrap()),
+                ..Default::default()
+            })
+            .unwrap();
+
+        let response = execute(
+            &storage,
+            &test_cognitive(),
+            &OutputConfig::default(),
+            Some(serde_json::json!({
+                "query": "deployment policy approvers",
+                "concrete": true,
+                "validAt": "2025-06-01"
+            })),
+        )
+        .await
+        .unwrap();
+        let ids: Vec<&str> = response["results"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|result| result["id"].as_str())
+            .collect();
+        assert!(ids.contains(&historical.id.as_str()));
+        assert!(!ids.contains(&current.id.as_str()));
+    }
+
+    #[tokio::test]
+    async fn current_recall_conservatively_downranks_expired_facts() {
+        let (storage, _dir) = test_storage().await;
+        storage
+            .ingest(IngestInput {
+                content: "release policy alpha".to_string(),
+                valid_until: Some(Utc::now() - chrono::Duration::days(1)),
+                ..Default::default()
+            })
+            .unwrap();
+        let current = storage
+            .ingest(IngestInput {
+                content: "release policy alpha current".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let response = execute(
+            &storage,
+            &test_cognitive(),
+            &OutputConfig::default(),
+            Some(serde_json::json!({
+                "query": "release policy alpha",
+                "concrete": true
+            })),
+        )
+        .await
+        .unwrap();
+        assert_eq!(response["results"][0]["id"], current.id);
+    }
+
+    #[tokio::test]
+    async fn malformed_valid_at_is_rejected() {
+        let (storage, _dir) = test_storage().await;
+        let result = execute(
+            &storage,
+            &test_cognitive(),
+            &OutputConfig::default(),
+            Some(serde_json::json!({"query": "policy", "validAt": "last Tuesday"})),
+        )
+        .await;
+        assert!(result.unwrap_err().contains("Invalid validAt"));
     }
 
     #[tokio::test]

--- a/crates/vestige-mcp/src/tools/smart_ingest.rs
+++ b/crates/vestige-mcp/src/tools/smart_ingest.rs
@@ -14,7 +14,7 @@
 //!   Pre-ingest: importance scoring (4-channel) + intent detection → auto-tag
 //!   Post-ingest: synaptic tagging + novelty model update + hippocampal indexing
 
-use chrono::Utc;
+use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use serde::Deserialize;
 use serde_json::Value;
 use std::sync::Arc;
@@ -57,6 +57,14 @@ pub fn schema() -> Value {
             "scope": {
                 "type": "string",
                 "description": "Project namespace for this memory. Defaults to 'user' for backward compatibility. Recall searches this namespace unless includeCrossScope=true."
+            },
+            "validFrom": {
+                "type": "string",
+                "description": "When this fact becomes true. Use RFC3339 or an exact YYYY-MM-DD date."
+            },
+            "validUntil": {
+                "type": "string",
+                "description": "When this fact stops being true. Use RFC3339 or an exact YYYY-MM-DD date; must be after validFrom."
             },
             "forceCreate": {
                 "type": "boolean",
@@ -103,6 +111,14 @@ pub fn schema() -> Value {
                             "type": "string",
                             "description": "Project namespace for this item. Overrides the batch scope when supplied."
                         },
+                        "validFrom": {
+                            "type": "string",
+                            "description": "When this item becomes true (RFC3339 or YYYY-MM-DD)."
+                        },
+                        "validUntil": {
+                            "type": "string",
+                            "description": "When this item stops being true (RFC3339 or YYYY-MM-DD; after validFrom)."
+                        },
                         "forceCreate": {
                             "type": "boolean",
                             "description": "Force creation of this item even if similar content exists",
@@ -130,6 +146,8 @@ struct SmartIngestArgs {
     tags: Option<Vec<String>>,
     source: Option<String>,
     scope: Option<String>,
+    valid_from: Option<String>,
+    valid_until: Option<String>,
     force_create: Option<bool>,
     allow_secrets: Option<bool>,
     batch_merge_policy: Option<String>,
@@ -146,8 +164,54 @@ struct BatchItem {
     node_type: Option<String>,
     source: Option<String>,
     scope: Option<String>,
+    valid_from: Option<String>,
+    valid_until: Option<String>,
     force_create: Option<bool>,
     allow_secrets: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ValidityRange {
+    from: Option<DateTime<Utc>>,
+    until: Option<DateTime<Utc>>,
+}
+
+fn parse_validity_timestamp(
+    raw: Option<&str>,
+    field: &str,
+) -> Result<Option<DateTime<Utc>>, String> {
+    let Some(raw) = raw else { return Ok(None) };
+    if raw.trim() != raw || raw.is_empty() {
+        return Err(format!(
+            "Invalid {field}: expected RFC3339 or YYYY-MM-DD without surrounding whitespace"
+        ));
+    }
+    if let Ok(timestamp) = DateTime::parse_from_rfc3339(raw) {
+        return Ok(Some(timestamp.with_timezone(&Utc)));
+    }
+    if let Ok(date) = NaiveDate::parse_from_str(raw, "%Y-%m-%d") {
+        return Ok(Some(Utc.from_utc_datetime(
+            &date.and_hms_opt(0, 0, 0).expect("midnight is valid"),
+        )));
+    }
+    Err(format!("Invalid {field}: expected RFC3339 or YYYY-MM-DD"))
+}
+
+fn parse_validity_range(
+    valid_from: Option<&str>,
+    valid_until: Option<&str>,
+) -> Result<ValidityRange, String> {
+    let valid_from = parse_validity_timestamp(valid_from, "validFrom")?;
+    let valid_until = parse_validity_timestamp(valid_until, "validUntil")?;
+    if let (Some(from), Some(until)) = (valid_from, valid_until)
+        && until <= from
+    {
+        return Err("Invalid validity range: validUntil must be after validFrom".to_string());
+    }
+    Ok(ValidityRange {
+        from: valid_from,
+        until: valid_until,
+    })
 }
 
 pub async fn execute(
@@ -201,6 +265,7 @@ pub async fn execute(
     let content = args.content.ok_or(
         "Missing 'content' field. Provide 'content' for single mode or 'items' for batch mode.",
     )?;
+    let validity = parse_validity_range(args.valid_from.as_deref(), args.valid_until.as_deref())?;
     let secret_policy = if args.allow_secrets.unwrap_or(false) {
         SecretPolicy::AllowExplicitly
     } else {
@@ -270,8 +335,8 @@ pub async fn execute(
         // Store importance composite as sentiment_magnitude for FSRS encoding boost
         sentiment_magnitude: importance_composite,
         tags,
-        valid_from: None,
-        valid_until: None,
+        valid_from: validity.from,
+        valid_until: validity.until,
         source_envelope: None,
     };
 
@@ -444,6 +509,19 @@ async fn execute_batch(
             .scope
             .clone()
             .unwrap_or_else(|| default_scope.to_string());
+        let validity =
+            match parse_validity_range(item.valid_from.as_deref(), item.valid_until.as_deref()) {
+                Ok(range) => range,
+                Err(reason) => {
+                    errors += 1;
+                    results.push(serde_json::json!({
+                        "index": i,
+                        "status": "error",
+                        "reason": reason
+                    }));
+                    continue;
+                }
+            };
         // Skip empty content
         if item.content.trim().is_empty() {
             results.push(serde_json::json!({
@@ -523,8 +601,8 @@ async fn execute_batch(
             sentiment_score: 0.0,
             sentiment_magnitude: importance_composite,
             tags,
-            valid_from: None,
-            valid_until: None,
+            valid_from: validity.from,
+            valid_until: validity.until,
             source_envelope: None,
         };
 
@@ -1321,8 +1399,87 @@ mod tests {
         assert!(schema_value["properties"]["forceCreate"].is_object());
         assert!(schema_value["properties"]["batchMergePolicy"].is_object());
         assert!(schema_value["properties"]["items"].is_object());
+        assert!(schema_value["properties"]["validFrom"].is_object());
+        assert!(schema_value["properties"]["validUntil"].is_object());
         // v1.7: no top-level required — content for single mode, items for batch mode
         assert!(schema_value.get("required").is_none() || schema_value["required"].is_null());
+    }
+
+    #[tokio::test]
+    async fn smart_ingest_persists_strict_single_item_validity() {
+        let (storage, _dir) = test_storage().await;
+        let response = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "content": "The deployment policy applies during Q3.",
+                "forceCreate": true,
+                "validFrom": "2026-07-01",
+                "validUntil": "2026-10-01T00:00:00Z"
+            })),
+        )
+        .await
+        .unwrap();
+        let node = storage
+            .get_node(response["nodeId"].as_str().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            node.valid_from.unwrap().to_rfc3339(),
+            "2026-07-01T00:00:00+00:00"
+        );
+        assert_eq!(
+            node.valid_until.unwrap().to_rfc3339(),
+            "2026-10-01T00:00:00+00:00"
+        );
+    }
+
+    #[tokio::test]
+    async fn smart_ingest_rejects_invalid_dates_and_reversed_ranges() {
+        let (storage, _dir) = test_storage().await;
+        for args in [
+            serde_json::json!({"content": "bad date", "validFrom": "07/01/2026"}),
+            serde_json::json!({
+                "content": "bad range",
+                "validFrom": "2026-10-01",
+                "validUntil": "2026-07-01"
+            }),
+        ] {
+            assert!(
+                execute(&storage, &test_cognitive(), Some(args))
+                    .await
+                    .is_err()
+            );
+        }
+        assert_eq!(storage.get_stats().unwrap().total_nodes, 0);
+    }
+
+    #[tokio::test]
+    async fn batch_validity_is_per_item_and_invalid_items_do_not_write() {
+        let (storage, _dir) = test_storage().await;
+        let response = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "items": [
+                    {"content": "dated item", "validFrom": "2026-08-01"},
+                    {"content": "invalid item", "validUntil": "yesterday"}
+                ]
+            })),
+        )
+        .await
+        .unwrap();
+        assert_eq!(response["success"], false);
+        assert_eq!(response["results"][1]["status"], "error");
+        let node = storage
+            .get_node(response["results"][0]["nodeId"].as_str().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            node.valid_from.unwrap().to_rfc3339(),
+            "2026-08-01T00:00:00+00:00"
+        );
+        assert_eq!(storage.get_stats().unwrap().total_nodes, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

- add explicit `validFrom` / `validUntil` inputs to single and batch `smart_ingest`
- strictly accept RFC3339 or exact `YYYY-MM-DD` timestamps and reject reversed ranges before writes
- preserve validity through create, fallback, update, reinforce, replace, context, merge, and supersede paths while retaining project scope isolation
- add explicit `validAt` recall for current/as-of filtering and conservatively downrank expired or future facts during ordinary recall
- prevent older dated or already-expired summaries from mutating or superseding newer current policies

## Scope boundary

This is only the bitemporal-validity slice of #156. It does not add tag rename/merge, hygiene reporting, ACL/auth behavior, or billing/cloud changes. #156 remains open for its remaining slices.

Natural-language `as of ...` parsing is intentionally omitted to avoid false positives; callers use the explicit `validAt` field.

## Verification

- `cargo test -p vestige-core -p vestige-mcp --lib` (707 core + 512 MCP tests)
- `cargo test -p vestige-core temporal_candidate_tests --lib --quiet`
- `cargo test -p vestige-mcp tools::smart_ingest::tests --lib --quiet` (45 tests)
- `cargo test -p vestige-mcp tools::search_unified::tests --lib --quiet` (56 tests)
- `cargo clippy -p vestige-core -p vestige-mcp --all-targets -- -D warnings`
- changed-file `rustfmt --edition 2024 --check`
- `git diff --check`
