### PR TITLE
fix(trace): pre-gate destructive memory mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,11 @@ tests. It now runs on every traced tool call:
   knows. The notice is truthful per-write: quarantined writes are reported as
   held; destructive writes (already applied) are reported as recorded for
   review, never as "quarantined".
-- Gating rides on the trace gate: `VESTIGE_TRACE_ENABLED=0` disables Memory
-  PRs along with the black box. Documented in `docs/CONFIGURATION.md`.
+- Confirmed purge/delete and direct suppression now open a durable Memory PR
+  before execution in risk-gated/paranoid mode. Failed PR persistence blocks
+  the mutation; review decisions then atomically purge, keep, or quarantine.
+- `VESTIGE_TRACE=0` disables Black Box recording without disabling the
+  pre-execution destructive safety gate.
 
 ## [2.3.0] - 2026-07-26 — "Cognitive Observatory + Zero-Knowledge Sync"
 

--- a/crates/vestige-core/src/lib.rs
+++ b/crates/vestige-core/src/lib.rs
@@ -210,6 +210,8 @@ pub use storage::{
     ModelSignature,
     NeverComposedCandidate,
     PORTABLE_ARCHIVE_FORMAT,
+    PendingMemoryMutationDecision,
+    PendingMemoryMutationEffect,
     PortableArchive,
     PortableImportMode,
     PortableImportReport,

--- a/crates/vestige-core/src/storage/migrations.rs
+++ b/crates/vestige-core/src/storage/migrations.rs
@@ -1633,6 +1633,34 @@ ALTER TABLE receipt_envelopes ADD COLUMN projection_json TEXT CHECK (
 /// bricked the DB permanently). VACUUM (V7) cannot run inside a transaction,
 /// so it runs after the transaction commits.
 pub fn apply_migrations(conn: &rusqlite::Connection) -> rusqlite::Result<u32> {
+    // A fresh local database can be opened simultaneously by two processes at
+    // startup. Individual migration transactions already take the writer lock
+    // and re-check the version, but SQLite can still return BUSY while a peer
+    // is switching journal modes for the V7 page-size migration. Retrying the
+    // complete, idempotent runner makes that startup race converge instead of
+    // surfacing a transient lock to one of the openers.
+    const MAX_BUSY_RETRIES: u8 = 40;
+    let mut attempts = 0_u8;
+
+    loop {
+        match apply_migrations_once(conn) {
+            Ok(applied) => return Ok(applied),
+            Err(rusqlite::Error::SqliteFailure(error, _))
+                if matches!(
+                    error.code,
+                    rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+                ) && attempts < MAX_BUSY_RETRIES =>
+            {
+                attempts += 1;
+                let delay_ms = 25_u64.saturating_mul(1_u64 << attempts.min(4));
+                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn apply_migrations_once(conn: &rusqlite::Connection) -> rusqlite::Result<u32> {
     let initial_version = get_current_version(conn)?;
     let mut applied = 0;
 

--- a/crates/vestige-core/src/storage/mod.rs
+++ b/crates/vestige-core/src/storage/mod.rs
@@ -62,7 +62,9 @@ pub use synaptic_store::{
     SynapticCapturePolicy, SynapticCaptureRequest, SynapticImportanceEvent, SynapticIngestOutcome,
     SynapticIngestRequest, SynapticSignalSnapshot,
 };
-pub use trace_store::AgentRunSummary;
+pub use trace_store::{
+    AgentRunSummary, PendingMemoryMutationDecision, PendingMemoryMutationEffect,
+};
 pub use unlearning::{
     AntiResurrectionCommitments, ArtifactKind, ArtifactRef, CheckStatus, Commitment, CommitmentKey,
     CommitmentKind, ErasureLedgerRecord, GuaranteeExclusion, LineageClosure, LineageEdge,

--- a/crates/vestige-core/src/storage/sqlite.rs
+++ b/crates/vestige-core/src/storage/sqlite.rs
@@ -423,7 +423,7 @@ struct PortableMergeState {
 ///
 /// Keeping these counters separate from the public report lets portable sync
 /// execute the identical cleanup inside its existing merge transaction.
-struct PurgeCleanup {
+pub(crate) struct PurgeCleanup {
     edges_pruned: i64,
     insights_rewritten: i64,
     insights_deleted: i64,
@@ -2576,7 +2576,7 @@ impl SqliteMemoryStore {
     }
 
     /// Log a memory interaction for audit and explicit-feedback learning.
-    fn log_access(&self, node_id: &str, access_type: &str) -> Result<()> {
+    pub(crate) fn log_access(&self, node_id: &str, access_type: &str) -> Result<()> {
         let writer = self
             .writer
             .lock()
@@ -3325,10 +3325,22 @@ impl SqliteMemoryStore {
         })
     }
 
+    /// Remove a committed purge from the optional in-process vector index.
+    pub(crate) fn remove_purged_node_from_vector_index(&self, id: &str) {
+        #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+        if let Some(index) = self.vector_index.as_ref()
+            && let Ok(mut index) = index.lock()
+        {
+            let _ = index.remove(id);
+        }
+        #[cfg(not(all(feature = "embeddings", feature = "vector-search")))]
+        let _ = id;
+    }
+
     /// Execute the privacy-critical delete work inside a caller-owned SQLite
     /// transaction. Portable merge uses this exact path so a remote deletion
     /// cannot leave local non-FK evidence behind.
-    fn purge_node_in_transaction(
+    pub(crate) fn purge_node_in_transaction(
         tx: &rusqlite::Transaction<'_>,
         id: &str,
         deleted_at: DateTime<Utc>,

--- a/crates/vestige-core/src/storage/trace_store.rs
+++ b/crates/vestige-core/src/storage/trace_store.rs
@@ -18,6 +18,26 @@ use super::sqlite::SqliteMemoryStore;
 use super::{Result, StorageError};
 use crate::trace::{MemoryPr, MemoryPrAction, MemoryPrStatus, MemoryTraceEvent, Receipt};
 
+/// Side effect applied while atomically deciding a pre-execution mutation PR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingMemoryMutationEffect {
+    /// The reviewer kept the memory unchanged.
+    Kept,
+    /// The reviewer approved the pending purge/delete.
+    Purged,
+    /// The reviewer held the memory under active suppression.
+    Suppressed,
+}
+
+/// Result of deciding a PR created before a destructive mutation.
+#[derive(Debug, Clone)]
+pub struct PendingMemoryMutationDecision {
+    /// Final PR state returned even when an approved purge removed its row.
+    pub pr: MemoryPr,
+    /// Mutation side effect committed with the decision.
+    pub effect: PendingMemoryMutationEffect,
+}
+
 /// Trace retention window used when `VESTIGE_TRACE_RETENTION_DAYS` is unset or
 /// unusable.
 const DEFAULT_TRACE_RETENTION_DAYS: i64 = 30;
@@ -681,6 +701,108 @@ impl SqliteMemoryStore {
         }
         self.get_memory_pr(id)?
             .ok_or_else(|| StorageError::NotFound(id.to_string()))
+    }
+
+    /// Atomically decide and, when approved, apply a mutation that was held
+    /// before execution. Returns `None` for ordinary post-commit Memory PRs.
+    ///
+    /// `Forget` approves the requested purge/suppression, `Promote` (and the
+    /// other accept actions) keeps the current memory unchanged, and
+    /// `Quarantine` keeps the row but applies suppression. The PR transition
+    /// and mutation share one SQLite transaction, so neither can commit alone.
+    pub fn decide_pending_memory_mutation(
+        &self,
+        id: &str,
+        action: MemoryPrAction,
+    ) -> Result<Option<PendingMemoryMutationDecision>> {
+        let pr = self
+            .get_memory_pr(id)?
+            .ok_or_else(|| StorageError::NotFound(id.to_string()))?;
+        let Some(pending_action) = pr
+            .diff
+            .get("pendingAction")
+            .and_then(serde_json::Value::as_str)
+        else {
+            return Ok(None);
+        };
+        let subject_id = pr.subject_id.clone().ok_or_else(|| {
+            StorageError::Init(format!("pending mutation PR {id} has no subject"))
+        })?;
+        let new_status = action.resulting_status().ok_or_else(|| {
+            StorageError::Init("ask_agent_why is read-only and decides nothing".into())
+        })?;
+        let decision = serde_json::to_value(action)
+            .ok()
+            .and_then(|v| v.as_str().map(str::to_string))
+            .unwrap_or_default();
+        let now = Utc::now();
+
+        let effect = {
+            let mut writer = self
+                .writer
+                .lock()
+                .map_err(|_| StorageError::Init("Writer lock poisoned".into()))?;
+            let tx = writer.transaction()?;
+
+            let changed = tx.execute(
+                "UPDATE memory_prs SET status = ?1, decision = ?2, decided_at = ?3
+                 WHERE id = ?4 AND status = 'pending'",
+                params![new_status.as_str(), decision, now.to_rfc3339(), id],
+            )?;
+            if changed == 0 {
+                return Err(StorageError::Init(format!(
+                    "memory PR {id} is already decided and cannot be re-decided"
+                )));
+            }
+
+            let effect = match action {
+                MemoryPrAction::Forget if matches!(pending_action, "purge" | "delete") => {
+                    let deleted =
+                        Self::purge_node_in_transaction(&tx, &subject_id, now, true)?.is_some();
+                    if !deleted {
+                        return Err(StorageError::NotFound(subject_id.to_string()));
+                    }
+                    PendingMemoryMutationEffect::Purged
+                }
+                MemoryPrAction::Forget | MemoryPrAction::Quarantine => {
+                    let changed = tx.execute(
+                        "UPDATE knowledge_nodes SET
+                            last_accessed = ?1,
+                            suppression_count = COALESCE(suppression_count, 0) + 1,
+                            suppressed_at = ?1,
+                            retrieval_strength = MAX(0.05, retrieval_strength - 0.35),
+                            retention_strength = MAX(0.05, retention_strength - 0.20),
+                            stability = stability * 0.4
+                         WHERE id = ?2",
+                        params![now.to_rfc3339(), &subject_id],
+                    )?;
+                    if changed == 0 {
+                        return Err(StorageError::NotFound(subject_id.to_string()));
+                    }
+                    Self::invalidate_replay_evidence_for_memory_in_transaction(
+                        &tx,
+                        &subject_id,
+                        crate::storage::ReplayInvalidationReason::Suppressed,
+                    )?;
+                    PendingMemoryMutationEffect::Suppressed
+                }
+                _ => PendingMemoryMutationEffect::Kept,
+            };
+
+            tx.commit()?;
+            effect
+        };
+
+        let mut pr = pr;
+        pr.status = new_status;
+        pr.decision = Some(action);
+        pr.decided_at = Some(now.to_rfc3339());
+        if effect == PendingMemoryMutationEffect::Purged {
+            self.remove_purged_node_from_vector_index(&subject_id);
+        } else if effect == PendingMemoryMutationEffect::Suppressed {
+            let _ = self.log_access(&subject_id, "suppress");
+        }
+        Ok(Some(PendingMemoryMutationDecision { pr, effect }))
     }
 
     fn row_to_memory_pr(row: &rusqlite::Row) -> rusqlite::Result<MemoryPr> {

--- a/crates/vestige-mcp/src/dashboard/handlers.rs
+++ b/crates/vestige-mcp/src/dashboard/handlers.rs
@@ -2237,17 +2237,31 @@ pub async fn act_on_memory_pr(
         })));
     }
 
-    let decided = state
+    let pending_decision = state
         .storage
-        .decide_memory_pr(&id, action)
-        .map_err(|_| StatusCode::NOT_FOUND)?;
+        .decide_pending_memory_mutation(&id, action)
+        .map_err(|e| {
+            tracing::warn!("failed to decide pending memory mutation {id}: {e}");
+            StatusCode::CONFLICT
+        })?;
+    let (decided, pending_effect) = match pending_decision {
+        Some(decision) => (decision.pr, Some(decision.effect)),
+        None => (
+            state
+                .storage
+                .decide_memory_pr(&id, action)
+                .map_err(|_| StatusCode::NOT_FOUND)?,
+            None,
+        ),
+    };
 
     // B1: an accept action (promote/merge/supersede) must RELEASE the subject
     // memory from quarantine — gate_writes suppressed it, so deciding the PR
     // without un-suppressing would leave it "promoted" yet still held out of
     // retrieval. Forget/Quarantine intentionally keep it suppressed.
     let mut released = false;
-    if action.releases_memory()
+    if pending_effect.is_none()
+        && action.releases_memory()
         && let Some(subject_id) = decided.subject_id.as_deref()
     {
         // Use the UNCONDITIONAL quarantine release, not reverse_suppression:
@@ -2276,6 +2290,33 @@ pub async fn act_on_memory_pr(
         }
     }
 
+    if let Some(effect) = pending_effect {
+        use vestige_core::PendingMemoryMutationEffect::*;
+        match effect {
+            Kept => {}
+            Purged => state.emit(VestigeEvent::MemoryDeleted {
+                id: decided.subject_id.clone().unwrap_or_default(),
+                timestamp: Utc::now(),
+            }),
+            Suppressed => {
+                if let Some(subject_id) = decided.subject_id.as_deref()
+                    && let Ok(Some(node)) = state.storage.get_node(subject_id)
+                {
+                    state.emit(VestigeEvent::MemorySuppressed {
+                        id: node.id,
+                        suppression_count: node.suppression_count,
+                        estimated_cascade: 0,
+                        reversible_until: node
+                            .suppressed_at
+                            .map(|at| at + Duration::hours(24))
+                            .unwrap_or_else(Utc::now),
+                        timestamp: Utc::now(),
+                    });
+                }
+            }
+        }
+    }
+
     state.emit(VestigeEvent::MemoryPrDecided {
         id: decided.id.clone(),
         decision: decided
@@ -2290,6 +2331,17 @@ pub async fn act_on_memory_pr(
     let mut out = serde_json::to_value(&decided).unwrap_or_default();
     if let Some(obj) = out.as_object_mut() {
         obj.insert("subjectReleased".to_string(), serde_json::json!(released));
+        if let Some(effect) = pending_effect {
+            let label = match effect {
+                vestige_core::PendingMemoryMutationEffect::Kept => "kept",
+                vestige_core::PendingMemoryMutationEffect::Purged => "purged",
+                vestige_core::PendingMemoryMutationEffect::Suppressed => "suppressed",
+            };
+            obj.insert(
+                "pendingMutationEffect".to_string(),
+                serde_json::json!(label),
+            );
+        }
     }
     Ok(Json(out))
 }
@@ -2949,6 +3001,116 @@ mod tests {
             })
             .unwrap();
         node.id
+    }
+
+    fn open_pending_mutation_pr(
+        storage: &Arc<Storage>,
+        node_id: &str,
+        pending_action: &str,
+    ) -> String {
+        let tool = if pending_action == "suppress" {
+            "suppress"
+        } else {
+            "memory"
+        };
+        let args = if pending_action == "suppress" {
+            serde_json::json!({ "id": node_id })
+        } else {
+            serde_json::json!({
+                "action": pending_action,
+                "id": node_id,
+                "confirm": true
+            })
+        };
+        crate::trace_recorder::gate_pending_memory_mutation(
+            storage,
+            None,
+            "run_review_outcome",
+            tool,
+            &Some(args),
+            vestige_core::ReviewMode::RiskGated,
+        )
+        .unwrap()
+        .expect("pending mutation should open a PR");
+        storage
+            .list_memory_prs(Some(vestige_core::MemoryPrStatus::Pending), 10)
+            .unwrap()[0]
+            .id
+            .clone()
+    }
+
+    #[tokio::test]
+    async fn pending_purge_forget_approves_and_executes_mutation() {
+        let (_dir, storage) = seed_storage();
+        let node_id = ingest(&storage, "purge after explicit review");
+        let pr_id = open_pending_mutation_pr(&storage, &node_id, "purge");
+        let state = AppState::new(storage.clone(), None);
+
+        let Json(body) = act_on_memory_pr(State(state), Path((pr_id, "forget".to_string())))
+            .await
+            .unwrap();
+
+        assert_eq!(body["pendingMutationEffect"], "purged");
+        assert!(storage.get_node(&node_id).unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn pending_purge_promote_keeps_memory() {
+        let (_dir, storage) = seed_storage();
+        let node_id = ingest(&storage, "keep after explicit review");
+        let pr_id = open_pending_mutation_pr(&storage, &node_id, "purge");
+        let state = AppState::new(storage.clone(), None);
+
+        let Json(body) = act_on_memory_pr(State(state), Path((pr_id, "promote".to_string())))
+            .await
+            .unwrap();
+
+        assert_eq!(body["pendingMutationEffect"], "kept");
+        assert!(storage.get_node(&node_id).unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn pending_purge_quarantine_keeps_but_suppresses_memory() {
+        let (_dir, storage) = seed_storage();
+        let node_id = ingest(&storage, "quarantine after explicit review");
+        let pr_id = open_pending_mutation_pr(&storage, &node_id, "purge");
+        let state = AppState::new(storage.clone(), None);
+
+        let Json(body) = act_on_memory_pr(State(state), Path((pr_id, "quarantine".to_string())))
+            .await
+            .unwrap();
+
+        assert_eq!(body["pendingMutationEffect"], "suppressed");
+        assert_eq!(
+            storage
+                .get_node(&node_id)
+                .unwrap()
+                .unwrap()
+                .suppression_count,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_suppress_forget_approves_and_executes_suppression() {
+        let (_dir, storage) = seed_storage();
+        let node_id = ingest(&storage, "suppress after explicit review");
+        let pr_id = open_pending_mutation_pr(&storage, &node_id, "suppress");
+        let state = AppState::new(storage.clone(), None);
+
+        let Json(body) = act_on_memory_pr(State(state), Path((pr_id, "forget".to_string())))
+            .await
+            .unwrap();
+
+        assert_eq!(body["pendingMutationEffect"], "suppressed");
+        assert_eq!(
+            storage
+                .get_node(&node_id)
+                .unwrap()
+                .unwrap()
+                .suppression_count,
+            1
+        );
     }
 
     #[test]

--- a/crates/vestige-mcp/src/server.rs
+++ b/crates/vestige-mcp/src/server.rs
@@ -520,6 +520,57 @@ impl McpServer {
             );
         }
 
+        // Destructive and suppressive mutations must be reviewed before their
+        // tool implementation can remove a node or change its retrieval
+        // influence. This deliberately runs after the opening trace event but
+        // before dispatch. Safety is intentionally independent of VESTIGE_TRACE:
+        // disabling the recorder must not silently permit destructive writes.
+        // Normal calls continue to #150's unchanged record_result -> receipt ->
+        // post-commit gate -> event order when tracing is enabled.
+        let mode = crate::trace_recorder::read_review_mode(&self.storage);
+        let pending = crate::trace_recorder::gate_pending_memory_mutation(
+            &self.storage,
+            self.event_tx.as_ref(),
+            &trace_run_id,
+            &request.name,
+            &saved_args,
+            mode,
+        );
+        match pending {
+            Ok(Some(content)) => {
+                // The pre-gate already emitted MemoryPrOpened. `success`
+                // is false, so emitting the normal tool event cannot claim
+                // a deletion or suppression that did not happen.
+                self.emit_tool_event(&request.name, &saved_args, &content);
+                let call_result = CallToolResult {
+                    content: vec![crate::protocol::messages::ToolResultContent {
+                        content_type: "text".to_string(),
+                        text: serde_json::to_string_pretty(&content)
+                            .unwrap_or_else(|_| content.to_string()),
+                    }],
+                    structured_content: Some(content),
+                    is_error: Some(false),
+                };
+                return serde_json::to_value(call_result)
+                    .map_err(|e| JsonRpcError::internal_error(&e.to_string()));
+            }
+            Ok(None) => {}
+            Err(error) => {
+                let error_content = serde_json::json!({ "error": error });
+                let call_result = CallToolResult {
+                    content: vec![crate::protocol::messages::ToolResultContent {
+                        content_type: "text".to_string(),
+                        text: serde_json::to_string_pretty(&error_content)
+                            .unwrap_or_else(|_| error_content.to_string()),
+                    }],
+                    structured_content: Some(error_content),
+                    is_error: Some(true),
+                };
+                return serde_json::to_value(call_result)
+                    .map_err(|e| JsonRpcError::internal_error(&e.to_string()));
+            }
+        }
+
         // `mut` so the post-call block can annotate a successful result with any
         // Memory PRs or receipts it attaches to a successful result.
         let mut result = match request.name.as_str() {
@@ -2032,21 +2083,14 @@ mod tests {
         );
     }
 
-    /// A destructive write is necessarily post-commit in this gate: the node
-    /// has already been purged when the gate observes the result. The response
-    /// must therefore say that it was recorded for review, never that it is
-    /// quarantined or held.
+    /// Deprecated aliases share the same destructive policy; otherwise an
+    /// older MCP client could bypass the canonical `memory` pre-gate.
     #[tokio::test]
-    async fn destructive_write_is_recorded_for_review_not_reported_as_held() {
+    async fn legacy_delete_knowledge_is_pre_gated_on_the_real_mcp_path() {
         let (storage, _dir) = test_storage().await;
-        std::fs::write(
-            storage.data_dir().join("review_mode.json"),
-            r#"{"mode":"paranoid"}"#,
-        )
-        .unwrap();
         let node = storage
             .ingest(vestige_core::IngestInput {
-                content: "Memory scheduled for destructive review.".to_string(),
+                content: "Memory preserved through the legacy delete alias.".to_string(),
                 node_type: "fact".to_string(),
                 ..Default::default()
             })
@@ -2062,21 +2106,23 @@ mod tests {
             .handle_request(make_request(
                 "tools/call",
                 Some(serde_json::json!({
-                    "name": "memory",
+                    "name": "delete_knowledge",
                     "arguments": {
-                        "action": "purge",
                         "id": node.id.clone(),
                         "confirm": true,
-                        "reason": "exercise the post-commit review notice"
+                        "reason": "exercise the pre-execution review gate"
                     }
                 })),
             ))
             .await
             .unwrap();
-        assert!(response.error.is_none(), "purge should succeed");
         assert!(
-            storage.get_node(&node.id).unwrap().is_none(),
-            "the post-commit gate cannot claim to have prevented the purge"
+            response.error.is_none(),
+            "pending review is a valid MCP result"
+        );
+        assert!(
+            storage.get_node(&node.id).unwrap().is_some(),
+            "the legacy alias must not bypass pre-execution review"
         );
 
         let structured = response
@@ -2084,13 +2130,199 @@ mod tests {
             .as_ref()
             .and_then(|result| result.get("structuredContent"))
             .expect("structured tool result");
-        assert_eq!(structured["memoryPrs"][0]["held"], false);
-        let notice = structured["memoryPrNotice"]
-            .as_str()
-            .expect("destructive write notice");
-        assert!(notice.contains("already applied but recorded for review"));
-        assert!(notice.contains("nothing is held"));
-        assert!(!notice.contains("quarantined until"));
+        assert_eq!(structured["action"], "delete_pending_review");
+        assert_eq!(structured["pendingReview"], true);
+        let prs = storage
+            .list_memory_prs(Some(vestige_core::MemoryPrStatus::Pending), 10)
+            .unwrap();
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].diff["pendingAction"], "delete");
+    }
+
+    /// Regression #117: purge must be intercepted on the real MCP path before
+    /// `memory_unified::execute` can delete the node. The response and dashboard
+    /// event must describe a pending review, not a completed deletion.
+    #[tokio::test]
+    async fn destructive_purge_is_pre_gated_on_the_real_mcp_path() {
+        use crate::dashboard::events::VestigeEvent;
+        use std::time::Duration;
+        use vestige_core::MemoryPrStatus;
+
+        let (storage, _dir) = test_storage().await;
+        let node = storage
+            .ingest(vestige_core::IngestInput {
+                content: "Memory that must survive pre-execution review.".to_string(),
+                node_type: "fact".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let (event_tx, mut events) = tokio::sync::broadcast::channel(16);
+        let cognitive = Arc::new(Mutex::new(CognitiveEngine::new()));
+        let mut server = McpServer::new_with_events(storage.clone(), cognitive, event_tx);
+        server
+            .handle_request(make_request("initialize", Some(init_params())))
+            .await;
+
+        let response = server
+            .handle_request(make_request(
+                "tools/call",
+                Some(serde_json::json!({
+                    "name": "memory",
+                    "arguments": {
+                        "action": "purge",
+                        "id": node.id,
+                        "confirm": true,
+                        "reason": "exercise the pre-execution review gate",
+                        "runId": "run_pre_execution_purge"
+                    }
+                })),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            response.error.is_none(),
+            "a pending-review response is a valid MCP result"
+        );
+
+        let structured = response
+            .result
+            .as_ref()
+            .and_then(|result| result.get("structuredContent"))
+            .expect("structured tool result");
+        assert_eq!(structured["success"], false);
+        assert_eq!(structured["pendingReview"], true);
+        assert_eq!(structured["action"], "purge_pending_review");
+        assert_eq!(structured["nodeId"], node.id);
+        assert!(
+            storage.get_node(&node.id).unwrap().is_some(),
+            "pre-execution gate must prevent the purge"
+        );
+
+        let prs = storage
+            .list_memory_prs(Some(MemoryPrStatus::Pending), 10)
+            .unwrap();
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].diff["pendingAction"], "purge");
+        assert_eq!(prs[0].diff["node"]["deleted"], false);
+
+        let mut saw_pr_opened = false;
+        for _ in 0..8 {
+            match tokio::time::timeout(Duration::from_millis(100), events.recv()).await {
+                Ok(Ok(VestigeEvent::MemoryPrOpened { .. })) => {
+                    saw_pr_opened = true;
+                }
+                Ok(Ok(VestigeEvent::MemoryDeleted { .. })) => {
+                    panic!("a blocked purge must not emit MemoryDeleted")
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(_)) | Err(_) => break,
+            }
+        }
+        assert!(saw_pr_opened, "pre-gate must announce the opened Memory PR");
+    }
+
+    /// Suppression changes retrieval influence immediately, so it is subject to
+    /// the same production pre-execution gate as an irreversible purge.
+    #[tokio::test]
+    async fn suppress_is_pre_gated_on_the_real_mcp_path() {
+        use vestige_core::MemoryPrStatus;
+
+        let (storage, _dir) = test_storage().await;
+        let node = storage
+            .ingest(vestige_core::IngestInput {
+                content: "Memory that must not be inhibited before review.".to_string(),
+                node_type: "fact".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let cognitive = Arc::new(Mutex::new(CognitiveEngine::new()));
+        let mut server = McpServer::new(storage.clone(), cognitive);
+        server
+            .handle_request(make_request("initialize", Some(init_params())))
+            .await;
+
+        let response = server
+            .handle_request(make_request(
+                "tools/call",
+                Some(serde_json::json!({
+                    "name": "suppress",
+                    "arguments": { "id": node.id, "reason": "requires review first" }
+                })),
+            ))
+            .await
+            .unwrap();
+        assert!(response.error.is_none());
+
+        let structured = response
+            .result
+            .as_ref()
+            .and_then(|result| result.get("structuredContent"))
+            .expect("structured tool result");
+        assert_eq!(structured["action"], "suppress_pending_review");
+        assert_eq!(structured["pendingReview"], true);
+        assert_eq!(
+            storage
+                .get_node(&node.id)
+                .unwrap()
+                .unwrap()
+                .suppression_count,
+            0,
+            "pre-execution gate must not change retrieval influence"
+        );
+        let prs = storage
+            .list_memory_prs(Some(MemoryPrStatus::Pending), 10)
+            .unwrap();
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].diff["pendingAction"], "suppress");
+    }
+
+    /// Fast mode is the documented explicit opt-out: it keeps legacy direct
+    /// execution instead of manufacturing a pending review.
+    #[tokio::test]
+    async fn fast_mode_allows_destructive_call_on_the_real_mcp_path() {
+        let (storage, _dir) = test_storage().await;
+        std::fs::write(
+            storage.data_dir().join("review_mode.json"),
+            r#"{"mode":"fast"}"#,
+        )
+        .unwrap();
+        let node = storage
+            .ingest(vestige_core::IngestInput {
+                content: "Fast mode purge target.".to_string(),
+                node_type: "fact".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let cognitive = Arc::new(Mutex::new(CognitiveEngine::new()));
+        let mut server = McpServer::new(storage.clone(), cognitive);
+        server
+            .handle_request(make_request("initialize", Some(init_params())))
+            .await;
+
+        let response = server
+            .handle_request(make_request(
+                "tools/call",
+                Some(serde_json::json!({
+                    "name": "memory",
+                    "arguments": { "action": "purge", "id": node.id, "confirm": true }
+                })),
+            ))
+            .await
+            .unwrap();
+        let structured = response
+            .result
+            .as_ref()
+            .and_then(|result| result.get("structuredContent"))
+            .expect("structured tool result");
+        assert_eq!(structured["success"], true);
+        assert!(storage.get_node(&node.id).unwrap().is_none());
+        assert!(
+            storage
+                .list_memory_prs(Some(vestige_core::MemoryPrStatus::Pending), 10)
+                .unwrap()
+                .is_empty(),
+            "Fast mode must not pre-gate the mutation"
+        );
     }
 
     /// Dashboard events must not announce a write as landed before the Memory

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -89,15 +89,20 @@ The mode is stored in `<data_dir>/review_mode.json` and set from the dashboard
 (`POST /api/memory-prs/mode`). A missing or corrupt file falls back to
 `risk_gated` — a bad file can never silently disable gating.
 
-When a write is gated, the tool response carries `memoryPrs` and a
-`memoryPrNotice` telling the agent whether the write is **quarantined until
-decided** or (for destructive writes, which have already been applied)
-**recorded for review** with nothing held.
+When a normal risky write is gated, the tool response carries `memoryPrs` and a
+`memoryPrNotice` describing the quarantine. Confirmed purge/delete calls and
+direct suppression are different: in `risk_gated` and `paranoid` modes Vestige
+durably opens a pending Memory PR **before** the mutation and returns without
+changing the memory. If the PR cannot be saved, the call fails closed.
 
-> **Note:** gating rides on the trace system. Setting `VESTIGE_TRACE_ENABLED=0`
-> disables the black box **and Memory PR gating together** — a Memory PR is an
-> auditable trace artifact, so turning off tracing turns off the gate. Leave
-> tracing on (the default) if you rely on review modes.
+For a pending destructive PR, `forget` approves and executes the requested
+purge or suppression, `promote` keeps the memory unchanged, and `quarantine`
+keeps the row but suppresses it. `fast` remains the explicit direct-execution
+opt-out.
+
+> **Note:** `VESTIGE_TRACE=0` disables Black Box trace/receipt recording, but it
+> does not disable this pre-execution safety gate. Review mode, not tracing,
+> controls destructive mutation policy.
 
 ---
 


### PR DESCRIPTION
Fixes #117.

## What changed

- Runs `gate_pending_memory_mutation` in the real MCP `tools/call` path before confirmed `memory` purge/delete, the deprecated delete alias, and direct suppression.
- Risk-gated/paranoid calls now durably open a pending Memory PR and return without mutating the memory; persistence failure fails closed. Fast mode remains the explicit direct-execution opt-out.
- Keeps #150's existing non-destructive order unchanged: opening trace -> tool execution -> result trace -> receipt -> post-commit write gate -> dashboard event.
- Makes safety independent of `VESTIGE_TRACE=0`; disabling Black Box recording does not silently disable destructive review.
- Applies review outcomes atomically with the PR decision: `forget` executes the requested purge/suppression, `promote` keeps the memory, and `quarantine` keeps but suppresses it.

## Verification

- `cargo test -p vestige-mcp --lib -- --test-threads=1` — 513 passed
- `cargo test -p vestige-core --lib memory_pr -- --test-threads=1` — passed
- `cargo clippy -p vestige-core -p vestige-mcp --lib -- -D warnings` — passed
- touched Rust files checked with rustfmt; `git diff --check origin/main...HEAD` — passed

Repository-wide rustfmt still reports pre-existing current-main drift in unrelated backfill, Redmine, and FTS files; those files are not changed here.
