### PR TITLE
fix(memory): stop as-of resurrection and make neverAccessed honest

### DIFF
--- a/crates/vestige-core/src/lib.rs
+++ b/crates/vestige-core/src/lib.rs
@@ -182,6 +182,7 @@ pub use trace::{
 
 // Storage layer
 pub use storage::{
+    ACCESS_LOG_RETENTION_DAYS,
     AgentRunSummary,
     ClassificationResult,
     CompositionEventRecord,
@@ -206,6 +207,7 @@ pub use storage::{
     FrozenReplayItem,
     HealthStatus,
     HygieneNodeSummary,
+    HygieneSnapshot,
     InsightRecord,
     IntentionRecord,
     LocalMemoryStore,
@@ -267,6 +269,7 @@ pub use storage::{
     SynapticIngestOutcome,
     SynapticIngestRequest,
     SynapticSignalSnapshot,
+    TagVocabulary,
     ablate_frozen_context,
     private_evidence_digest,
     replay_evidence_slot,

--- a/crates/vestige-core/src/memory/node.rs
+++ b/crates/vestige-core/src/memory/node.rs
@@ -386,6 +386,13 @@ pub struct IngestInput {
     /// When this knowledge stops being valid
     #[serde(skip_serializing_if = "Option::is_none")]
     pub valid_until: Option<DateTime<Utc>>,
+    /// True when `valid_from` was inferred from prose (an "as of YYYY-MM-DD"
+    /// phrase) rather than supplied explicitly by the caller. Inferred
+    /// validity may stamp a newly created node but must never rewrite an
+    /// existing node's window. Internal flag set by smart ingest; never part
+    /// of the wire format.
+    #[serde(skip)]
+    pub validity_inferred: bool,
     /// Structured provenance for connector-ingested records (#57). When set
     /// with a `(source_system, source_id)` key, callers should route through
     /// `upsert_by_source` for idempotent sync rather than plain `ingest`.
@@ -404,6 +411,7 @@ impl Default for IngestInput {
             tags: vec![],
             valid_from: None,
             valid_until: None,
+            validity_inferred: false,
             source_envelope: None,
         }
     }

--- a/crates/vestige-core/src/storage/migrations.rs
+++ b/crates/vestige-core/src/storage/migrations.rs
@@ -1380,9 +1380,12 @@ INSERT OR IGNORE INTO embedding_profile_manifests (
 UPDATE schema_version SET version = 28, applied_at = datetime('now');
 "#;
 
-/// V29: index the exact normalized scope expression used by scoped recall and
-/// hygiene/tag maintenance. The V27 data repair handles current databases;
-/// the expression preserves safe behavior for later direct/legacy blank rows.
+/// V29: index the exact normalized scope expression used by the hygiene/tag
+/// maintenance full-scope scans (`hygiene_snapshot`, `tag_vocabulary`, and
+/// `tag_mutation_state`). Scoped recall does NOT use this index — its scope
+/// filter is a per-id primary-key probe (`node_is_in_scope`). The V27 data
+/// repair handles current databases; the expression preserves safe behavior
+/// for later direct/legacy blank rows.
 const MIGRATION_V29_UP: &str = r#"
 CREATE INDEX IF NOT EXISTS idx_nodes_normalized_scope
     ON knowledge_nodes(COALESCE(NULLIF(trim(scope), ''), 'user'));
@@ -2748,6 +2751,65 @@ mod tests {
             .collect::<rusqlite::Result<_>>()
             .expect("collect scopes");
         assert_eq!(scopes, vec!["user", "user"]);
+    }
+
+    #[test]
+    fn v29_creates_the_normalized_scope_expression_index() {
+        let conn = rusqlite::Connection::open_in_memory().expect("open in-memory");
+        apply_migrations(&conn).expect("apply_migrations");
+
+        let index_sql: Vec<String> = conn
+            .prepare(
+                "SELECT sql FROM sqlite_master
+                 WHERE type='index' AND name='idx_nodes_normalized_scope'",
+            )
+            .expect("prepare index lookup")
+            .query_map([], |row| row.get(0))
+            .expect("read index sql")
+            .collect::<rusqlite::Result<_>>()
+            .expect("collect index sql");
+        assert_eq!(
+            index_sql.len(),
+            1,
+            "V29 must create exactly one idx_nodes_normalized_scope"
+        );
+        assert!(
+            index_sql[0].contains("COALESCE(NULLIF(trim(scope), ''), 'user')"),
+            "the index expression must match the hygiene/tag scan predicate byte-for-byte, got: {}",
+            index_sql[0]
+        );
+    }
+
+    #[test]
+    fn v29_index_serves_the_scoped_hygiene_scan_query_plan() {
+        let conn = rusqlite::Connection::open_in_memory().expect("open in-memory");
+        apply_migrations(&conn).expect("apply_migrations");
+        conn.execute(
+            "INSERT INTO knowledge_nodes (id, content, node_type, created_at, updated_at, last_accessed, scope)
+             VALUES ('plan-a', 'row', 'fact', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'user'),
+                    ('plan-b', 'row', 'fact', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'project-a'),
+                    ('plan-c', 'row', 'fact', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', NULL)",
+            [],
+        )
+        .expect("seed scoped rows");
+
+        // The scoped hygiene/tag scans all filter on this exact expression.
+        let plan: Vec<String> = conn
+            .prepare(
+                "EXPLAIN QUERY PLAN
+                 SELECT id FROM knowledge_nodes
+                 WHERE COALESCE(NULLIF(trim(scope), ''), 'user') = ?1",
+            )
+            .expect("prepare query plan")
+            .query_map(["user"], |row| row.get::<_, String>(3))
+            .expect("read query plan")
+            .collect::<rusqlite::Result<_>>()
+            .expect("collect query plan");
+        assert!(
+            plan.iter()
+                .any(|step| step.contains("idx_nodes_normalized_scope")),
+            "the scoped hygiene scan must use the V29 expression index, got plan: {plan:?}"
+        );
     }
 
     #[test]

--- a/crates/vestige-core/src/storage/mod.rs
+++ b/crates/vestige-core/src/storage/mod.rs
@@ -48,14 +48,15 @@ pub use replay_store::{
     replay_evidence_slot, replay_idempotency_key, replay_policy_digest,
 };
 pub use sqlite::{
-    CompositionEventRecord, CompositionMemberRecord, CompositionNeighborRecord,
-    CompositionOutcomeRecord, ConnectionRecord, ConnectorCursor, ConsolidationHistoryRecord,
-    DEFAULT_MEMORY_SCOPE, DreamHistoryRecord, EmbeddingProfileIntegrityManifest,
-    EmbeddingProfileMigrationNodeCheckpoint, EmbeddingProfileMigrationRecord,
-    EmbeddingProfileVector, FilePortableSyncBackend, HygieneNodeSummary, InsightRecord,
-    IntentionRecord, NeverComposedCandidate, PortableSyncBackend, PortableSyncReport,
-    ReconcileReport, Result, SmartIngestResult, SourceUpsertOutcome, SourceUpsertResult,
-    SqliteMemoryStore, StateTransitionRecord, StorageError,
+    ACCESS_LOG_RETENTION_DAYS, CompositionEventRecord, CompositionMemberRecord,
+    CompositionNeighborRecord, CompositionOutcomeRecord, ConnectionRecord, ConnectorCursor,
+    ConsolidationHistoryRecord, DEFAULT_MEMORY_SCOPE, DreamHistoryRecord,
+    EmbeddingProfileIntegrityManifest, EmbeddingProfileMigrationNodeCheckpoint,
+    EmbeddingProfileMigrationRecord, EmbeddingProfileVector, FilePortableSyncBackend,
+    HygieneNodeSummary, HygieneSnapshot, InsightRecord, IntentionRecord, NeverComposedCandidate,
+    PortableSyncBackend, PortableSyncReport, ReconcileReport, Result, SmartIngestResult,
+    SourceUpsertOutcome, SourceUpsertResult, SqliteMemoryStore, StateTransitionRecord,
+    StorageError, TagVocabulary,
 };
 pub use synaptic_store::{
     DurableSynapticCapture, DurableSynapticPairReceipt, SYNAPTIC_CAPTURE_ALGORITHM_V1,

--- a/crates/vestige-core/src/storage/sqlite.rs
+++ b/crates/vestige-core/src/storage/sqlite.rs
@@ -20492,6 +20492,58 @@ mod tests {
 
     #[cfg(all(feature = "embeddings", feature = "vector-search"))]
     #[test]
+    fn inferred_as_of_must_not_resurrect_an_expired_similar_node() {
+        let dir = tempdir().unwrap();
+        let storage = storage_with_marker_gate_runtime(&dir);
+        let expired_from = Utc::now() - Duration::days(90);
+        let expired_until = Utc::now() - Duration::days(7);
+        let target = storage
+            .ingest(IngestInput {
+                content: "alpha deployment policy is retries with backoff".to_string(),
+                valid_from: Some(expired_from),
+                valid_until: Some(expired_until),
+                ..Default::default()
+            })
+            .unwrap();
+        assert!(
+            !storage
+                .get_node(&target.id)
+                .unwrap()
+                .unwrap()
+                .is_currently_valid(),
+            "fixture must start expired"
+        );
+
+        // Live #170 failure: inferred validFrom + PEG update used to
+        // REPLACE valid_until with NULL and un-expire the similar row.
+        let result = storage
+            .smart_ingest(IngestInput {
+                content: "alpha deployment policy is retries with backoff as of 2026-03-04"
+                    .to_string(),
+                valid_from: Some(Utc::now() - Duration::days(10)),
+                validity_inferred: true,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(result.decision, "reinforce");
+        assert_eq!(result.node.id, target.id);
+
+        let node = storage.get_node(&target.id).unwrap().unwrap();
+        assert_eq!(
+            node.valid_from.map(|value| value.to_rfc3339()),
+            Some(expired_from.to_rfc3339()),
+            "inferred as-of must not move the expired node's valid_from"
+        );
+        assert_eq!(
+            node.valid_until.map(|value| value.to_rfc3339()),
+            Some(expired_until.to_rfc3339()),
+            "inferred as-of must not un-expire the similar node"
+        );
+        assert!(!node.is_currently_valid());
+    }
+
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    #[test]
     fn explicit_valid_from_on_reinforce_updates_without_clearing_valid_until() {
         let dir = tempdir().unwrap();
         let storage = storage_with_marker_gate_runtime(&dir);

--- a/crates/vestige-core/src/storage/sqlite.rs
+++ b/crates/vestige-core/src/storage/sqlite.rs
@@ -100,6 +100,22 @@ pub type Result<T> = std::result::Result<T, StorageError>;
 pub const DEFAULT_MEMORY_SCOPE: &str = "user";
 const MAX_TAG_MUTATION_MEMORIES: usize = 50_000;
 const MAX_TAG_MUTATION_AUDIT_BYTES: usize = 16 * 1024 * 1024;
+/// Retention window for `memory_access_log` rows. `prune_access_log` deletes
+/// everything older on every consolidation, so any "never accessed" claim is
+/// only meaningful for memories created inside this window.
+pub const ACCESS_LOG_RETENTION_DAYS: i64 = 90;
+/// Cap on the malformed-row id list surfaced by [`HygieneSnapshot`].
+const MAX_MALFORMED_TAG_ROW_IDS: usize = 50;
+
+#[cfg(test)]
+thread_local! {
+    /// Test-only fail point armed by regression tests to prove the tag
+    /// UPDATE loop and its audit INSERT share one SQLite transaction: an
+    /// injected failure between them must roll back both. Invisible in
+    /// release builds.
+    static FAIL_TAG_MUTATION_BEFORE_AUDIT: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
+}
 type TagMutationState = (
     std::collections::BTreeMap<String, usize>,
     usize,
@@ -121,7 +137,42 @@ pub struct HygieneNodeSummary {
     pub superseded: bool,
     pub content_bytes: usize,
     pub content_preview: String,
+    /// No access evidence exists AND the memory was created inside the
+    /// retained access-log window, so the absence of log rows is meaningful.
     pub never_accessed: bool,
+    /// No access evidence exists but the memory predates the retained
+    /// access-log window: pruning makes past access unknowable, so this row
+    /// must never be claimed as never-accessed.
+    pub access_unknown: bool,
+}
+
+/// Full hygiene population plus row-corruption findings. Malformed rows are
+/// tolerated (mirroring `row_to_node`) and reported instead of aborting the
+/// whole stats view, because hand-edited stores are exactly where hygiene
+/// tooling is needed most.
+#[derive(Debug, Clone)]
+pub struct HygieneSnapshot {
+    pub nodes: Vec<HygieneNodeSummary>,
+    /// Rows whose stored `tags` column is NULL or unparseable JSON; their
+    /// tags are treated as empty in `nodes`.
+    pub malformed_tag_rows: usize,
+    /// Capped id list for the malformed rows (first
+    /// [`MAX_MALFORMED_TAG_ROW_IDS`] in id order).
+    pub malformed_tag_row_ids: Vec<String>,
+    pub malformed_tag_row_ids_truncated: bool,
+    /// Rows whose nullable `retention_strength` was NULL and fell back to the
+    /// schema default of 1.0.
+    pub defaulted_retention_rows: usize,
+}
+
+/// Exact tag vocabulary for one scope plus the count of stored tags that were
+/// skipped because they exceed the 200-character similarity safety limit.
+/// Overlong stored tags degrade gracefully (skip-and-count) instead of
+/// disabling suggestions for the whole scope.
+#[derive(Debug, Clone)]
+pub struct TagVocabulary {
+    pub tags: Vec<String>,
+    pub skipped_overlong: usize,
 }
 
 fn temporal_candidate_is_eligible(
@@ -300,6 +351,10 @@ pub struct SmartIngestResult {
     /// Full updated content after a merge/append/context write.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub merge_preview: Option<String>,
+    /// World-time close stamped onto a newly created dated claim that is
+    /// already superseded by a currently-valid fact starting later.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_closed_until: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -712,6 +767,7 @@ impl SqliteMemoryStore {
             previous_content: None,
             merged_from: None,
             merge_preview: None,
+            auto_closed_until: None,
         })
     }
 
@@ -1884,6 +1940,11 @@ impl SqliteMemoryStore {
 
         // Build candidate memories
         let mut candidates: Vec<CandidateMemory> = Vec::new();
+        // The earliest currently-valid similar fact starting AFTER the
+        // incoming dated claim. When only such newer facts exclude every
+        // candidate, the incoming claim is a stale snapshot whose world time
+        // is already known to end where the newer fact begins.
+        let mut superseding_valid_from: Option<DateTime<Utc>> = None;
         for (node_id, _similarity) in similar.iter() {
             if excluded_node_ids.iter().any(|id| id == node_id) {
                 continue;
@@ -1902,6 +1963,13 @@ impl SqliteMemoryStore {
                     node.is_currently_valid(),
                     Utc::now(),
                 ) {
+                    if let (Some(incoming), Some(existing)) = (input.valid_from, node.valid_from)
+                        && incoming < existing
+                        && node.is_currently_valid()
+                        && superseding_valid_from.is_none_or(|earliest| existing < earliest)
+                    {
+                        superseding_valid_from = Some(existing);
+                    }
                     continue;
                 }
                 // Get embedding for this node
@@ -1936,25 +2004,44 @@ impl SqliteMemoryStore {
                 reason,
                 ..
             } => {
+                // A dated claim (explicit or inferred) that lost every
+                // candidate to a currently-valid newer fact is created as a
+                // closed historical snapshot, never as an open current fact.
+                // Undated content and explicitly bounded claims are untouched.
+                let auto_closed_until = superseding_valid_from
+                    .filter(|_| input.valid_from.is_some() && input.valid_until.is_none());
                 // Create new memory
-                let node = self.ingest_in_scope_with_secret_policy(input, scope, policy)?;
+                let mut node = self.ingest_in_scope_with_secret_policy(input, scope, policy)?;
+                if let Some(closes_at) = auto_closed_until {
+                    self.close_node_validity(&node.id, closes_at)?;
+                    let id = node.id.clone();
+                    node = self.get_node(&id)?.ok_or(StorageError::NotFound(id))?;
+                }
+                let mut reason = if related_memory_ids.is_empty() {
+                    format!("Created new memory: {:?}", reason)
+                } else {
+                    format!(
+                        "Created new memory: {:?}. Semantically similar (not linked): {:?}",
+                        reason, related_memory_ids
+                    )
+                };
+                if let Some(closes_at) = auto_closed_until {
+                    reason.push_str(&format!(
+                        ". Closed validity at {} because a currently-valid newer fact starts then",
+                        closes_at.to_rfc3339()
+                    ));
+                }
                 Ok(SmartIngestResult {
                     decision: "create".to_string(),
                     node,
                     superseded_id: None,
                     similarity: None,
                     prediction_error: Some(prediction_error),
-                    reason: if related_memory_ids.is_empty() {
-                        format!("Created new memory: {:?}", reason)
-                    } else {
-                        format!(
-                            "Created new memory: {:?}. Semantically similar (not linked): {:?}",
-                            reason, related_memory_ids
-                        )
-                    },
+                    reason,
                     previous_content: None,
                     merged_from: None,
                     merge_preview: None,
+                    auto_closed_until,
                 })
             }
             GateDecision::Update {
@@ -1963,12 +2050,16 @@ impl SqliteMemoryStore {
                 update_type,
                 prediction_error,
             } => {
+                // A prose-inferred "as of" date describes the incoming text
+                // only; it may stamp a NEW node but must never rewrite an
+                // existing node's window. Only explicit caller validity may.
+                let explicit_valid_from = input.valid_from.filter(|_| !input.validity_inferred);
                 match update_type {
                     UpdateType::Reinforce => {
-                        if input.valid_from.is_some() || input.valid_until.is_some() {
+                        if explicit_valid_from.is_some() || input.valid_until.is_some() {
                             self.update_node_validity(
                                 &target_id,
-                                input.valid_from,
+                                explicit_valid_from,
                                 input.valid_until,
                             )?;
                         }
@@ -1988,6 +2079,7 @@ impl SqliteMemoryStore {
                             previous_content: None,
                             merged_from: None,
                             merge_preview: None,
+                            auto_closed_until: None,
                         })
                     }
                     UpdateType::Merge | UpdateType::Append => {
@@ -2009,10 +2101,10 @@ impl SqliteMemoryStore {
                             &merged_content,
                             policy,
                         )?;
-                        if input.valid_from.is_some() || input.valid_until.is_some() {
+                        if explicit_valid_from.is_some() || input.valid_until.is_some() {
                             self.update_node_validity(
                                 &target_id,
-                                input.valid_from,
+                                explicit_valid_from,
                                 input.valid_until,
                             )?;
                         }
@@ -2032,6 +2124,7 @@ impl SqliteMemoryStore {
                             previous_content: Some(previous_content),
                             merged_from: Some(target_id),
                             merge_preview: Some(merged_content),
+                            auto_closed_until: None,
                         })
                     }
                     UpdateType::Replace => {
@@ -2046,10 +2139,10 @@ impl SqliteMemoryStore {
                             &input.content,
                             policy,
                         )?;
-                        if input.valid_from.is_some() || input.valid_until.is_some() {
+                        if explicit_valid_from.is_some() || input.valid_until.is_some() {
                             self.update_node_validity(
                                 &target_id,
-                                input.valid_from,
+                                explicit_valid_from,
                                 input.valid_until,
                             )?;
                         }
@@ -2067,6 +2160,7 @@ impl SqliteMemoryStore {
                             previous_content: Some(previous_content),
                             merged_from: Some(target_id),
                             merge_preview: Some(input.content),
+                            auto_closed_until: None,
                         })
                     }
                     UpdateType::AddContext => {
@@ -2084,10 +2178,10 @@ impl SqliteMemoryStore {
                             &merged_content,
                             policy,
                         )?;
-                        if input.valid_from.is_some() || input.valid_until.is_some() {
+                        if explicit_valid_from.is_some() || input.valid_until.is_some() {
                             self.update_node_validity(
                                 &target_id,
-                                input.valid_from,
+                                explicit_valid_from,
                                 input.valid_until,
                             )?;
                         }
@@ -2105,6 +2199,7 @@ impl SqliteMemoryStore {
                             previous_content: Some(previous_content),
                             merged_from: Some(target_id),
                             merge_preview: Some(merged_content),
+                            auto_closed_until: None,
                         })
                     }
                 }
@@ -2116,11 +2211,16 @@ impl SqliteMemoryStore {
                 prediction_error,
             } => {
                 // Close the old fact's world-time interval before demoting it.
-                // A dated replacement takes effect at its declared start;
-                // otherwise the supersession becomes effective now.
+                // An explicitly dated replacement takes effect at its declared
+                // start; otherwise — including a prose-inferred "as of" date,
+                // which must never backdate another node's expiry — the
+                // supersession becomes effective now.
                 self.close_node_validity(
                     &old_memory_id,
-                    input.valid_from.unwrap_or_else(Utc::now),
+                    input
+                        .valid_from
+                        .filter(|_| !input.validity_inferred)
+                        .unwrap_or_else(Utc::now),
                 )?;
                 self.demote_memory(&old_memory_id)?;
 
@@ -2137,6 +2237,7 @@ impl SqliteMemoryStore {
                     previous_content: None,
                     merged_from: None,
                     merge_preview: None,
+                    auto_closed_until: None,
                 })
             }
             GateDecision::Merge {
@@ -2161,6 +2262,7 @@ impl SqliteMemoryStore {
                     previous_content: None,
                     merged_from: None,
                     merge_preview: None,
+                    auto_closed_until: None,
                 })
             }
         }
@@ -2280,8 +2382,10 @@ impl SqliteMemoryStore {
         self.update_node_content_unchecked(id, new_content)
     }
 
-    /// Replace a node's declared world-time interval without changing its
-    /// project namespace or transaction-time history.
+    /// Update a node's declared world-time interval without changing its
+    /// project namespace or transaction-time history. A `None` bound keeps the
+    /// stored column: updating only `valid_from` never clears an existing
+    /// `valid_until`, and vice versa.
     pub fn update_node_validity(
         &self,
         id: &str,
@@ -2299,8 +2403,35 @@ impl SqliteMemoryStore {
             .writer
             .lock()
             .map_err(|_| StorageError::Init("Writer lock poisoned".into()))?;
+        // Validate the EFFECTIVE post-merge window under the writer lock so
+        // a partial update cannot invert a window against the stored bound.
+        let stored: Option<(Option<String>, Option<String>)> = writer
+            .query_row(
+                "SELECT valid_from, valid_until FROM knowledge_nodes WHERE id = ?1",
+                params![id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+        if let Some((stored_from, stored_until)) = stored {
+            let parse = |value: Option<String>| {
+                value.and_then(|value| {
+                    DateTime::parse_from_rfc3339(&value)
+                        .map(|dt| dt.with_timezone(&Utc))
+                        .ok()
+                })
+            };
+            let effective_from = valid_from.or_else(|| parse(stored_from));
+            let effective_until = valid_until.or_else(|| parse(stored_until));
+            if let (Some(from), Some(until)) = (effective_from, effective_until)
+                && until <= from
+            {
+                return Err(StorageError::InvalidTimestamp(
+                    "valid_until must be after valid_from".to_string(),
+                ));
+            }
+        }
         writer.execute(
-            "UPDATE knowledge_nodes SET valid_from = ?1, valid_until = ?2, updated_at = ?3 WHERE id = ?4",
+            "UPDATE knowledge_nodes SET valid_from = COALESCE(?1, valid_from), valid_until = COALESCE(?2, valid_until), updated_at = ?3 WHERE id = ?4",
             params![
                 valid_from.map(|value| value.to_rfc3339()),
                 valid_until.map(|value| value.to_rfc3339()),
@@ -5329,9 +5460,21 @@ impl SqliteMemoryStore {
     /// query. Content is bounded to a short preview; access history is reduced
     /// with `NOT EXISTS` in SQL, avoiding both full-body loads and N+1 reads.
     /// `None` is an explicit all-scopes request. `Some(scope)` uses the same
-    /// legacy-compatible normalized predicate as scoped recall.
-    pub fn hygiene_snapshot(&self, scope: Option<&str>) -> Result<Vec<HygieneNodeSummary>> {
+    /// legacy-compatible normalized predicate as the tag-maintenance scans.
+    ///
+    /// Access classification is honest about the pruned log: `never_accessed`
+    /// requires zero log rows AND zero durable retrieval counters
+    /// (`times_retrieved`/`times_useful`) AND creation inside the retained
+    /// [`ACCESS_LOG_RETENTION_DAYS`] window. Older rows without durable
+    /// evidence are reported as `access_unknown` instead — their pre-prune
+    /// access history is unknowable, never provably absent.
+    ///
+    /// Malformed legacy rows (NULL/unparseable `tags`, NULL
+    /// `retention_strength`) are tolerated exactly like `row_to_node` and
+    /// surfaced as counts, so one hand-edited row cannot abort the stats view.
+    pub fn hygiene_snapshot(&self, scope: Option<&str>) -> Result<HygieneSnapshot> {
         let scope = scope.map(Self::normalize_scope).transpose()?;
+        let log_window_start = Utc::now() - Duration::days(ACCESS_LOG_RETENTION_DAYS);
         let reader = self
             .reader
             .lock()
@@ -5340,10 +5483,12 @@ impl SqliteMemoryStore {
             "SELECT n.id, n.node_type, n.created_at, n.retention_strength, n.tags,
                     n.valid_from, n.valid_until, n.superseded_by IS NOT NULL,
                     length(CAST(n.content AS BLOB)), substr(n.content, 1, 240),
-                    NOT EXISTS (
+                    (NOT EXISTS (
                         SELECT 1 FROM memory_access_log AS access
                         WHERE access.node_id = n.id
-                    )
+                    ))
+                    AND COALESCE(n.times_retrieved, 0) = 0
+                    AND COALESCE(n.times_useful, 0) = 0
              FROM knowledge_nodes AS n
              WHERE COALESCE(NULLIF(trim(n.scope), ''), 'user') = ?1
              ORDER BY n.id"
@@ -5351,10 +5496,12 @@ impl SqliteMemoryStore {
             "SELECT n.id, n.node_type, n.created_at, n.retention_strength, n.tags,
                     n.valid_from, n.valid_until, n.superseded_by IS NOT NULL,
                     length(CAST(n.content AS BLOB)), substr(n.content, 1, 240),
-                    NOT EXISTS (
+                    (NOT EXISTS (
                         SELECT 1 FROM memory_access_log AS access
                         WHERE access.node_id = n.id
-                    )
+                    ))
+                    AND COALESCE(n.times_retrieved, 0) = 0
+                    AND COALESCE(n.times_useful, 0) = 0
              FROM knowledge_nodes AS n
              ORDER BY n.id"
         };
@@ -5364,12 +5511,43 @@ impl SqliteMemoryStore {
             None => stmt.query([])?,
         };
         let mut summaries = Vec::new();
+        let mut malformed_tag_rows = 0usize;
+        let mut malformed_tag_row_ids = Vec::new();
+        let mut malformed_tag_row_ids_truncated = false;
+        let mut defaulted_retention_rows = 0usize;
         while let Some(row) = rows.next()? {
             let id: String = row.get(0)?;
-            let tags_raw: String = row.get(4)?;
-            let tags = serde_json::from_str(&tags_raw).map_err(|error| {
-                StorageError::Init(format!("invalid tags JSON for memory {id}: {error}"))
-            })?;
+            let parsed_tags = match row.get::<_, Option<String>>(4)? {
+                Some(tags_raw) => match serde_json::from_str::<Vec<String>>(&tags_raw) {
+                    Ok(tags) => Some(tags),
+                    Err(error) => {
+                        tracing::warn!(
+                            memory_id = %id,
+                            "hygiene snapshot: unparseable tags JSON, treating as untagged: {error}"
+                        );
+                        None
+                    }
+                },
+                None => None,
+            };
+            let tags = parsed_tags.unwrap_or_else(|| {
+                malformed_tag_rows += 1;
+                if malformed_tag_row_ids.len() < MAX_MALFORMED_TAG_ROW_IDS {
+                    malformed_tag_row_ids.push(id.clone());
+                } else {
+                    malformed_tag_row_ids_truncated = true;
+                }
+                Vec::new()
+            });
+            let retention_strength = match row.get::<_, Option<f64>>(3)? {
+                Some(value) => value,
+                None => {
+                    // The column is nullable and hand-edited stores can hold
+                    // NULL; report those rows at the schema default of 1.0.
+                    defaulted_retention_rows += 1;
+                    1.0
+                }
+            };
             let valid_from = row
                 .get::<_, Option<String>>(5)?
                 .map(|value| Self::parse_timestamp(&value, "valid_from"))
@@ -5378,72 +5556,79 @@ impl SqliteMemoryStore {
                 .get::<_, Option<String>>(6)?
                 .map(|value| Self::parse_timestamp(&value, "valid_until"))
                 .transpose()?;
+            let created_at = Self::parse_timestamp(&row.get::<_, String>(2)?, "created_at")?;
+            let no_access_evidence: bool = row.get(10)?;
+            let created_inside_log_window = created_at >= log_window_start;
             summaries.push(HygieneNodeSummary {
                 id,
                 node_type: row.get(1)?,
-                created_at: Self::parse_timestamp(&row.get::<_, String>(2)?, "created_at")?,
-                retention_strength: row.get(3)?,
+                created_at,
+                retention_strength,
                 tags,
                 valid_from,
                 valid_until,
                 superseded: row.get(7)?,
                 content_bytes: row.get::<_, i64>(8)?.max(0) as usize,
                 content_preview: row.get(9)?,
-                never_accessed: row.get(10)?,
+                never_accessed: no_access_evidence && created_inside_log_window,
+                access_unknown: no_access_evidence && !created_inside_log_window,
             });
         }
-        Ok(summaries)
+        Ok(HygieneSnapshot {
+            nodes: summaries,
+            malformed_tag_rows,
+            malformed_tag_row_ids,
+            malformed_tag_row_ids_truncated,
+            defaulted_retention_rows,
+        })
     }
 
     /// Return the complete, exact tag vocabulary for one scope (or all scopes
     /// when explicitly requested). This powers non-mutating ingest nudges; it
     /// parses JSON arrays rather than relying on substring SQL matching.
-    pub fn tag_vocabulary(&self, scope: Option<&str>) -> Result<Vec<String>> {
+    ///
+    /// Stored tags longer than the 200-character similarity safety limit are
+    /// skipped and counted instead of erroring the whole scope, mirroring how
+    /// overlong INPUT tags and secret-shaped vocabulary tags already degrade
+    /// gracefully. The 10,000-tag vocabulary bound stays a hard error and is
+    /// evaluated over the remaining (eligible) vocabulary, so skipping
+    /// overlong tags can never mask it.
+    pub fn tag_vocabulary(&self, scope: Option<&str>) -> Result<TagVocabulary> {
         const MAX_TAG_VOCABULARY: usize = 10_000;
-        const MAX_TAG_LENGTH: usize = 200;
         let scope = scope.map(Self::normalize_scope).transpose()?;
         let reader = self
             .reader
             .lock()
             .map_err(|_| StorageError::Init("Reader lock poisoned".into()))?;
         let overlong_sql = if scope.is_some() {
-            "SELECT EXISTS(
-                 SELECT 1
-                 FROM knowledge_nodes AS node, json_each(node.tags) AS tags
-                 WHERE COALESCE(NULLIF(trim(node.scope), ''), 'user') = ?1
-                   AND tags.type = 'text'
-                   AND length(tags.value) > 200
-                 LIMIT 1
-             )"
+            "SELECT COUNT(DISTINCT tags.value)
+             FROM knowledge_nodes AS node, json_each(node.tags) AS tags
+             WHERE COALESCE(NULLIF(trim(node.scope), ''), 'user') = ?1
+               AND tags.type = 'text'
+               AND length(tags.value) > 200"
         } else {
-            "SELECT EXISTS(
-                 SELECT 1
-                 FROM knowledge_nodes AS node, json_each(node.tags) AS tags
-                 WHERE tags.type = 'text'
-                   AND length(tags.value) > 200
-                 LIMIT 1
-             )"
+            "SELECT COUNT(DISTINCT tags.value)
+             FROM knowledge_nodes AS node, json_each(node.tags) AS tags
+             WHERE tags.type = 'text'
+               AND length(tags.value) > 200"
         };
-        let contains_overlong: bool = match scope {
+        let skipped_overlong: i64 = match scope {
             Some(scope) => reader.query_row(overlong_sql, params![scope], |row| row.get(0))?,
             None => reader.query_row(overlong_sql, [], |row| row.get(0))?,
         };
-        if contains_overlong {
-            return Err(StorageError::Init(format!(
-                "tag vocabulary contains a tag longer than the {MAX_TAG_LENGTH}-character similarity safety limit"
-            )));
-        }
         let sql = if scope.is_some() {
             "SELECT DISTINCT tags.value
              FROM knowledge_nodes AS node, json_each(node.tags) AS tags
              WHERE COALESCE(NULLIF(trim(node.scope), ''), 'user') = ?1
                AND tags.type = 'text'
+               AND length(tags.value) <= 200
              ORDER BY tags.value
              LIMIT 10001"
         } else {
             "SELECT DISTINCT tags.value
              FROM knowledge_nodes AS node, json_each(node.tags) AS tags
              WHERE tags.type = 'text'
+               AND length(tags.value) <= 200
              ORDER BY tags.value
              LIMIT 10001"
         };
@@ -5461,7 +5646,10 @@ impl SqliteMemoryStore {
                 "tag vocabulary exceeds the {MAX_TAG_VOCABULARY}-tag similarity safety limit"
             )));
         }
-        Ok(vocabulary)
+        Ok(TagVocabulary {
+            tags: vocabulary,
+            skipped_overlong: skipped_overlong.max(0) as usize,
+        })
     }
 
     /// Get nodes by type and optional tag filter
@@ -7276,9 +7464,11 @@ impl SqliteMemoryStore {
         Ok(count)
     }
 
-    /// Prune old access log entries (keep last 90 days)
+    /// Prune old access log entries (keep the last [`ACCESS_LOG_RETENTION_DAYS`]).
+    /// `hygiene_snapshot` derives its "never accessed" window from the same
+    /// constant; keep the two in lockstep.
     fn prune_access_log(&self) -> Result<i64> {
-        let cutoff = (Utc::now() - Duration::days(90)).to_rfc3339();
+        let cutoff = (Utc::now() - Duration::days(ACCESS_LOG_RETENTION_DAYS)).to_rfc3339();
         let writer = self
             .writer
             .lock()
@@ -11502,9 +11692,11 @@ impl SqliteMemoryStore {
         scope: Option<&str>,
     ) -> Result<serde_json::Value> {
         let (source_tags, target_tag) = Self::validate_tag_mutation(source_tags, target_tag)?;
-        for source_tag in &source_tags {
-            Self::enforce_secret_policy_for_content(source_tag, SecretPolicy::Reject)?;
-        }
+        // Secret policy applies to the TARGET (newly persisted) only. A
+        // secret-shaped SOURCE tag can legitimately already exist in the store
+        // (explicit-allow ingest, pre-scanning clients); matching it adds no
+        // new exposure, and rejecting it would make the credential-shaped tag
+        // impossible to rename AWAY — backwards for a cleanup tool.
         Self::enforce_secret_policy_for_content(&target_tag, SecretPolicy::Reject)?;
         let scope = scope
             .map(Self::normalize_scope)
@@ -11591,9 +11783,9 @@ impl SqliteMemoryStore {
             .transpose()?
             .map(str::to_string);
         let reason = Self::validate_tag_mutation_reason(reason)?;
-        for source_tag in &source_tags {
-            Self::enforce_secret_policy_for_content(source_tag, SecretPolicy::Reject)?;
-        }
+        // As in `preview_tag_mutation`: secret policy guards only the newly
+        // persisted TARGET and reason. A secret-shaped SOURCE tag already
+        // exists in the store, so matching it to remove it adds no exposure.
         Self::enforce_secret_policy_for_content(&target_tag, SecretPolicy::Reject)?;
         Self::enforce_secret_policy_for_content(&reason, SecretPolicy::Reject)?;
         let now = Utc::now();
@@ -11667,6 +11859,15 @@ impl SqliteMemoryStore {
                     id,
                 ],
             )?;
+        }
+        // Regression guard for the single-transaction guarantee: an armed test
+        // fail point errors out here, after every row UPDATE but before the
+        // audit INSERT, and the transaction drop must roll back both.
+        #[cfg(test)]
+        if FAIL_TAG_MUTATION_BEFORE_AUDIT.with(std::cell::Cell::get) {
+            return Err(StorageError::Init(
+                "test fail point: injected failure between tag updates and audit insert".into(),
+            ));
         }
         tx.execute(
             "INSERT INTO merge_operations
@@ -11832,8 +12033,14 @@ impl SqliteMemoryStore {
             )));
         }
 
-        let normalize = |tag: &str| -> Result<String> {
-            let tag = tag.trim();
+        // Only the TARGET is newly persisted, so only it gets shape rules for
+        // new values (trim + length cap). SOURCE tags are exact-match lookup
+        // keys for values that already exist in the store: they stay
+        // byte-exact (no trim, no length cap) so whitespace-padded or overlong
+        // stored tags remain reachable by rename/merge. Empty-after-trim and
+        // control characters are still rejected on both sides.
+        let target_tag = {
+            let tag = target_tag.trim();
             if tag.is_empty() {
                 return Err(StorageError::Init("tags cannot be empty".into()));
             }
@@ -11842,19 +12049,24 @@ impl SqliteMemoryStore {
                     "invalid tag: expected at most {MAX_TAG_LENGTH} visible characters"
                 )));
             }
-            Ok(tag.to_string())
+            tag.to_string()
         };
-
-        let target_tag = normalize(target_tag)?;
         let mut unique = std::collections::BTreeSet::new();
         for source in source_tags {
-            let source = normalize(source)?;
-            if source == target_tag {
+            if source.trim().is_empty() {
+                return Err(StorageError::Init("tags cannot be empty".into()));
+            }
+            if source.chars().any(char::is_control) {
+                return Err(StorageError::Init(
+                    "invalid source tag: control characters are not allowed".into(),
+                ));
+            }
+            if source == &target_tag {
                 return Err(StorageError::Init(
                     "source tags must differ from target_tag".into(),
                 ));
             }
-            unique.insert(source);
+            unique.insert(source.clone());
         }
         Ok((unique.into_iter().collect(), target_tag))
     }
@@ -12243,7 +12455,9 @@ impl SqliteMemoryStore {
 
     /// List tag rename/merge audit operations directly so they cannot be
     /// hidden by a busy merge/supersede reflog. `None` is explicit all-scopes;
-    /// a named scope returns only operations recorded for that exact scope.
+    /// a named scope returns operations recorded for that exact scope PLUS
+    /// every all-scopes operation, because an all-scopes mutation rewrote this
+    /// scope's tags too and must stay visible to an agent auditing it.
     pub fn list_tag_operations(
         &self,
         limit: usize,
@@ -12259,8 +12473,8 @@ impl SqliteMemoryStore {
                     survivor_id, affected_ids, confidence, signals, reason
              FROM merge_operations
              WHERE op_type IN ('tag_rename', 'tag_merge')
-               AND json_extract(signals, '$.allScopes') = 0
-               AND json_extract(signals, '$.scope') = ?1
+               AND (json_extract(signals, '$.allScopes') = 1
+                    OR json_extract(signals, '$.scope') = ?1)
              ORDER BY created_at DESC, id DESC LIMIT ?2"
         } else {
             "SELECT id, plan_id, op_type, status, created_at, reverted_at, reverts_op_id,
@@ -15693,11 +15907,9 @@ mod tests {
             "multi source tag merge",
             &["keep", "beta", "alpha", "target", "target", "tail"],
         );
-        let sources = vec![
-            " beta ".to_string(),
-            "alpha".to_string(),
-            "alpha".to_string(),
-        ];
+        // Duplicate sources dedupe; matching is byte-exact (padded variants
+        // are separate, reachable keys — see the padded-source test).
+        let sources = vec!["beta".to_string(), "alpha".to_string(), "alpha".to_string()];
         let preview = storage
             .preview_tag_mutation(&sources, "target", Some("user"))
             .unwrap();
@@ -15863,12 +16075,13 @@ mod tests {
         assert!(target_error.contains("probable credential"));
         assert!(!target_error.contains(&credential));
 
-        let source_error = storage
+        // SOURCE tags are exact-match lookup keys for values that already
+        // exist in the store, so a secret-shaped source is accepted (it must
+        // stay renameable AWAY); only newly persisted fields are rejected.
+        let source_preview = storage
             .preview_tag_mutation(std::slice::from_ref(&credential), "new", Some("user"))
-            .unwrap_err()
-            .to_string();
-        assert!(source_error.contains("probable credential"));
-        assert!(!source_error.contains(&credential));
+            .unwrap();
+        assert_eq!(source_preview["affectedMemoryCount"], 0);
 
         let safe_preview = storage
             .preview_tag_mutation(&source, "new", Some("user"))
@@ -16006,9 +16219,405 @@ mod tests {
             tx.commit().unwrap();
         }
         let snapshot = storage.hygiene_snapshot(Some("user")).unwrap();
-        assert_eq!(snapshot.len(), 501);
-        assert!(snapshot.iter().all(|row| row.content_preview.len() <= 240));
-        assert!(snapshot.iter().all(|row| row.never_accessed));
+        assert_eq!(snapshot.nodes.len(), 501);
+        assert!(
+            snapshot
+                .nodes
+                .iter()
+                .all(|row| row.content_preview.len() <= 240)
+        );
+        assert!(snapshot.nodes.iter().all(|row| row.never_accessed));
+        assert!(snapshot.nodes.iter().all(|row| !row.access_unknown));
+        assert_eq!(snapshot.malformed_tag_rows, 0);
+        assert_eq!(snapshot.defaulted_retention_rows, 0);
+    }
+
+    #[test]
+    fn hygiene_snapshot_distinguishes_unknown_pruned_access_from_never_accessed() {
+        let storage = create_test_storage();
+        let now = Utc::now();
+        let fresh = now.to_rfc3339();
+        let before_log_window =
+            (now - Duration::days(ACCESS_LOG_RETENTION_DAYS + 110)).to_rfc3339();
+        {
+            let writer = storage.writer.lock().unwrap();
+            // Heavily used old memory: its log rows were pruned, but the
+            // durable retrieval counter survives on the node row.
+            writer
+                .execute(
+                    "INSERT INTO knowledge_nodes
+                        (id, content, node_type, created_at, updated_at, last_accessed,
+                         tags, scope, times_retrieved)
+                     VALUES ('old-used', 'used before the log window', 'fact',
+                             ?1, ?1, ?1, '[]', 'user', 5)",
+                    params![&before_log_window],
+                )
+                .unwrap();
+            // Old memory with no evidence either way: pruning makes its
+            // history unknowable, so it must not be claimed never-accessed.
+            writer
+                .execute(
+                    "INSERT INTO knowledge_nodes
+                        (id, content, node_type, created_at, updated_at, last_accessed,
+                         tags, scope)
+                     VALUES ('old-unknown', 'predates the log window', 'fact',
+                             ?1, ?1, ?1, '[]', 'user')",
+                    params![&before_log_window],
+                )
+                .unwrap();
+            // Fresh memory with no accesses: the retained log is complete
+            // evidence for its whole lifetime, so never-accessed is provable.
+            writer
+                .execute(
+                    "INSERT INTO knowledge_nodes
+                        (id, content, node_type, created_at, updated_at, last_accessed,
+                         tags, scope)
+                     VALUES ('fresh-never', 'created inside the log window', 'fact',
+                             ?1, ?1, ?1, '[]', 'user')",
+                    params![&fresh],
+                )
+                .unwrap();
+        }
+        let shown = ingest_tagged_in_scope(&storage, "user", "fresh shown row", &[]);
+        storage.record_batch_retrieval(&[&shown.id]).unwrap();
+
+        let snapshot = storage.hygiene_snapshot(Some("user")).unwrap();
+        let by_id = |id: &str| {
+            snapshot
+                .nodes
+                .iter()
+                .find(|node| node.id == id)
+                .unwrap_or_else(|| panic!("snapshot row {id}"))
+        };
+        let old_used = by_id("old-used");
+        assert!(
+            !old_used.never_accessed && !old_used.access_unknown,
+            "a durable retrieval counter proves past access even after log pruning"
+        );
+        let old_unknown = by_id("old-unknown");
+        assert!(
+            !old_unknown.never_accessed,
+            "a pre-window row without counters must never be claimed never-accessed"
+        );
+        assert!(old_unknown.access_unknown);
+        let fresh_never = by_id("fresh-never");
+        assert!(fresh_never.never_accessed && !fresh_never.access_unknown);
+        let shown_row = by_id(&shown.id);
+        assert!(!shown_row.never_accessed && !shown_row.access_unknown);
+    }
+
+    #[test]
+    fn hygiene_snapshot_tolerates_malformed_and_null_legacy_rows() {
+        let storage = create_test_storage();
+        for index in 0..3 {
+            ingest_tagged_in_scope(&storage, "user", &format!("clean row {index}"), &["clean"]);
+        }
+        let now = Utc::now().to_rfc3339();
+        {
+            let writer = storage.writer.lock().unwrap();
+            writer
+                .execute(
+                    "INSERT INTO knowledge_nodes
+                        (id, content, node_type, created_at, updated_at, last_accessed,
+                         tags, scope)
+                     VALUES ('bad-json', 'hand-edited tags', 'fact', ?1, ?1, ?1,
+                             'not-json', 'user')",
+                    params![&now],
+                )
+                .unwrap();
+            writer
+                .execute(
+                    "INSERT INTO knowledge_nodes
+                        (id, content, node_type, created_at, updated_at, last_accessed,
+                         tags, scope, retention_strength)
+                     VALUES ('null-tags', 'hand-edited null row', 'fact', ?1, ?1, ?1,
+                             NULL, 'user', NULL)",
+                    params![&now],
+                )
+                .unwrap();
+        }
+
+        let snapshot = storage.hygiene_snapshot(Some("user")).unwrap();
+        assert_eq!(
+            snapshot.nodes.len(),
+            5,
+            "aggregates must cover every row, corrupted ones included"
+        );
+        assert_eq!(snapshot.malformed_tag_rows, 2);
+        assert_eq!(
+            snapshot.malformed_tag_row_ids,
+            vec!["bad-json".to_string(), "null-tags".to_string()]
+        );
+        assert!(!snapshot.malformed_tag_row_ids_truncated);
+        assert_eq!(snapshot.defaulted_retention_rows, 1);
+        let null_row = snapshot
+            .nodes
+            .iter()
+            .find(|node| node.id == "null-tags")
+            .unwrap();
+        assert!(null_row.tags.is_empty());
+        assert_eq!(null_row.retention_strength, 1.0);
+    }
+
+    #[test]
+    fn tag_apply_and_audit_roll_back_together_on_injected_failure() {
+        let storage = create_test_storage();
+        let first = ingest_tagged_in_scope(&storage, "user", "atomic pair first", &["old"]);
+        let second = ingest_tagged_in_scope(&storage, "user", "atomic pair second", &["old"]);
+        let sources = vec!["old".to_string()];
+        let preview = storage
+            .preview_tag_mutation(&sources, "new", Some("user"))
+            .unwrap();
+
+        FAIL_TAG_MUTATION_BEFORE_AUDIT.with(|flag| flag.set(true));
+        let error = storage
+            .apply_tag_mutation(
+                &sources,
+                "new",
+                Some("user"),
+                preview_token(&preview),
+                "tag_rename",
+                "single transaction fail point",
+            )
+            .unwrap_err();
+        FAIL_TAG_MUTATION_BEFORE_AUDIT.with(|flag| flag.set(false));
+        assert!(error.to_string().contains("fail point"));
+        // The failure fired AFTER every row UPDATE: rollback must restore all
+        // tag arrays AND leave no audit row, proving one shared transaction.
+        assert_eq!(
+            storage.get_node(&first.id).unwrap().unwrap().tags,
+            vec!["old"]
+        );
+        assert_eq!(
+            storage.get_node(&second.id).unwrap().unwrap().tags,
+            vec!["old"]
+        );
+        assert!(storage.list_merge_operations(20).unwrap().is_empty());
+        assert!(storage.list_tag_operations(20, None).unwrap().is_empty());
+
+        // Disarmed, the same untouched preview applies normally.
+        let applied = storage
+            .apply_tag_mutation(
+                &sources,
+                "new",
+                Some("user"),
+                preview_token(&preview),
+                "tag_rename",
+                "single transaction fail point disarmed",
+            )
+            .unwrap();
+        assert_eq!(applied.affected_ids.len(), 2);
+        assert_eq!(
+            storage.get_node(&first.id).unwrap().unwrap().tags,
+            vec!["new"]
+        );
+    }
+
+    #[test]
+    fn tag_vocabulary_skips_and_counts_overlong_stored_tags() {
+        let storage = create_test_storage();
+        ingest_tagged_in_scope(&storage, "user", "normal tag row", &["normal"]);
+        let overlong = "x".repeat(201);
+        ingest_tagged_in_scope(&storage, "user", "overlong tag row", &[&overlong]);
+
+        let vocabulary = storage.tag_vocabulary(Some("user")).unwrap();
+        assert_eq!(vocabulary.tags, vec!["normal".to_string()]);
+        assert_eq!(vocabulary.skipped_overlong, 1);
+    }
+
+    #[test]
+    fn overlong_source_tags_can_be_renamed_away_end_to_end() {
+        let storage = create_test_storage();
+        let overlong = "y".repeat(250);
+        let node =
+            ingest_tagged_in_scope(&storage, "user", "overlong rename fixture", &[&overlong]);
+
+        let sources = vec![overlong.clone()];
+        let preview = storage
+            .preview_tag_mutation(&sources, "short-tag", Some("user"))
+            .unwrap();
+        assert_eq!(preview["affectedMemoryCount"], 1);
+        storage
+            .apply_tag_mutation(
+                &sources,
+                "short-tag",
+                Some("user"),
+                preview_token(&preview),
+                "tag_rename",
+                "repair an overlong stored tag",
+            )
+            .unwrap();
+        assert_eq!(
+            storage.get_node(&node.id).unwrap().unwrap().tags,
+            vec!["short-tag"]
+        );
+        let vocabulary = storage.tag_vocabulary(Some("user")).unwrap();
+        assert_eq!(vocabulary.skipped_overlong, 0, "the overlong tag is gone");
+    }
+
+    #[test]
+    fn tag_vocabulary_rejects_more_than_ten_thousand_tags() {
+        let storage = create_test_storage();
+        let tags: Vec<String> = (0..10_001)
+            .map(|index| format!("bulk-{index:05}"))
+            .collect();
+        let now = Utc::now().to_rfc3339();
+        {
+            let writer = storage.writer.lock().unwrap();
+            writer
+                .execute(
+                    "INSERT INTO knowledge_nodes
+                        (id, content, node_type, created_at, updated_at, last_accessed,
+                         tags, scope)
+                     VALUES ('vocab-bound', 'vocabulary bound fixture', 'fact', ?1, ?1, ?1,
+                             ?2, 'user')",
+                    params![&now, serde_json::to_string(&tags).unwrap()],
+                )
+                .unwrap();
+        }
+        let error = storage
+            .tag_vocabulary(Some("user"))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("exceeds the 10000-tag"));
+    }
+
+    #[test]
+    fn padded_source_tags_are_reachable_byte_exact() {
+        let storage = create_test_storage();
+        let padded = ingest_tagged_in_scope(&storage, "user", "padded tag fixture", &[" prix-six"]);
+        let unpadded = ingest_tagged_in_scope(&storage, "user", "unpadded fixture", &["prix-six"]);
+
+        // The padded stored variant is addressable exactly as stored; the
+        // trimmed TARGET merges it into the canonical spelling.
+        let sources = vec![" prix-six".to_string()];
+        let preview = storage
+            .preview_tag_mutation(&sources, "prix-six", Some("user"))
+            .unwrap();
+        assert_eq!(preview["affectedMemoryCount"], 1);
+        storage
+            .apply_tag_mutation(
+                &sources,
+                "prix-six",
+                Some("user"),
+                preview_token(&preview),
+                "tag_rename",
+                "collapse a whitespace-padded tag variant",
+            )
+            .unwrap();
+        assert_eq!(
+            storage.get_node(&padded.id).unwrap().unwrap().tags,
+            vec!["prix-six"]
+        );
+
+        // A trimmed source still matches unpadded stored tags as before.
+        let trimmed_sources = vec!["prix-six".to_string()];
+        let trimmed_preview = storage
+            .preview_tag_mutation(&trimmed_sources, "grand-prix", Some("user"))
+            .unwrap();
+        assert_eq!(trimmed_preview["affectedMemoryCount"], 2);
+        storage
+            .apply_tag_mutation(
+                &trimmed_sources,
+                "grand-prix",
+                Some("user"),
+                preview_token(&trimmed_preview),
+                "tag_rename",
+                "rename the canonical spelling",
+            )
+            .unwrap();
+        assert_eq!(
+            storage.get_node(&unpadded.id).unwrap().unwrap().tags,
+            vec!["grand-prix"]
+        );
+    }
+
+    #[test]
+    fn secret_shaped_stored_tags_can_be_renamed_away() {
+        let storage = create_test_storage();
+        let credential = format!("ghp_{}", "b".repeat(36));
+        let node = storage
+            .ingest_with_secret_policy(
+                IngestInput {
+                    content: "explicit-allow credential tag fixture".to_string(),
+                    tags: vec![credential.clone(), "keep".to_string()],
+                    ..Default::default()
+                },
+                SecretPolicy::AllowExplicitly,
+            )
+            .unwrap();
+
+        let sources = vec![credential.clone()];
+        let preview = storage
+            .preview_tag_mutation(&sources, "rotated-token-reference", Some("user"))
+            .unwrap();
+        assert_eq!(preview["affectedMemoryCount"], 1);
+        storage
+            .apply_tag_mutation(
+                &sources,
+                "rotated-token-reference",
+                Some("user"),
+                preview_token(&preview),
+                "tag_rename",
+                "replace a credential-shaped tag with a safe reference",
+            )
+            .unwrap();
+        assert_eq!(
+            storage.get_node(&node.id).unwrap().unwrap().tags,
+            vec!["rotated-token-reference", "keep"]
+        );
+    }
+
+    #[test]
+    fn scoped_tag_operation_listing_includes_all_scopes_operations() {
+        let storage = create_test_storage();
+        ingest_tagged_in_scope(&storage, "user", "scoped audit row", &["scoped-old"]);
+        ingest_tagged_in_scope(&storage, "user", "shared audit row", &["shared-old"]);
+        ingest_tagged_in_scope(&storage, "project-b", "other scope row", &["shared-old"]);
+
+        let scoped_sources = vec!["scoped-old".to_string()];
+        let scoped_preview = storage
+            .preview_tag_mutation(&scoped_sources, "scoped-new", Some("user"))
+            .unwrap();
+        let scoped_op = storage
+            .apply_tag_mutation(
+                &scoped_sources,
+                "scoped-new",
+                Some("user"),
+                preview_token(&scoped_preview),
+                "tag_rename",
+                "scoped audit fixture",
+            )
+            .unwrap();
+
+        let shared_sources = vec!["shared-old".to_string()];
+        let shared_preview = storage
+            .preview_tag_mutation(&shared_sources, "shared-new", None)
+            .unwrap();
+        let shared_op = storage
+            .apply_tag_mutation(
+                &shared_sources,
+                "shared-new",
+                None,
+                preview_token(&shared_preview),
+                "tag_rename",
+                "all-scopes audit fixture",
+            )
+            .unwrap();
+
+        let user_view = storage.list_tag_operations(50, Some("user")).unwrap();
+        let user_ids: Vec<&str> = user_view.iter().map(|op| op.id.as_str()).collect();
+        assert!(
+            user_ids.contains(&scoped_op.id.as_str()) && user_ids.contains(&shared_op.id.as_str()),
+            "a scope's audit must show all-scopes operations that rewrote it"
+        );
+
+        let other_view = storage.list_tag_operations(50, Some("project-b")).unwrap();
+        assert_eq!(other_view.len(), 1);
+        assert_eq!(other_view[0].id, shared_op.id);
+
+        let all_view = storage.list_tag_operations(50, None).unwrap();
+        assert_eq!(all_view.len(), 2);
     }
 
     #[cfg(all(feature = "embeddings", feature = "vector-search"))]
@@ -19710,5 +20319,375 @@ mod tests {
         assert!(!parse(Some("false")), "false is OFF");
         assert!(!parse(Some("OFF")), "OFF (case-insensitive) is OFF");
         assert!(!parse(Some(" no ")), "whitespace-padded no is OFF (trim)");
+    }
+
+    // =====================================================================
+    // Smart-ingest bitemporal validity gates (issue #156)
+    // =====================================================================
+
+    /// Marker-keyed test embedder: contents sharing the "alpha" marker embed
+    /// to the same axis (cosine similarity 1.0) and everything else lands on
+    /// the orthogonal axis, so gate decisions are fully controlled by content.
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    struct MarkerEmbedder;
+
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    impl crate::embedder::EmbedderSend for MarkerEmbedder {
+        async fn embed(&self, text: &str) -> crate::embedder::EmbedderResult<Vec<f32>> {
+            Ok(if text.contains("alpha") {
+                vec![1.0, 0.0]
+            } else {
+                vec![0.0, 1.0]
+            })
+        }
+        fn model_name(&self) -> &str {
+            "marker-gate-test-runner"
+        }
+        fn dimension(&self) -> usize {
+            2
+        }
+        fn model_hash(&self) -> String {
+            "0".repeat(64)
+        }
+        async fn embed_batch(
+            &self,
+            texts: &[&str],
+        ) -> crate::embedder::EmbedderResult<Vec<Vec<f32>>> {
+            let mut result = Vec::with_capacity(texts.len());
+            for text in texts {
+                result.push(if text.contains("alpha") {
+                    vec![1.0, 0.0]
+                } else {
+                    vec![0.0, 1.0]
+                });
+            }
+            Ok(result)
+        }
+    }
+
+    /// Install, promote, activate, and attach a verified 2-dimensional marker
+    /// profile so smart-ingest gate decisions run end to end without a model
+    /// download. Mirrors the lifecycle install/evaluate/migrate/activate flow;
+    /// the Ready promotion is applied directly to the persisted manifest since
+    /// the process-local registry is private to the lifecycle module.
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    fn storage_with_marker_gate_runtime(dir: &tempfile::TempDir) -> Storage {
+        use crate::embedding::{
+            ChunkingStrategy, EmbeddingDevice, EmbeddingEvaluationSummary, EmbeddingNormalization,
+            EmbeddingProfile, EmbeddingProfileLifecycle, EmbeddingRuntimeMetadata,
+            EncodingTemplate, ModelArtifactHash, VerifiedLocalArtifact,
+        };
+        use sha2::{Digest, Sha256};
+
+        let storage = create_test_storage_at(dir, "marker-gate.db");
+        let artifact_bytes: &[u8] = b"marker gate test artifact";
+        std::fs::write(dir.path().join("runner.bin"), artifact_bytes).unwrap();
+        let artifact = ModelArtifactHash::sha256(
+            "runner.bin",
+            format!("{:x}", Sha256::digest(artifact_bytes)),
+        );
+        let profile = EmbeddingProfile {
+            profile_id: EmbeddingProfileId::new("marker-gate-test-2d").unwrap(),
+            display_name: "Marker Gate Test Profile".to_string(),
+            model_id: "test/marker-gate".to_string(),
+            immutable_model_revision: "immutable-test-revision".to_string(),
+            verified_model_artifact_hashes: vec![artifact.clone()],
+            runtime_backend: EmbeddingRuntimeBackend::FastembedCandle,
+            embedding_dimension: 2,
+            normalization_method: EmbeddingNormalization::L2,
+            document_encoding_template: EncodingTemplate::Raw,
+            query_encoding_template: EncodingTemplate::Raw,
+            maximum_token_limit: 64,
+            chunking_strategy: ChunkingStrategy::WholeDocument,
+            created_at: Utc::now(),
+        };
+        let artifacts = vec![VerifiedLocalArtifact::from_root(artifact, dir.path()).unwrap()];
+        let source = EmbeddingProfileId::new("nomic-v1.5-legacy-raw-256").unwrap();
+        let lifecycle = EmbeddingProfileLifecycle::new(&storage);
+        let mut manifest = lifecycle
+            .install_verified(
+                profile.clone(),
+                &artifacts,
+                EmbeddingRuntimeMetadata {
+                    backend: EmbeddingRuntimeBackend::FastembedCandle,
+                    device: EmbeddingDevice::Cpu,
+                    runtime_version: "test".to_string(),
+                    initialized_at: Utc::now(),
+                    local_only: true,
+                },
+                Arc::new(MarkerEmbedder),
+            )
+            .unwrap();
+        manifest.state = EmbeddingProfileState::Ready;
+        manifest.evaluation = Some(EmbeddingEvaluationSummary {
+            evaluation_id: Uuid::new_v4(),
+            compared_against: source.clone(),
+            completed_at: Utc::now(),
+            corpus_size: 0,
+            recall_at_5: None,
+            recall_at_10: None,
+            ndcg_at_10: None,
+            exact_match_preservation: None,
+            false_positive_rate: None,
+            p50_query_latency_ms: None,
+            p95_query_latency_ms: None,
+            ingestion_throughput_per_second: None,
+            report_hash: "1".repeat(64),
+        });
+        storage.save_embedding_profile_manifest(&manifest).unwrap();
+        lifecycle
+            .migrate_registered(&profile.profile_id, &source, None, None)
+            .unwrap();
+        storage
+            .activate_embedding_profile(&profile.profile_id)
+            .unwrap();
+        lifecycle
+            .attach_registered_active_profile(&profile.profile_id)
+            .unwrap();
+        storage
+    }
+
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    #[test]
+    fn inferred_as_of_validity_never_mutates_an_existing_nodes_window() {
+        let dir = tempdir().unwrap();
+        let storage = storage_with_marker_gate_runtime(&dir);
+        let explicit_from = Utc::now() - Duration::days(60);
+        let explicit_until = Utc::now() + Duration::days(300);
+        let target = storage
+            .ingest(IngestInput {
+                content: "alpha deployment policy is retries with backoff".to_string(),
+                valid_from: Some(explicit_from),
+                valid_until: Some(explicit_until),
+                ..Default::default()
+            })
+            .unwrap();
+
+        // Near-identical content whose only validity is a prose-inferred
+        // "as of" date must reinforce WITHOUT touching the target's window.
+        let result = storage
+            .smart_ingest(IngestInput {
+                content: "alpha deployment policy is retries with backoff, as of last review"
+                    .to_string(),
+                valid_from: Some(Utc::now() - Duration::days(10)),
+                validity_inferred: true,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(result.decision, "reinforce");
+        assert_eq!(result.node.id, target.id);
+
+        let node = storage.get_node(&target.id).unwrap().unwrap();
+        assert_eq!(
+            node.valid_from.map(|value| value.to_rfc3339()),
+            Some(explicit_from.to_rfc3339()),
+            "an inferred date must not move valid_from"
+        );
+        assert_eq!(
+            node.valid_until.map(|value| value.to_rfc3339()),
+            Some(explicit_until.to_rfc3339()),
+            "an inferred date must not clear or move valid_until"
+        );
+    }
+
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    #[test]
+    fn explicit_valid_from_on_reinforce_updates_without_clearing_valid_until() {
+        let dir = tempdir().unwrap();
+        let storage = storage_with_marker_gate_runtime(&dir);
+        let explicit_from = Utc::now() - Duration::days(60);
+        let explicit_until = Utc::now() + Duration::days(300);
+        let target = storage
+            .ingest(IngestInput {
+                content: "alpha deployment policy is retries with backoff".to_string(),
+                valid_from: Some(explicit_from),
+                valid_until: Some(explicit_until),
+                ..Default::default()
+            })
+            .unwrap();
+
+        // An explicit caller-supplied valid_from still updates the window, and
+        // omitting valid_until must preserve the stored bound (merge, not
+        // replace).
+        let new_from = Utc::now() - Duration::days(10);
+        let result = storage
+            .smart_ingest(IngestInput {
+                content: "alpha deployment policy is retries with backoff".to_string(),
+                valid_from: Some(new_from),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(result.decision, "reinforce");
+
+        let node = storage.get_node(&target.id).unwrap().unwrap();
+        assert_eq!(
+            node.valid_from.map(|value| value.to_rfc3339()),
+            Some(new_from.to_rfc3339()),
+            "explicit valid_from must update the window"
+        );
+        assert_eq!(
+            node.valid_until.map(|value| value.to_rfc3339()),
+            Some(explicit_until.to_rfc3339()),
+            "an explicit valid_from-only update must not NULL valid_until"
+        );
+    }
+
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    #[test]
+    fn create_path_still_stamps_inferred_validity_on_the_new_node() {
+        let dir = tempdir().unwrap();
+        let storage = storage_with_marker_gate_runtime(&dir);
+        let inferred_from = Utc::now() - Duration::days(10);
+        let result = storage
+            .smart_ingest(IngestInput {
+                content: "beta service quota was raised".to_string(),
+                valid_from: Some(inferred_from),
+                validity_inferred: true,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(result.decision, "create");
+        assert!(result.auto_closed_until.is_none());
+        let node = storage.get_node(&result.node.id).unwrap().unwrap();
+        assert_eq!(
+            node.valid_from.map(|value| value.to_rfc3339()),
+            Some(inferred_from.to_rfc3339()),
+            "the issue-156 feature: inferred validity stamps the NEW node"
+        );
+        assert!(node.valid_until.is_none());
+    }
+
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    #[test]
+    fn older_dated_claim_after_newer_fact_is_created_with_a_closed_window() {
+        let dir = tempdir().unwrap();
+        let storage = storage_with_marker_gate_runtime(&dir);
+        let newer_from = Utc::now() - Duration::days(30);
+        storage
+            .ingest(IngestInput {
+                content: "alpha runtime version is 5.0".to_string(),
+                valid_from: Some(newer_from),
+                ..Default::default()
+            })
+            .unwrap();
+
+        // The stale snapshot loses every candidate to the newer current fact,
+        // so it is created as a CLOSED historical claim, never an open one.
+        let result = storage
+            .smart_ingest(IngestInput {
+                content: "alpha runtime version is 4.2".to_string(),
+                valid_from: Some(Utc::now() - Duration::days(180)),
+                validity_inferred: true,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(result.decision, "create");
+        assert_eq!(
+            result.auto_closed_until.map(|value| value.to_rfc3339()),
+            Some(newer_from.to_rfc3339()),
+            "the new node closes exactly where the newer fact begins"
+        );
+        assert!(result.reason.contains("Closed validity at"));
+        let node = storage.get_node(&result.node.id).unwrap().unwrap();
+        assert_eq!(
+            node.valid_until.map(|value| value.to_rfc3339()),
+            Some(newer_from.to_rfc3339())
+        );
+        assert!(!node.is_currently_valid());
+
+        // Reverse order on a fresh store: the newer dated claim arriving
+        // second keeps the normal gate behavior (reinforce, no auto-close).
+        let dir = tempdir().unwrap();
+        let storage = storage_with_marker_gate_runtime(&dir);
+        let target = storage
+            .ingest(IngestInput {
+                content: "alpha runtime version is 4.2".to_string(),
+                valid_from: Some(Utc::now() - Duration::days(180)),
+                ..Default::default()
+            })
+            .unwrap();
+        let result = storage
+            .smart_ingest(IngestInput {
+                content: "alpha runtime version is 5.0".to_string(),
+                valid_from: Some(newer_from),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(result.decision, "reinforce");
+        assert_eq!(result.node.id, target.id);
+        assert!(result.auto_closed_until.is_none());
+        let node = storage.get_node(&target.id).unwrap().unwrap();
+        assert_eq!(
+            node.valid_from.map(|value| value.to_rfc3339()),
+            Some(newer_from.to_rfc3339())
+        );
+    }
+
+    #[test]
+    fn update_node_validity_merges_bounds_and_validates_the_effective_window() {
+        let storage = create_test_storage();
+        let node = storage
+            .ingest(IngestInput {
+                content: "validity merge fixture".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let from = Utc::now() - Duration::days(10);
+        let until = Utc::now() + Duration::days(10);
+        storage
+            .update_node_validity(&node.id, Some(from), Some(until))
+            .unwrap();
+
+        // Updating only valid_from must not clear the stored valid_until.
+        let new_from = Utc::now() - Duration::days(5);
+        storage
+            .update_node_validity(&node.id, Some(new_from), None)
+            .unwrap();
+        let stored = storage.get_node(&node.id).unwrap().unwrap();
+        assert_eq!(
+            stored.valid_from.map(|value| value.to_rfc3339()),
+            Some(new_from.to_rfc3339())
+        );
+        assert_eq!(
+            stored.valid_until.map(|value| value.to_rfc3339()),
+            Some(until.to_rfc3339())
+        );
+
+        // Updating only valid_until must not clear the stored valid_from.
+        let new_until = Utc::now() + Duration::days(20);
+        storage
+            .update_node_validity(&node.id, None, Some(new_until))
+            .unwrap();
+        let stored = storage.get_node(&node.id).unwrap().unwrap();
+        assert_eq!(
+            stored.valid_from.map(|value| value.to_rfc3339()),
+            Some(new_from.to_rfc3339())
+        );
+        assert_eq!(
+            stored.valid_until.map(|value| value.to_rfc3339()),
+            Some(new_until.to_rfc3339())
+        );
+
+        // The EFFECTIVE post-merge window is validated: a valid_from at or
+        // beyond the stored valid_until is rejected and nothing changes.
+        let error = storage
+            .update_node_validity(&node.id, Some(Utc::now() + Duration::days(30)), None)
+            .unwrap_err();
+        assert!(matches!(error, StorageError::InvalidTimestamp(_)));
+        let stored = storage.get_node(&node.id).unwrap().unwrap();
+        assert_eq!(
+            stored.valid_from.map(|value| value.to_rfc3339()),
+            Some(new_from.to_rfc3339())
+        );
+        assert_eq!(
+            stored.valid_until.map(|value| value.to_rfc3339()),
+            Some(new_until.to_rfc3339())
+        );
+
+        // Both bounds supplied together are still validated up front.
+        let error = storage
+            .update_node_validity(&node.id, Some(until), Some(from))
+            .unwrap_err();
+        assert!(matches!(error, StorageError::InvalidTimestamp(_)));
     }
 }

--- a/crates/vestige-mcp/src/bin/cli.rs
+++ b/crates/vestige-mcp/src/bin/cli.rs
@@ -2344,6 +2344,7 @@ fn run_restore(backup_path: PathBuf) -> anyhow::Result<()> {
             tags: memory.tags.unwrap_or_default(),
             valid_from: None,
             valid_until: None,
+            validity_inferred: false,
             source_envelope: None,
         };
 
@@ -3003,6 +3004,7 @@ fn run_ingest(
         tags: tag_list,
         valid_from: None,
         valid_until: None,
+        validity_inferred: false,
         source_envelope: None,
     };
 

--- a/crates/vestige-mcp/src/bin/restore.rs
+++ b/crates/vestige-mcp/src/bin/restore.rs
@@ -77,6 +77,7 @@ fn main() -> anyhow::Result<()> {
             tags: memory.tags.unwrap_or_default(),
             valid_from: None,
             valid_until: None,
+            validity_inferred: false,
             source_envelope: None,
         };
 

--- a/crates/vestige-mcp/src/cognitive.rs
+++ b/crates/vestige-mcp/src/cognitive.rs
@@ -208,6 +208,7 @@ mod tests {
                 tags: vec!["test".to_string()],
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap();

--- a/crates/vestige-mcp/src/tools/changelog.rs
+++ b/crates/vestige-mcp/src/tools/changelog.rs
@@ -278,6 +278,7 @@ mod tests {
                 tags: vec![],
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap();

--- a/crates/vestige-mcp/src/tools/codebase_unified.rs
+++ b/crates/vestige-mcp/src/tools/codebase_unified.rs
@@ -154,6 +154,7 @@ async fn execute_remember_pattern(
         tags,
         valid_from: None,
         valid_until: None,
+        validity_inferred: false,
         source_envelope: None,
     };
 
@@ -251,6 +252,7 @@ async fn execute_remember_decision(
         tags,
         valid_from: None,
         valid_until: None,
+        validity_inferred: false,
         source_envelope: None,
     };
 

--- a/crates/vestige-mcp/src/tools/cross_reference.rs
+++ b/crates/vestige-mcp/src/tools/cross_reference.rs
@@ -469,6 +469,23 @@ struct ScoredMemory {
     created_at: chrono::DateTime<Utc>,
     retention: f64,
     combined_score: f32,
+    valid_until: Option<chrono::DateTime<Utc>>,
+    currently_valid: bool,
+}
+
+/// Default validity penalty, mirroring search_unified's
+/// `apply_default_validity_penalty`: historical and future facts remain
+/// available for audit, but should not outrank a current fact on relevance
+/// alone. Applied exactly once — when SearchResults are folded into
+/// ScoredMemory (STAGE 3) — so candidate pools, primary selection, and the
+/// final composite all see the same penalized relevance without a chance of
+/// double-penalizing.
+pub(crate) fn validity_adjusted_score(combined_score: f32, currently_valid: bool) -> f32 {
+    if currently_valid {
+        combined_score
+    } else {
+        combined_score * 0.1
+    }
 }
 
 // ============================================================================
@@ -572,6 +589,7 @@ pub async fn execute(
                 r.node.reps,
                 r.node.lapses,
             );
+            let currently_valid = r.node.is_currently_valid();
             ScoredMemory {
                 id: r.node.id.clone(),
                 content: r.node.content.clone(),
@@ -580,7 +598,9 @@ pub async fn execute(
                 updated_at: r.node.updated_at,
                 created_at: r.node.created_at,
                 retention: r.node.retention_strength,
-                combined_score: r.combined_score,
+                combined_score: validity_adjusted_score(r.combined_score, currently_valid),
+                valid_until: r.node.valid_until,
+                currently_valid,
             }
         })
         .collect();
@@ -854,6 +874,8 @@ pub async fn execute(
                 "trust": (s.trust * 100.0).round() / 100.0,
                 "relevanceScore": ((composite(s) * 100.0).round() / 100.0),
                 "date": s.updated_at.to_rfc3339(),
+                "validUntil": s.valid_until.map(|dt| dt.to_rfc3339()),
+                "currentlyValid": s.currently_valid,
                 "role": if i == 0 { "primary" } else { "supporting" },
             })
         })
@@ -959,6 +981,8 @@ pub async fn execute(
             "memory_id": rec.id,
             "trust_score": (rec.trust * 100.0).round() / 100.0,
             "date": rec.updated_at.to_rfc3339(),
+            "validUntil": rec.valid_until.map(|dt| dt.to_rfc3339()),
+            "currentlyValid": rec.currently_valid,
         });
     }
 
@@ -1169,10 +1193,43 @@ mod tests {
                 tags: tags.iter().map(|s| s.to_string()).collect(),
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap()
             .id
+    }
+
+    async fn ingest_with_validity(
+        storage: &Arc<Storage>,
+        content: &str,
+        tags: &[&str],
+        valid_until: Option<chrono::DateTime<Utc>>,
+    ) -> String {
+        storage
+            .ingest(vestige_core::IngestInput {
+                content: content.to_string(),
+                node_type: "fact".to_string(),
+                source: None,
+                sentiment_score: 0.0,
+                sentiment_magnitude: 0.0,
+                tags: tags.iter().map(|s| s.to_string()).collect(),
+                valid_from: None,
+                valid_until,
+                validity_inferred: false,
+                source_envelope: None,
+            })
+            .unwrap()
+            .id
+    }
+
+    fn evidence_entry<'a>(result: &'a serde_json::Value, id: &str) -> &'a serde_json::Value {
+        result["evidence"]
+            .as_array()
+            .expect("evidence array should be present")
+            .iter()
+            .find(|e| e["id"].as_str() == Some(id))
+            .unwrap_or_else(|| panic!("memory {} missing from evidence", id))
     }
 
     // ========================================================================
@@ -1627,5 +1684,167 @@ mod tests {
             0.7,
         );
         assert!(matches!(rel.relation, Relation::Contradicts));
+    }
+
+    // ========================================================================
+    // VALIDITY (issue #156 Ask 1): expired facts must not compose at full rank.
+    // Mirrors search_unified's default validity penalty on the reason path.
+    // ========================================================================
+
+    #[test]
+    fn test_validity_adjusted_score_only_penalizes_invalid() {
+        assert_eq!(validity_adjusted_score(0.8, true), 0.8);
+        let penalized = validity_adjusted_score(0.8, false);
+        assert!(
+            (penalized - 0.08).abs() < 1e-6,
+            "invalid facts must be downranked to 0.1x, got {}",
+            penalized
+        );
+    }
+
+    #[tokio::test]
+    async fn test_expired_memory_ranked_below_current_and_flagged() {
+        let (storage, _dir) = test_storage().await;
+
+        let expired_id = ingest_with_validity(
+            &storage,
+            "Kubernetes ingress gateway timeout policy for the payments cluster \
+             is ninety seconds.",
+            &["kubernetes", "payments"],
+            Some(Utc::now() - chrono::Duration::days(30)),
+        )
+        .await;
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        let current_id = ingest_with_validity(
+            &storage,
+            "Kubernetes ingress gateway timeout policy for the payments cluster \
+             is thirty seconds.",
+            &["kubernetes", "payments"],
+            None,
+        )
+        .await;
+
+        let result = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "query": "Kubernetes ingress gateway timeout policy payments cluster"
+            })),
+        )
+        .await
+        .expect("execute should succeed");
+
+        let expired = evidence_entry(&result, &expired_id);
+        let current = evidence_entry(&result, &current_id);
+
+        assert_eq!(
+            expired["currentlyValid"].as_bool(),
+            Some(false),
+            "expired memory must carry currentlyValid=false: {:?}",
+            expired
+        );
+        assert!(
+            expired["validUntil"].as_str().is_some(),
+            "expired memory must surface its validUntil (RFC3339): {:?}",
+            expired
+        );
+        assert_eq!(
+            current["currentlyValid"].as_bool(),
+            Some(true),
+            "current memory must carry currentlyValid=true: {:?}",
+            current
+        );
+
+        let expired_score = expired["relevanceScore"].as_f64().unwrap();
+        let current_score = current["relevanceScore"].as_f64().unwrap();
+        assert!(
+            expired_score < current_score,
+            "an expired fact must rank below its current replacement \
+             (expired={}, current={}). Without the validity penalty, both \
+             carry identical trust/terms and the expired one can win.",
+            expired_score,
+            current_score
+        );
+        assert_eq!(
+            result["recommended"]["memory_id"].as_str(),
+            Some(current_id.as_str()),
+            "the current fact must win primary selection over the expired one"
+        );
+        assert_eq!(
+            result["recommended"]["currentlyValid"].as_bool(),
+            Some(true),
+            "recommended block must surface validity too"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_future_valid_until_not_penalized() {
+        let (storage, _dir) = test_storage().await;
+
+        let expired_id = ingest_with_validity(
+            &storage,
+            "Redis cache eviction policy for the checkout service keeps entries \
+             for sixty minutes.",
+            &["redis", "checkout"],
+            Some(Utc::now() - chrono::Duration::days(30)),
+        )
+        .await;
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        let future_id = ingest_with_validity(
+            &storage,
+            "Redis cache eviction policy for the checkout service keeps entries \
+             for ninety minutes.",
+            &["redis", "checkout"],
+            Some(Utc::now() + chrono::Duration::days(365)),
+        )
+        .await;
+
+        let result = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "query": "Redis cache eviction policy checkout service entries"
+            })),
+        )
+        .await
+        .expect("execute should succeed");
+
+        let future = evidence_entry(&result, &future_id);
+        let expired = evidence_entry(&result, &expired_id);
+
+        assert_eq!(
+            future["currentlyValid"].as_bool(),
+            Some(true),
+            "a fact whose valid_until is in the FUTURE is currently valid: {:?}",
+            future
+        );
+        assert!(
+            future["validUntil"].as_str().is_some(),
+            "future validUntil must still be surfaced for the reasoning layer: {:?}",
+            future
+        );
+
+        let future_score = future["relevanceScore"].as_f64().unwrap();
+        let expired_score = expired["relevanceScore"].as_f64().unwrap();
+        // If future validity were wrongly penalized (e.g. keying the penalty on
+        // valid_until.is_some() instead of is_currently_valid()), both twins
+        // would sit in the same 0.1x band and the gap collapses to <=~0.03.
+        // Unpenalized, the future-valid fact keeps its full 0.5-weighted
+        // relevance slot: the gap over the penalized expired twin is >=~0.09.
+        assert!(
+            future_score - expired_score >= 0.05,
+            "a future-valid fact must NOT be penalized (future={}, expired={})",
+            future_score,
+            expired_score
+        );
+        assert_eq!(
+            result["recommended"]["memory_id"].as_str(),
+            Some(future_id.as_str()),
+            "the future-valid fact must win primary selection over the expired one"
+        );
     }
 }

--- a/crates/vestige-mcp/src/tools/dedup.rs
+++ b/crates/vestige-mcp/src/tools/dedup.rs
@@ -420,6 +420,12 @@ fn execute_tag_mutation(
         .get("all_scopes")
         .and_then(Value::as_bool)
         .unwrap_or(false);
+    // An explicit scope alongside all_scopes=true is contradictory: silently
+    // dropping the scope would rewrite every scope while the caller believes
+    // the mutation is project-scoped.
+    if all_scopes && args.get("scope").is_some_and(|value| !value.is_null()) {
+        return Err("pass either scope or all_scopes=true, not both".into());
+    }
     let scope = if all_scopes {
         None
     } else {
@@ -621,6 +627,109 @@ mod tests {
         assert_eq!(
             storage.get_node(&node.id).unwrap().unwrap().tags,
             vec!["old", "keep"]
+        );
+    }
+
+    #[tokio::test]
+    async fn tag_actions_reject_scope_combined_with_all_scopes() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let storage = Arc::new(Storage::new(Some(dir.path().join("test.db"))).unwrap());
+        storage
+            .ingest(IngestInput {
+                content: "scope conflict fixture".to_string(),
+                tags: vec!["old".to_string()],
+                ..Default::default()
+            })
+            .unwrap();
+
+        let conflict = execute_unified(
+            &storage,
+            Some(serde_json::json!({
+                "action": "tag_rename",
+                "source_tag": "old",
+                "target_tag": "new",
+                "scope": "project-a",
+                "all_scopes": true
+            })),
+        )
+        .await
+        .unwrap_err();
+        assert!(conflict.contains("not both"));
+
+        let scoped_only = execute_unified(
+            &storage,
+            Some(serde_json::json!({
+                "action": "tag_rename",
+                "source_tag": "old",
+                "target_tag": "new",
+                "scope": "user"
+            })),
+        )
+        .await
+        .unwrap();
+        assert_eq!(scoped_only["allScopes"], false);
+        assert_eq!(scoped_only["affectedMemoryCount"], 1);
+
+        let all_scopes_only = execute_unified(
+            &storage,
+            Some(serde_json::json!({
+                "action": "tag_rename",
+                "source_tag": "old",
+                "target_tag": "new",
+                "all_scopes": true
+            })),
+        )
+        .await
+        .unwrap();
+        assert_eq!(all_scopes_only["allScopes"], true);
+        assert_eq!(all_scopes_only["affectedMemoryCount"], 1);
+    }
+
+    #[tokio::test]
+    async fn overlong_source_tag_is_renameable_end_to_end() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let storage = Arc::new(Storage::new(Some(dir.path().join("test.db"))).unwrap());
+        let overlong = "z".repeat(250);
+        let node = storage
+            .ingest(IngestInput {
+                content: "overlong tag repair fixture".to_string(),
+                tags: vec![overlong.clone()],
+                ..Default::default()
+            })
+            .unwrap();
+
+        let preview = execute_unified(
+            &storage,
+            Some(serde_json::json!({
+                "action": "tag_rename",
+                "source_tag": overlong,
+                "target_tag": "short-tag",
+                "scope": "user"
+            })),
+        )
+        .await
+        .unwrap();
+        assert_eq!(preview["affectedMemoryCount"], 1);
+
+        let applied = execute_unified(
+            &storage,
+            Some(serde_json::json!({
+                "action": "tag_rename",
+                "source_tag": overlong,
+                "target_tag": "short-tag",
+                "scope": "user",
+                "confirm": true,
+                "preview_token": preview["previewToken"],
+                "reason": "repair an overlong stored tag"
+            })),
+        )
+        .await
+        .unwrap();
+        assert_eq!(applied["status"], "applied");
+        assert_eq!(
+            storage.get_node(&node.id).unwrap().unwrap().tags,
+            vec!["short-tag"],
+            "the overlong tag must be gone after the rename"
         );
     }
 

--- a/crates/vestige-mcp/src/tools/dream.rs
+++ b/crates/vestige-mcp/src/tools/dream.rs
@@ -283,6 +283,7 @@ mod tests {
                     tags: vec!["dream-test".to_string()],
                     valid_from: None,
                     valid_until: None,
+                    validity_inferred: false,
                     source_envelope: None,
                 })
                 .unwrap();
@@ -421,6 +422,7 @@ mod tests {
                     tags: vec!["dream-roundtrip".to_string()],
                     valid_from: None,
                     valid_until: None,
+                    validity_inferred: false,
                     source_envelope: None,
                 })
                 .unwrap();
@@ -487,6 +489,7 @@ mod tests {
                     tags: vec!["save-conn-test".to_string()],
                     valid_from: None,
                     valid_until: None,
+                    validity_inferred: false,
                     source_envelope: None,
                 })
                 .unwrap();
@@ -591,6 +594,7 @@ mod tests {
                     tags: tags.iter().map(|t| t.to_string()).collect(),
                     valid_from: None,
                     valid_until: None,
+                    validity_inferred: false,
                     source_envelope: None,
                 })
                 .unwrap();
@@ -717,6 +721,7 @@ mod tests {
                     tags: tags.iter().map(|t| t.to_string()).collect(),
                     valid_from: None,
                     valid_until: None,
+                    validity_inferred: false,
                     source_envelope: None,
                 })
                 .unwrap();

--- a/crates/vestige-mcp/src/tools/explore.rs
+++ b/crates/vestige-mcp/src/tools/explore.rs
@@ -414,6 +414,7 @@ mod tests {
                 tags: vec!["test".to_string()],
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap()
@@ -429,6 +430,7 @@ mod tests {
                 tags: vec!["test".to_string()],
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap()
@@ -480,6 +482,7 @@ mod tests {
             tags: vec!["test".to_string()],
             valid_from: None,
             valid_until: None,
+            validity_inferred: false,
             source_envelope: None,
         };
         let id_a = storage.ingest(make("Memory A about databases")).unwrap().id;
@@ -532,6 +535,7 @@ mod tests {
             tags: vec!["test".to_string()],
             valid_from: None,
             valid_until: None,
+            validity_inferred: false,
             source_envelope: None,
         };
         let id_a = storage.ingest(make("Bridge test memory A")).unwrap().id;

--- a/crates/vestige-mcp/src/tools/feedback.rs
+++ b/crates/vestige-mcp/src/tools/feedback.rs
@@ -313,6 +313,7 @@ mod tests {
                 tags: vec![],
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap();
@@ -557,6 +558,7 @@ mod tests {
                 tags: vec![],
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap();

--- a/crates/vestige-mcp/src/tools/graph.rs
+++ b/crates/vestige-mcp/src/tools/graph.rs
@@ -328,6 +328,7 @@ mod tests {
                 tags: vec!["test".to_string()],
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap();
@@ -356,6 +357,7 @@ mod tests {
                 tags: vec!["science".to_string()],
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap();
@@ -380,6 +382,7 @@ mod tests {
                 tags: vec![],
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap();

--- a/crates/vestige-mcp/src/tools/health.rs
+++ b/crates/vestige-mcp/src/tools/health.rs
@@ -119,6 +119,7 @@ mod tests {
                     tags: vec!["test".to_string()],
                     valid_from: None,
                     valid_until: None,
+                    validity_inferred: false,
                     source_envelope: None,
                 })
                 .unwrap();
@@ -145,6 +146,7 @@ mod tests {
                 tags: vec![],
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap();

--- a/crates/vestige-mcp/src/tools/hygiene_stats.rs
+++ b/crates/vestige-mcp/src/tools/hygiene_stats.rs
@@ -10,11 +10,18 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use serde_json::{Value, json};
-use vestige_core::{DEFAULT_MEMORY_SCOPE, HygieneNodeSummary, Storage, scan_secrets};
+use vestige_core::{
+    ACCESS_LOG_RETENTION_DAYS, DEFAULT_MEMORY_SCOPE, HygieneNodeSummary, HygieneSnapshot, Storage,
+    scan_secrets,
+};
 
 const DEFAULT_DETAIL_LIMIT: usize = 50;
 const MAX_DETAIL_LIMIT: usize = 200;
 const TAG_AUDIT_WINDOW: usize = 50;
+/// The byTag aggregate is bounded to the top entries by count so a store with
+/// tens of thousands of distinct tags cannot blow the 200k payload cap and
+/// clip the entire stats JSON mid-document.
+const MAX_TAG_COUNT_ENTRIES: usize = 200;
 
 #[derive(Debug, Clone)]
 struct TagAuditSummary {
@@ -53,13 +60,13 @@ pub async fn execute(storage: &Arc<Storage>, args: Option<Value>) -> Result<Valu
         })
     };
 
-    let nodes = storage
+    let snapshot = storage
         .hygiene_snapshot(selected_scope)
         .map_err(|error| format!("Failed to build hygiene snapshot: {error}"))?;
     let tag_audit = load_tag_audit(storage, selected_scope)?;
 
     Ok(build_response(
-        nodes,
+        snapshot,
         selected_scope,
         limit,
         Utc::now(),
@@ -170,12 +177,13 @@ fn load_tag_audit(
 }
 
 fn build_response(
-    nodes: Vec<HygieneNodeSummary>,
+    snapshot: HygieneSnapshot,
     selected_scope: Option<&str>,
     limit: usize,
     now: DateTime<Utc>,
     tag_audit: TagAuditWindow,
 ) -> Value {
+    let nodes = snapshot.nodes;
     let total = nodes.len();
     let mut type_counts = BTreeMap::<String, usize>::new();
     let mut tag_counts = BTreeMap::<String, usize>::new();
@@ -254,6 +262,23 @@ fn build_response(
         .map(detail_item)
         .collect();
 
+    // Memories created before the retained access-log window with zero
+    // durable counters: their access history was pruned, so they are
+    // reported separately, never claimed as never-accessed.
+    let mut access_unknown: Vec<&HygieneNodeSummary> =
+        nodes.iter().filter(|node| node.access_unknown).collect();
+    access_unknown.sort_by(|left, right| {
+        left.created_at
+            .cmp(&right.created_at)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    let access_unknown_total = access_unknown.len();
+    let access_unknown_ids: Vec<&str> = access_unknown
+        .into_iter()
+        .take(limit)
+        .map(|node| node.id.as_str())
+        .collect();
+
     let mut largest: Vec<&HygieneNodeSummary> = nodes.iter().collect();
     largest.sort_by(|left, right| {
         right
@@ -262,6 +287,19 @@ fn build_response(
             .then_with(|| left.id.cmp(&right.id))
     });
     let largest_items: Vec<Value> = largest.into_iter().take(limit).map(detail_item).collect();
+
+    // Bound byTag to the top entries by count (ties broken by tag name asc)
+    // so an unbounded tag vocabulary cannot clip the whole stats payload.
+    let distinct_tag_total = tag_counts.len();
+    let by_tag_truncated = distinct_tag_total > MAX_TAG_COUNT_ENTRIES;
+    let tag_counts = if by_tag_truncated {
+        let mut ranked: Vec<(String, usize)> = tag_counts.into_iter().collect();
+        ranked.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+        ranked.truncate(MAX_TAG_COUNT_ENTRIES);
+        ranked.into_iter().collect::<BTreeMap<String, usize>>()
+    } else {
+        tag_counts
+    };
 
     let tag_operations: Vec<Value> = tag_audit
         .operations
@@ -293,10 +331,12 @@ fn build_response(
         },
         "semantics": {
             "population": "Every stored knowledge_nodes row in the selected scope, including expired, not-yet-valid, invalid-bound, and superseded rows.",
-            "tagCounts": "Number of memories carrying each exact tag; duplicate entries within one memory count once.",
+            "tagCounts": format!("Number of memories carrying each exact tag; duplicate entries within one memory count once. byTag is bounded to the top {MAX_TAG_COUNT_ENTRIES} tags by count (ties by tag name); distinctTagTotal and byTagTruncated report the full vocabulary size."),
             "age": "Whole elapsed days from createdAt to computedAt. Future-created rows are reported separately.",
             "validity": "Temporal buckets are mutually exclusive: expired first, then not-yet-valid, then within-window. Superseded and invalid-bound counts are independent overlays.",
-            "neverAccessed": "No durable memory_access_log row exists for the memory.",
+            "neverAccessed": format!("No access recorded in the retained {ACCESS_LOG_RETENTION_DAYS}-day access log, durable retrieval counters (times_retrieved/times_useful) are zero, AND the memory was created inside that window — so the absence of evidence is meaningful. Access-log rows are pruned after {ACCESS_LOG_RETENTION_DAYS} days; they are not durable."),
+            "accessUnknownPrunedLog": format!("Created before the retained {ACCESS_LOG_RETENTION_DAYS}-day access-log window with zero durable retrieval counters. Their pre-prune access history is unknowable, so they are reported here and never claimed as never-accessed. Do not suppress or purge them on access grounds."),
+            "dataQuality": "malformedTagRows counts rows whose stored tags column is NULL or unparseable JSON (treated as untagged in aggregates); retentionDefaultedRows counts rows whose NULL retention_strength was reported at the schema default 1.0.",
             "contentSize": "UTF-8 bytes. Returned content is a bounded preview, never the full body. Blocking credential shapes are redacted without echoing the matched bytes."
         },
         "population": {
@@ -307,8 +347,18 @@ fn build_response(
         "counts": {
             "byMemoryType": type_counts,
             "byTag": tag_counts,
+            "distinctTagTotal": distinct_tag_total,
+            "byTagTruncated": by_tag_truncated,
             "untagged": untagged,
             "byAge": age_counts,
+        },
+        "dataQuality": {
+            "malformedTagRows": {
+                "count": snapshot.malformed_tag_rows,
+                "memoryIds": snapshot.malformed_tag_row_ids,
+                "memoryIdsTruncated": snapshot.malformed_tag_row_ids_truncated,
+            },
+            "retentionDefaultedRows": snapshot.defaulted_retention_rows,
         },
         "retentionDistribution": {
             "buckets": retention_counts,
@@ -327,6 +377,13 @@ fn build_response(
             "truncated": never_accessed_total > never_accessed_items.len(),
             "memories": never_accessed_items,
         },
+        "accessUnknownPrunedLog": {
+            "total": access_unknown_total,
+            "returned": access_unknown_ids.len(),
+            "limit": limit,
+            "truncated": access_unknown_total > access_unknown_ids.len(),
+            "memoryIds": access_unknown_ids,
+        },
         "largestNodes": {
             "total": total,
             "returned": largest_items.len(),
@@ -340,7 +397,7 @@ fn build_response(
             "scannedOperations": tag_audit.scanned_operations,
             "returned": tag_operations.len(),
             "truncated": tag_audit.truncated,
-            "note": "Tag rename/merge operations are read directly from merge_operations so unrelated merge/supersede activity cannot bury them. Single-scope stats expose only operations recorded for that exact scope; all-scopes stats expose every tag scope. A reverted operation remains visible with status and revertedAt.",
+            "note": "Tag rename/merge operations are read directly from merge_operations so unrelated merge/supersede activity cannot bury them. Single-scope stats expose operations recorded for that exact scope plus every all-scopes operation (flagged allScopes=true), because an all-scopes mutation rewrote this scope's tags too; all-scopes stats expose every tag scope. A reverted operation remains visible with status and revertedAt.",
             "operations": tag_operations,
         },
     })
@@ -423,6 +480,16 @@ mod tests {
         }
     }
 
+    fn snapshot_of(nodes: Vec<HygieneNodeSummary>) -> HygieneSnapshot {
+        HygieneSnapshot {
+            nodes,
+            malformed_tag_rows: 0,
+            malformed_tag_row_ids: Vec::new(),
+            malformed_tag_row_ids_truncated: false,
+            defaulted_retention_rows: 0,
+        }
+    }
+
     fn summary(
         id: &str,
         node_type: &str,
@@ -443,6 +510,7 @@ mod tests {
             content_bytes,
             content_preview: format!("preview-{id}"),
             never_accessed: false,
+            access_unknown: false,
         }
     }
 
@@ -533,6 +601,76 @@ mod tests {
         .await
         .expect("other-scope stats");
         assert_eq!(other_stats["recentTagOperations"]["returned"], 0);
+
+        // An all-scopes operation rewrites every scope's tags, so it must be
+        // visible in EVERY single-scope audit view, flagged allScopes=true.
+        storage
+            .ingest_in_scope(
+                IngestInput {
+                    content: "other-project audit fixture".into(),
+                    tags: vec!["shared-tag".into()],
+                    ..Default::default()
+                },
+                "other-project",
+            )
+            .expect("seed other-project memory");
+        let shared_sources = vec!["shared-tag".to_string()];
+        let shared_preview = storage
+            .preview_tag_mutation(&shared_sources, "shared-canonical", None)
+            .expect("all-scopes preview");
+        storage
+            .apply_tag_mutation(
+                &shared_sources,
+                "shared-canonical",
+                None,
+                shared_preview["previewToken"].as_str().expect("token"),
+                "tag_rename",
+                "verify all-scopes audit visibility",
+            )
+            .expect("apply all-scopes rename");
+
+        let user_stats = execute(&storage, Some(json!({ "view": "stats" })))
+            .await
+            .expect("user-scope stats after all-scopes op");
+        let user_ops = user_stats["recentTagOperations"]["operations"]
+            .as_array()
+            .expect("operations array");
+        assert_eq!(user_ops.len(), 2, "scoped op plus the all-scopes op");
+        assert!(
+            user_ops
+                .iter()
+                .any(|op| op["allScopes"] == true && op["targetTag"] == "shared-canonical"),
+            "the all-scopes operation must be flagged in the scoped view"
+        );
+        assert!(
+            user_ops
+                .iter()
+                .any(|op| op["allScopes"] == false && op["scope"] == "user"),
+        );
+
+        let other_stats = execute(
+            &storage,
+            Some(json!({ "view": "stats", "scope": "other-project" })),
+        )
+        .await
+        .expect("other-scope stats after all-scopes op");
+        let other_ops = other_stats["recentTagOperations"]["operations"]
+            .as_array()
+            .expect("operations array");
+        assert_eq!(
+            other_ops.len(),
+            1,
+            "a different scope sees only the all-scopes operation"
+        );
+        assert_eq!(other_ops[0]["allScopes"], true);
+
+        let all_stats = execute(
+            &storage,
+            Some(json!({ "view": "stats", "all_scopes": true })),
+        )
+        .await
+        .expect("all-scopes stats");
+        assert_eq!(all_stats["recentTagOperations"]["returned"], 2);
     }
 
     #[test]
@@ -585,7 +723,7 @@ mod tests {
         nodes[4].never_accessed = true;
         nodes[3].never_accessed = true;
 
-        let response = build_response(nodes, None, 2, now, empty_audit());
+        let response = build_response(snapshot_of(nodes), None, 2, now, empty_audit());
 
         assert_eq!(response["scope"]["mode"], "all");
         assert_eq!(response["population"]["total"], 8);
@@ -640,7 +778,13 @@ mod tests {
         node.never_accessed = true;
         node.content_preview = format!("rotated token {credential}");
 
-        let response = build_response(vec![node], Some("user"), 50, now, empty_audit());
+        let response = build_response(
+            snapshot_of(vec![node]),
+            Some("user"),
+            50,
+            now,
+            empty_audit(),
+        );
         let encoded = serde_json::to_string(&response).expect("encode stats response");
         assert!(
             !encoded.contains(&credential),
@@ -721,5 +865,180 @@ mod tests {
         );
         assert!(parse_limit(&json!({ "limit": 0 })).is_err());
         assert!(parse_limit(&json!({ "limit": "many" })).is_err());
+    }
+
+    #[test]
+    fn pruned_log_unknowns_are_reported_separately_not_as_never_accessed() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 19, 12, 0, 0).unwrap();
+        let mut unknown = summary(
+            "pre-window",
+            "fact",
+            now - Duration::days(200),
+            0.9,
+            &["ops"],
+            10,
+        );
+        unknown.access_unknown = true;
+        let mut never = summary(
+            "fresh-never",
+            "fact",
+            now - Duration::days(2),
+            0.9,
+            &["ops"],
+            10,
+        );
+        never.never_accessed = true;
+
+        let response = build_response(
+            snapshot_of(vec![unknown, never]),
+            Some("user"),
+            50,
+            now,
+            empty_audit(),
+        );
+
+        assert_eq!(response["neverAccessed"]["total"], 1);
+        assert_eq!(
+            response["neverAccessed"]["memories"][0]["id"], "fresh-never",
+            "a pre-window row must never appear in neverAccessed"
+        );
+        assert_eq!(response["accessUnknownPrunedLog"]["total"], 1);
+        assert_eq!(
+            response["accessUnknownPrunedLog"]["memoryIds"][0],
+            "pre-window"
+        );
+        assert_eq!(response["accessUnknownPrunedLog"]["truncated"], false);
+        let never_semantics = response["semantics"]["neverAccessed"]
+            .as_str()
+            .expect("neverAccessed semantics");
+        assert!(never_semantics.contains("90-day access log"));
+        assert!(never_semantics.contains("durable retrieval counters"));
+        assert!(
+            never_semantics.contains("pruned"),
+            "the semantics must state that log rows are not durable"
+        );
+        assert!(
+            response["semantics"]["accessUnknownPrunedLog"]
+                .as_str()
+                .expect("accessUnknownPrunedLog semantics")
+                .contains("unknowable")
+        );
+    }
+
+    #[test]
+    fn by_tag_aggregate_is_bounded_to_the_top_entries_by_count() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 19, 12, 0, 0).unwrap();
+        let mut nodes = Vec::new();
+        for index in 0..250 {
+            let tag = format!("tag-{index:03}");
+            nodes.push(summary(
+                &format!("n-{index:03}"),
+                "fact",
+                now - Duration::days(1),
+                0.9,
+                &[tag.as_str()],
+                10,
+            ));
+        }
+        for index in 0..5 {
+            nodes.push(summary(
+                &format!("popular-{index}"),
+                "fact",
+                now - Duration::days(1),
+                0.9,
+                &["zzz-popular"],
+                10,
+            ));
+        }
+
+        let response = build_response(snapshot_of(nodes), Some("user"), 50, now, empty_audit());
+        let by_tag = response["counts"]["byTag"].as_object().expect("byTag map");
+        assert_eq!(by_tag.len(), MAX_TAG_COUNT_ENTRIES);
+        assert_eq!(response["counts"]["distinctTagTotal"], 251);
+        assert_eq!(response["counts"]["byTagTruncated"], true);
+        assert_eq!(
+            by_tag["zzz-popular"], 5,
+            "a high-count tag survives the bound regardless of its name"
+        );
+        assert_eq!(by_tag["tag-000"], 1);
+        assert!(
+            !by_tag.contains_key("tag-199"),
+            "count-1 ties beyond the bound are dropped by name order"
+        );
+
+        let small = build_response(
+            snapshot_of(vec![summary(
+                "solo",
+                "fact",
+                now - Duration::days(1),
+                0.9,
+                &["only-tag"],
+                10,
+            )]),
+            Some("user"),
+            50,
+            now,
+            empty_audit(),
+        );
+        assert_eq!(small["counts"]["distinctTagTotal"], 1);
+        assert_eq!(small["counts"]["byTagTruncated"], false);
+        assert_eq!(small["counts"]["byTag"]["only-tag"], 1);
+    }
+
+    #[test]
+    fn malformed_rows_and_defaulted_retention_are_surfaced_as_data_quality() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 19, 12, 0, 0).unwrap();
+        let mut snapshot = snapshot_of(vec![summary(
+            "clean",
+            "fact",
+            now - Duration::days(1),
+            0.9,
+            &["ok"],
+            10,
+        )]);
+        snapshot.malformed_tag_rows = 2;
+        snapshot.malformed_tag_row_ids = vec!["bad-json".into(), "null-tags".into()];
+        snapshot.defaulted_retention_rows = 1;
+
+        let response = build_response(snapshot, Some("user"), 50, now, empty_audit());
+        assert_eq!(response["dataQuality"]["malformedTagRows"]["count"], 2);
+        assert_eq!(
+            response["dataQuality"]["malformedTagRows"]["memoryIds"],
+            json!(["bad-json", "null-tags"])
+        );
+        assert_eq!(
+            response["dataQuality"]["malformedTagRows"]["memoryIdsTruncated"],
+            false
+        );
+        assert_eq!(response["dataQuality"]["retentionDefaultedRows"], 1);
+    }
+
+    #[test]
+    fn retention_bucket_boundaries_land_in_the_lower_bucket() {
+        assert_eq!(retention_bucket(0.0), "0-20%");
+        assert_eq!(retention_bucket(0.2), "0-20%");
+        assert_eq!(retention_bucket(0.4), ">20-40%");
+        assert_eq!(retention_bucket(0.6), ">40-60%");
+        assert_eq!(retention_bucket(0.8), ">60-80%");
+        assert_eq!(retention_bucket(1.0), ">80-100%");
+    }
+
+    #[test]
+    fn age_bucket_boundaries_land_in_the_lower_bucket() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 19, 12, 0, 0).unwrap();
+        let nodes = vec![
+            summary("age-7", "fact", now - Duration::days(7), 0.9, &[], 10),
+            summary("age-30", "fact", now - Duration::days(30), 0.9, &[], 10),
+            summary("age-90", "fact", now - Duration::days(90), 0.9, &[], 10),
+            summary("age-180", "fact", now - Duration::days(180), 0.9, &[], 10),
+            summary("age-181", "fact", now - Duration::days(181), 0.9, &[], 10),
+        ];
+        let response = build_response(snapshot_of(nodes), Some("user"), 50, now, empty_audit());
+        assert_eq!(response["counts"]["byAge"]["0-7d"], 1);
+        assert_eq!(response["counts"]["byAge"]["8-30d"], 1);
+        assert_eq!(response["counts"]["byAge"]["31-90d"], 1);
+        assert_eq!(response["counts"]["byAge"]["91-180d"], 1);
+        assert_eq!(response["counts"]["byAge"]["181d+"], 1);
+        assert_eq!(response["counts"]["byAge"]["futureDated"], 0);
     }
 }

--- a/crates/vestige-mcp/src/tools/maintenance.rs
+++ b/crates/vestige-mcp/src/tools/maintenance.rs
@@ -778,6 +778,7 @@ mod tests {
                     tags: vec![],
                     valid_from: None,
                     valid_until: None,
+                    validity_inferred: false,
                     source_envelope: None,
                 })
                 .unwrap();
@@ -833,6 +834,7 @@ mod tests {
                         tags: vec![],
                         valid_from: None,
                         valid_until: None,
+                        validity_inferred: false,
                         source_envelope: None,
                     })
                     .unwrap();
@@ -906,6 +908,7 @@ mod tests {
                 tags: vec!["schema-test".to_string()],
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap();
@@ -1018,6 +1021,7 @@ mod tests {
                 tags: vec!["portable".to_string()],
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap();

--- a/crates/vestige-mcp/src/tools/memory_unified.rs
+++ b/crates/vestige-mcp/src/tools/memory_unified.rs
@@ -580,6 +580,7 @@ mod tests {
                 tags: vec!["test-tag".to_string()],
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap();

--- a/crates/vestige-mcp/src/tools/restore.rs
+++ b/crates/vestige-mcp/src/tools/restore.rs
@@ -173,6 +173,7 @@ pub async fn execute(storage: &Arc<Storage>, args: Option<Value>) -> Result<Valu
             tags: memory.tags.clone().unwrap_or_default(),
             valid_from: None,
             valid_until: None,
+            validity_inferred: false,
             source_envelope: None,
         };
 
@@ -350,6 +351,7 @@ mod tests {
                 tags: vec!["portable".to_string()],
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap();

--- a/crates/vestige-mcp/src/tools/review.rs
+++ b/crates/vestige-mcp/src/tools/review.rs
@@ -117,6 +117,7 @@ mod tests {
             tags: vec![],
             valid_from: None,
             valid_until: None,
+            validity_inferred: false,
             source_envelope: None,
         };
         let node = storage.ingest(input).unwrap();

--- a/crates/vestige-mcp/src/tools/search_unified.rs
+++ b/crates/vestige-mcp/src/tools/search_unified.rs
@@ -1450,6 +1450,7 @@ mod tests {
             tags: vec![],
             valid_from: None,
             valid_until: None,
+            validity_inferred: false,
             source_envelope: None,
         };
         let node = storage.ingest(input).unwrap();
@@ -2602,6 +2603,7 @@ mod tests {
             tags: tags.into_iter().map(String::from).collect(),
             valid_from: None,
             valid_until: None,
+            validity_inferred: false,
             source_envelope: None,
         };
         let node = storage.ingest(input).unwrap();

--- a/crates/vestige-mcp/src/tools/session_context.rs
+++ b/crates/vestige-mcp/src/tools/session_context.rs
@@ -509,6 +509,7 @@ mod tests {
             tags: tags.into_iter().map(|s| s.to_string()).collect(),
             valid_from: None,
             valid_until: None,
+            validity_inferred: false,
             source_envelope: None,
         };
         let node = storage.ingest(input).unwrap();
@@ -716,6 +717,7 @@ mod tests {
             tags: vec!["pattern".to_string(), "codebase:vestige".to_string()],
             valid_from: None,
             valid_until: None,
+            validity_inferred: false,
             source_envelope: None,
         };
         storage.ingest(input).unwrap();

--- a/crates/vestige-mcp/src/tools/smart_ingest.rs
+++ b/crates/vestige-mcp/src/tools/smart_ingest.rs
@@ -256,7 +256,9 @@ fn infer_as_of_dates(content: &str) -> Vec<(DateTime<Utc>, String)> {
             && content[..phrase_start]
                 .chars()
                 .next_back()
-                .is_some_and(char::is_alphanumeric)
+                .is_some_and(|character| {
+                    character.is_alphanumeric() || character == '_' || character == '-'
+                })
         {
             continue;
         }
@@ -274,7 +276,7 @@ fn infer_as_of_dates(content: &str) -> Vec<(DateTime<Utc>, String)> {
         }
         if bytes
             .get(date_end)
-            .is_some_and(|byte| byte.is_ascii_digit() || *byte == b'-')
+            .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'-')
         {
             continue;
         }
@@ -311,13 +313,22 @@ fn resolve_validity_range(
 
     if range.from.is_none() {
         if inferred.len() == 1 {
-            range.from = Some(inferred[0].0);
-            inferred_phrase = Some(inferred[0].1.clone());
-            source = if explicit {
-                "explicit_and_inferred_as_of"
+            let (timestamp, phrase) = inferred[0].clone();
+            if range.until.is_some_and(|until| until <= timestamp) {
+                // An incidental prose date at or after the explicit validUntil
+                // is not caller intent; abstain from inference instead of
+                // failing the whole ingest, and surface the skipped phrase.
+                ambiguous_phrases.push(phrase);
+                source = "inferred_as_of_conflicts_with_explicit_validity_ignored";
             } else {
-                "inferred_as_of"
-            };
+                range.from = Some(timestamp);
+                inferred_phrase = Some(phrase);
+                source = if explicit {
+                    "explicit_and_inferred_as_of"
+                } else {
+                    "inferred_as_of"
+                };
+            }
         } else if inferred.len() > 1 {
             ambiguous_phrases = inferred.into_iter().map(|(_, phrase)| phrase).collect();
             source = if explicit {
@@ -326,14 +337,6 @@ fn resolve_validity_range(
                 "ambiguous_as_of_not_applied"
             };
         }
-    }
-    if let (Some(from), Some(until)) = (range.from, range.until)
-        && until <= from
-    {
-        return Err(
-            "Invalid validity range: inferred/explicit validFrom must be before validUntil"
-                .to_string(),
-        );
     }
     Ok(ValidityResolution {
         range,
@@ -381,21 +384,28 @@ fn bounded_levenshtein(left: &str, right: &str, maximum: usize) -> Option<usize>
             }
         })
         .collect();
+    // Two rows are swapped instead of allocating a fresh row per left char.
+    // Each row only rewrites its banded window, so the cells just outside the
+    // band are pinned to `outside_band` to keep off-band reads unchanged.
+    let mut current = vec![outside_band; right.len() + 1];
     for (left_index, left_char) in left.iter().enumerate() {
         let row = left_index + 1;
-        let mut current = vec![outside_band; right.len() + 1];
-        if row <= maximum {
-            current[0] = row;
-        }
+        current[0] = if row <= maximum { row } else { outside_band };
         let start = row.saturating_sub(maximum).max(1);
         let end = (row + maximum).min(right.len());
+        if start > 1 {
+            current[start - 1] = outside_band;
+        }
+        if end < right.len() {
+            current[end + 1] = outside_band;
+        }
         for column in start..=end {
             current[column] = std::cmp::min(
                 std::cmp::min(current[column - 1] + 1, previous[column] + 1),
                 previous[column - 1] + usize::from(*left_char != right[column - 1]),
             );
         }
-        previous = current;
+        std::mem::swap(&mut previous, &mut current);
     }
     (previous[right.len()] <= maximum).then_some(previous[right.len()])
 }
@@ -422,13 +432,18 @@ fn similar_tag_suggestions(
                 "maximumVocabulary": 10_000,
                 "requestedTagsTruncated": false,
                 "ignoredOverlongInputTags": 0,
+                "ignoredOverlongVocabularyTags": 0,
                 "ignoredSecretShapedVocabularyTags": 0,
                 "unicodeNormalization": "NFKC plus Unicode lowercase",
             }),
         };
     }
-    let vocabulary = match storage.tag_vocabulary(Some(scope)) {
-        Ok(vocabulary) => vocabulary,
+    // Overlong STORED tags are skipped and counted by the storage layer
+    // (mirroring overlong-input and secret-shaped handling), so one legacy
+    // tag cannot disable suggestions for the whole scope. Only the hard
+    // 10,000-tag vocabulary bound still surfaces as "unavailable".
+    let (vocabulary, ignored_overlong_vocabulary_tags) = match storage.tag_vocabulary(Some(scope)) {
+        Ok(vocabulary) => (vocabulary.tags, vocabulary.skipped_overlong),
         Err(error) => {
             return TagSuggestionReport {
                 suggestions: Vec::new(),
@@ -473,20 +488,27 @@ fn similar_tag_suggestions(
         if input_fingerprint.chars().count() < 4 {
             continue;
         }
+        // The input-side suffix fingerprint is loop-invariant; computing it
+        // per vocabulary entry repeats the NFKC normalization up to the full
+        // 10k-entry bound on the hot ingest path.
+        let input_is_namespaced = input.rsplit_once(':').is_some();
+        let input_suffix_fingerprint = normalized_tag_fingerprint(
+            input
+                .rsplit_once(':')
+                .map_or(input.as_str(), |(_, suffix)| suffix),
+        );
+        let input_suffix_is_comparable = input_suffix_fingerprint.chars().count() >= 4;
         let mut candidates = Vec::new();
         for (existing, existing_lower, existing_fingerprint) in &normalized_vocabulary {
             if existing.as_str() == input.as_str() {
                 continue;
             }
-            let input_suffix = input.rsplit_once(':').map(|(_, suffix)| suffix);
             let existing_suffix = existing.rsplit_once(':').map(|(_, suffix)| suffix);
-            let exactly_one_namespaced = input_suffix.is_some() ^ existing_suffix.is_some();
-            let input_suffix = input_suffix.unwrap_or(input);
+            let exactly_one_namespaced = input_is_namespaced ^ existing_suffix.is_some();
             let existing_suffix = existing_suffix.unwrap_or(existing);
             let namespace_variant = exactly_one_namespaced
-                && normalized_tag_fingerprint(input_suffix).chars().count() >= 4
-                && normalized_tag_fingerprint(input_suffix)
-                    == normalized_tag_fingerprint(existing_suffix);
+                && input_suffix_is_comparable
+                && input_suffix_fingerprint == normalized_tag_fingerprint(existing_suffix);
             let (score, reason) = if existing_lower.as_str() == input_lower.as_str() {
                 (1.0, "casing_variant")
             } else if existing_fingerprint.as_str() == input_fingerprint.as_str() {
@@ -539,6 +561,7 @@ fn similar_tag_suggestions(
             "maximumVocabulary": 10_000,
             "requestedTagsTruncated": requested.len() > 50,
             "ignoredOverlongInputTags": ignored_overlong,
+            "ignoredOverlongVocabularyTags": ignored_overlong_vocabulary_tags,
             "ignoredSecretShapedVocabularyTags": ignored_secret_shaped_vocabulary_tags,
             "unicodeNormalization": "NFKC plus Unicode lowercase",
         }),
@@ -741,6 +764,7 @@ pub async fn execute(
         tags,
         valid_from: validity.range.from,
         valid_until: validity.range.until,
+        validity_inferred: validity.inferred_phrase.is_some(),
         source_envelope: None,
     };
 
@@ -832,6 +856,7 @@ pub async fn execute(
             "previousContent": previous_content,
             "mergedFrom": result.merged_from,
             "mergePreview": merge_preview,
+            "autoClosedUntil": result.auto_closed_until.map(|value| value.to_rfc3339()),
             "importanceScore": importance_composite,
             "synapticCapture": synaptic_capture,
             "reason": result.reason,
@@ -1054,6 +1079,7 @@ async fn execute_batch(
             tags,
             valid_from: validity.range.from,
             valid_until: validity.range.until,
+            validity_inferred: validity.inferred_phrase.is_some(),
             source_envelope: None,
         };
 
@@ -1164,6 +1190,7 @@ async fn execute_batch(
                         "previousContent": previous_content,
                         "mergedFrom": result.merged_from,
                         "mergePreview": merge_preview,
+                        "autoClosedUntil": result.auto_closed_until.map(|value| value.to_rfc3339()),
                         "importanceScore": importance_composite,
                         "synapticCapture": synaptic_capture,
                         "reason": result.reason,
@@ -1946,13 +1973,96 @@ mod tests {
             1,
             "a Unicode phrase before the ASCII marker must not break byte boundaries"
         );
+
+        assert!(
+            infer_as_of_dates("as of 2026-03-04T09:15:00Z must not match").is_empty(),
+            "a trailing timestamp component is not a bare date"
+        );
+        assert!(
+            infer_as_of_dates("as of 2026-03-04abc must not match").is_empty(),
+            "a trailing letter means the token is not a date"
+        );
+        assert!(
+            infer_as_of_dates("save_as of 2026-03-04 must not match").is_empty(),
+            "a preceding underscore is not an 'as of' phrase boundary"
+        );
+        assert!(
+            infer_as_of_dates("x-as of 2026-03-04 must not match").is_empty(),
+            "a preceding hyphen is not an 'as of' phrase boundary"
+        );
+        assert_eq!(
+            infer_as_of_dates("Reported as of 2026-03-04.").len(),
+            1,
+            "trailing punctuation is a valid right boundary"
+        );
+        assert_eq!(
+            infer_as_of_dates("Inventory (as of 2026-03-04)").len(),
+            1,
+            "surrounding parentheses are valid boundaries"
+        );
+        assert!(
+            infer_as_of_dates("as of 2026-03-041 must not match").is_empty(),
+            "a trailing digit means the token is not a date"
+        );
+        assert!(
+            infer_as_of_dates("as of 2026-03-04-05 must not match").is_empty(),
+            "a trailing hyphen means the token is not a date"
+        );
     }
 
     #[test]
     fn inferred_as_of_must_not_cross_an_explicit_valid_until() {
-        let error = resolve_validity_range("Policy as of 2026-04-01", None, Some("2026-03-01"))
-            .unwrap_err();
-        assert!(error.contains("must be before validUntil"));
+        // An incidental prose date at or after the explicit validUntil is not
+        // caller intent: the inference abstains instead of failing the ingest.
+        let resolution =
+            resolve_validity_range("Policy as of 2026-04-01", None, Some("2026-03-01"))
+                .expect("a conflicting inferred date abstains instead of erroring");
+        assert!(resolution.range.from.is_none());
+        assert_eq!(
+            resolution.range.until.unwrap().to_rfc3339(),
+            "2026-03-01T00:00:00+00:00"
+        );
+        assert_eq!(
+            resolution.source,
+            "inferred_as_of_conflicts_with_explicit_validity_ignored"
+        );
+        assert!(resolution.inferred_phrase.is_none());
+        assert_eq!(resolution.ambiguous_phrases, vec!["as of 2026-04-01"]);
+    }
+
+    #[tokio::test]
+    async fn conflicting_inferred_as_of_abstains_and_the_ingest_still_stores() {
+        let (storage, _dir) = test_storage().await;
+        let response = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "content": "Retrospective written as of 2026-04-01 about the old policy.",
+                "validUntil": "2026-03-01",
+                "forceCreate": true
+            })),
+        )
+        .await
+        .expect("the conflicting phrase must not hard-fail the whole ingest");
+        assert_eq!(
+            response["validity"]["source"],
+            "inferred_as_of_conflicts_with_explicit_validity_ignored"
+        );
+        assert_eq!(
+            response["validity"]["ambiguousPhrases"][0],
+            "as of 2026-04-01"
+        );
+        assert!(response["validity"]["inferredPhrase"].is_null());
+        let node = storage
+            .get_node(response["nodeId"].as_str().unwrap())
+            .unwrap()
+            .unwrap();
+        assert!(node.valid_from.is_none(), "the inference was dropped");
+        assert_eq!(
+            node.valid_until.unwrap().to_rfc3339(),
+            "2026-03-01T00:00:00+00:00",
+            "the explicit bound is kept"
+        );
     }
 
     #[test]
@@ -1963,6 +2073,49 @@ mod tests {
         );
         assert_eq!(bounded_levenshtein("colour", "colur", 1), Some(1));
         assert_eq!(bounded_levenshtein("unrelated", "banana", 2), None);
+    }
+
+    #[test]
+    fn bounded_levenshtein_matches_the_naive_distance_at_band_edges() {
+        fn naive(left: &str, right: &str) -> usize {
+            let left: Vec<char> = left.chars().collect();
+            let right: Vec<char> = right.chars().collect();
+            let mut previous: Vec<usize> = (0..=right.len()).collect();
+            for (row, left_char) in left.iter().enumerate() {
+                let mut current = vec![row + 1];
+                for (column, right_char) in right.iter().enumerate() {
+                    current.push(std::cmp::min(
+                        std::cmp::min(current[column] + 1, previous[column + 1] + 1),
+                        previous[column] + usize::from(left_char != right_char),
+                    ));
+                }
+                previous = current;
+            }
+            previous[right.len()]
+        }
+        for (left, right) in [
+            ("", ""),
+            ("", "ab"),
+            ("ab", ""),
+            ("kitten", "sitting"),
+            ("sitting", "kitten"),
+            ("colour", "colur"),
+            ("abcdef", "abcdef"),
+            ("axcdef", "abcdef"),
+            ("abc", "abcde"),
+            ("abcde", "abc"),
+            ("résumé", "resume"),
+            ("prix-six", "prixsix"),
+        ] {
+            for maximum in 0..=3 {
+                let expected = Some(naive(left, right)).filter(|distance| *distance <= maximum);
+                assert_eq!(
+                    bounded_levenshtein(left, right, maximum),
+                    expected,
+                    "left={left:?} right={right:?} maximum={maximum}"
+                );
+            }
+        }
     }
 
     #[tokio::test]
@@ -2216,15 +2369,87 @@ mod tests {
         assert_eq!(tagless.status["status"], "complete");
         assert_eq!(tagless.status["vocabularyScanned"], false);
 
+        // One overlong stored tag degrades gracefully: it is skipped and
+        // counted instead of disabling suggestions for the whole scope.
         let bounded = similar_tag_suggestions(&storage, "user", &["candidate".to_string()]);
-        assert_eq!(bounded.status["status"], "unavailable");
+        assert_eq!(bounded.status["status"], "complete");
+        assert_eq!(bounded.status["vocabularyScanned"], true);
+        assert_eq!(bounded.status["vocabularyCount"], 0);
+        assert_eq!(bounded.status["ignoredOverlongVocabularyTags"], 1);
+        assert!(bounded.suggestions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn vocabulary_beyond_ten_thousand_tags_is_reported_unavailable() {
+        let (storage, _dir) = test_storage().await;
+        // 21 memories x 500 distinct tags = 10,500 eligible vocabulary tags.
+        for batch in 0..21 {
+            let tags: Vec<String> = (0..500)
+                .map(|index| format!("bulk-{batch:02}-{index:03}"))
+                .collect();
+            storage
+                .ingest(IngestInput {
+                    content: format!("vocabulary bound fixture {batch}"),
+                    tags,
+                    ..Default::default()
+                })
+                .unwrap();
+        }
+
+        let report = similar_tag_suggestions(&storage, "user", &["candidate".to_string()]);
+        assert_eq!(report.status["status"], "unavailable");
         assert!(
-            bounded.status["reason"]
+            report.status["reason"]
                 .as_str()
                 .unwrap()
-                .contains("longer than the 200-character")
+                .contains("exceeds the 10000-tag"),
+            "the 10,000-tag bound stays a hard error and is not masked by overlong skipping"
         );
-        assert!(bounded.suggestions.is_empty());
+        assert!(report.suggestions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn requested_tags_beyond_the_50_bound_are_reported_truncated_and_skipped() {
+        let (storage, _dir) = test_storage().await;
+        storage
+            .ingest(IngestInput {
+                content: "vocabulary for the truncation bound".to_string(),
+                tags: vec!["colour".to_string()],
+                ..Default::default()
+            })
+            .unwrap();
+
+        // 50 requested tags stay within the bound: the last one is scanned.
+        let mut within: Vec<String> = (0..49)
+            .map(|index| format!("filler-tag-{index:02}"))
+            .collect();
+        within.push("colur".to_string());
+        let report = similar_tag_suggestions(&storage, "user", &within);
+        assert_eq!(report.status["status"], "complete");
+        assert_eq!(report.status["requestedTagsTruncated"], false);
+        assert!(
+            report
+                .suggestions
+                .iter()
+                .any(|suggestion| suggestion["inputTag"] == "colur"),
+            "the 50th requested tag is still scanned"
+        );
+
+        // A 51st tag crosses the bound: it is reported truncated and skipped.
+        let mut truncated: Vec<String> = (0..50)
+            .map(|index| format!("filler-tag-{index:02}"))
+            .collect();
+        truncated.push("colur".to_string());
+        let report = similar_tag_suggestions(&storage, "user", &truncated);
+        assert_eq!(report.status["status"], "complete");
+        assert_eq!(report.status["requestedTagsTruncated"], true);
+        assert!(
+            !report
+                .suggestions
+                .iter()
+                .any(|suggestion| suggestion["inputTag"] == "colur"),
+            "the 51st requested tag must not be scanned"
+        );
     }
 
     #[tokio::test]

--- a/crates/vestige-mcp/src/tools/suppress.rs
+++ b/crates/vestige-mcp/src/tools/suppress.rs
@@ -177,6 +177,7 @@ mod tests {
                 tags: vec!["test".to_string()],
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap()

--- a/crates/vestige-mcp/src/tools/timeline.rs
+++ b/crates/vestige-mcp/src/tools/timeline.rs
@@ -209,6 +209,7 @@ mod tests {
                 tags: vec!["timeline-test".to_string()],
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap();
@@ -227,6 +228,7 @@ mod tests {
                 tags: tags.iter().map(|t| t.to_string()).collect(),
                 valid_from: None,
                 valid_until: None,
+                validity_inferred: false,
                 source_envelope: None,
             })
             .unwrap();

--- a/crates/vestige-mcp/src/trace_recorder.rs
+++ b/crates/vestige-mcp/src/trace_recorder.rs
@@ -1806,6 +1806,10 @@ mod tests {
 
     #[test]
     fn receipt_and_final_capsule_persist_atomically_without_raw_replay_material() {
+        // configured_receipt_signer reads process env. Serialize with the
+        // signing-env tests so a parallel missing-key fixture cannot turn this
+        // unsigned persist into "temporarily unavailable".
+        let _lock = receipt_signing_env_lock().lock().unwrap();
         let temp = tempfile::tempdir().unwrap();
         let db_path = temp.path().join("retrieval-capsule.db");
         let storage = Arc::new(vestige_core::Storage::new(Some(db_path.clone())).unwrap());

--- a/docs/MEMORY_HYGIENE.md
+++ b/docs/MEMORY_HYGIENE.md
@@ -6,7 +6,9 @@ Vestige exposes project-isolated, agent-facing hygiene workflows without requiri
 
 `smart_ingest` accepts explicit `validFrom` and `validUntil` values as RFC 3339 timestamps or exact `YYYY-MM-DD` dates. Explicit values remain authoritative.
 
-When `validFrom` is omitted and content contains exactly one distinct, strict `as of YYYY-MM-DD` date, Vestige infers that date as `validFrom`. Matching is case-insensitive and boundary-aware. Repeating the same date is unambiguous; multiple distinct dates, invalid calendar dates, or embedded-word matches are not inferred. The response's `validity` object always reports whether values were `explicit`, `inferred_as_of`, ambiguous and ignored, or absent. An inferred start that conflicts with an explicit `validUntil` is rejected before any write.
+When `validFrom` is omitted and content contains exactly one distinct, strict `as of YYYY-MM-DD` date, Vestige infers that date as `validFrom` for a **new** node. Matching is case-insensitive and boundary-aware. Repeating the same date is unambiguous; multiple distinct dates, invalid calendar dates, or embedded-word matches are not inferred. The response's `validity` object always reports whether values were `explicit`, `inferred_as_of`, ambiguous and ignored, or absent.
+
+An inferred start that conflicts with an explicit `validUntil` is **not** applied; the ingest still stores and the skipped phrase is reported. Prose-inferred dates never rewrite an existing node's window: Prediction Error Gating `Update` / `Reinforce` / `Merge` / `Replace` only mutates stored `valid_from` / `valid_until` when the caller supplied those fields explicitly. `update_node_validity` merges bounds (`COALESCE`); omitting a bound preserves the stored value instead of writing `NULL`. That keeps an expired fact expired when a near-duplicate arrives with `as of YYYY-MM-DD` in the body.
 
 ## Similar-tag preflight
 
@@ -38,7 +40,9 @@ This returns `wouldWrite: false`, a `tagSuggestions` list, and `tagSuggestionSta
 
 Vestige recalculates the same-scope vocabulary and rejects any mapping that is no longer a current suggestion. Omitting `acceptedTagSuggestions` preserves the caller's original tags. Batch items support the same two fields independently.
 
-The vocabulary scan uses distinct same-scope tags and fails the nudge explicitly above 10,000 distinct tags or when legacy vocabulary contains an over-200-character tag. At most 50 caller tags of at most 200 characters each are considered, and edit distance is bounded to the one- or two-edit window Vestige can actually suggest. Secret-shaped caller mappings are rejected without echoing their bytes; secret-shaped legacy tags are excluded from responses and reported only as an ignored count. NFKC plus Unicode lowercase normalization is used; locale-specific language rules are deliberately not inferred.
+The vocabulary scan uses distinct same-scope tags and fails the nudge explicitly above 10,000 distinct tags. Stored tags longer than 200 characters are skipped and counted (`ignoredOverlongVocabularyTags`) instead of disabling suggestions for the whole scope; they remain renameable through `dedup`. At most 50 caller tags of at most 200 characters each are considered, and edit distance is bounded to the one- or two-edit window Vestige can actually suggest. Secret-shaped caller mappings are rejected without echoing their bytes; secret-shaped legacy tags are excluded from responses and reported only as an ignored count. NFKC plus Unicode lowercase normalization is used; locale-specific language rules are deliberately not inferred.
+
+Ordinary tagged `smart_ingest` still computes suggestions on the write path. Deferring that scan until `previewTagSuggestions` or `acceptedTagSuggestions` is tracked separately and is not claimed here.
 
 ## Exact tag rename and merge
 
@@ -66,8 +70,9 @@ Aggregates cover the full store and include:
 - age bands `0-7d`, `8-30d`, `31-90d`, `91-180d`, `181d+`, plus future-dated rows;
 - fixed retention buckets, including zero-count buckets;
 - lifecycle counts for current, future, expired, invalid-window, and superseded rows;
-- never-accessed total and deterministic bounded list;
+- `neverAccessed`: no retained access-log row, durable retrieval counters (`times_retrieved` / `times_useful`) are zero, **and** the memory was created inside the 90-day access-log window. The log is pruned after 90 days, so absence of a log row is not durable evidence;
+- `accessUnknownPrunedLog`: created before that window with zero durable counters. Pre-prune history is unknowable. Agents must not suppress or purge these on access grounds;
 - largest-node total and deterministic bounded list by UTF-8 byte size;
-- recent tag rename/merge audit operations.
+- recent tag rename/merge audit operations. `all_scopes` operations appear on single-scope stats when they rewrote that scope's tags.
 
 Only detail lists are capped (`limit` defaults to 50 and is at most 200). Each list reports its total and whether it was truncated. The storage query loads bounded content previews rather than every full memory body and computes access status without per-row queries. If a preview contains a blocking credential shape, the preview is replaced with a redaction marker and `contentPreviewRedacted` is true; the matched secret bytes are not returned.

--- a/tests/e2e/src/harness/db_manager.rs
+++ b/tests/e2e/src/harness/db_manager.rs
@@ -31,6 +31,7 @@ fn make_ingest_input(
         source,
         valid_from,
         valid_until,
+        validity_inferred: false,
         source_envelope: None,
     }
 }

--- a/tests/e2e/src/mocks/fixtures.rs
+++ b/tests/e2e/src/mocks/fixtures.rs
@@ -29,6 +29,7 @@ fn make_ingest_input(
         source,
         valid_from,
         valid_until,
+        validity_inferred: false,
         source_envelope: None,
     }
 }


### PR DESCRIPTION
Follow-up to #170. Do not reopen #156.

## Headlines

1. **As-of resurrection (#170 regression, no separate issue).** Prose `as of YYYY-MM-DD` on a similar ingest was inferred as `validFrom`, then PEG Update/Reinforce called `update_node_validity(inferred, None)`, which **REPLACE**-set `valid_until` to `NULL` and un-expired the matched existing node. Inferred dates now stamp **new** nodes only. Explicit caller validity still mutates stored bounds. `update_node_validity` **merges** with `COALESCE`. Regression: similar ingest of an already-expired node keeps `valid_until`.

2. **#171 neverAccessed lied after the 90-day access-log prune.** On Aaron Garcia's ~7-month store, used memories looked untouched. `neverAccessed` now requires zero log rows, zero durable retrieval counters, **and** creation inside the retained window. Older rows with no counters go to `accessUnknownPrunedLog` and must not be purged on access grounds. Docs in `MEMORY_HYGIENE.md` match the payload.

## Not closed: #172

#172 asks to **defer** the similar-tag vocabulary scan until `previewTagSuggestions` / `acceptedTagSuggestions`. This branch does **not** change when suggestions run. It hoists loop-invariant fingerprints, reuses Levenshtein buffers, and skips overlong stored tags instead of failing the whole scope. Leave #172 on the roadmap.

Closes #171

## Also in this PR (adversarial hardening on the #170 surface)

- reason-mode recall gets the same ×0.1 expiry penalty and surfaces currentlyValid/validUntil
- out-of-order dated claims auto-close at the newer claim's validFrom
- as-of parser boundaries (alnum right, `_`/`-` left)
- inferred date vs explicit validUntil **abstains** instead of failing the ingest
- malformed/NULL tag rows and NULL retention are tolerated and counted
- `byTag` bounded top-200 with `distinctTagTotal`
- scoped audit listings include all-scopes operations
- overlong stored tags are renameable (length cap is target-only)
- source tags match byte-exact; credential-shaped source tags can be renamed away
- `dedup` rejects contradictory `scope` + `all_scopes`
- V29 normalized-scope index assertions
- tag mutation + audit share one transaction (fault-injection)
- 50-tag / 10k-vocabulary bounds
- unsigned receipt persist test serialized against signing-env races (CI flake on parallel `VESTIGE_RECEIPT_SIGNING_KEY_ID`)

## Verification

- `cargo clippy --workspace -- -D warnings` clean
- `git diff --check origin/main...HEAD` clean
- `cargo fmt --all --check` is **not** a merge gate here: `main` already has pre-existing rustfmt drift outside this diff
- Headline regressions green: `inferred_as_of_must_not_resurrect_an_expired_similar_node`, `inferred_as_of_validity_never_mutates_an_existing_nodes_window`, `update_node_validity_merges_bounds_and_validates_the_effective_window`, `hygiene_snapshot_distinguishes_unknown_pruned_access_from_never_accessed`, `pruned_log_unknowns_are_reported_separately_not_as_never_accessed`
- `cargo test --workspace`: vestige-core 753 ok; e2e/journey/mcp integration ok; vestige-mcp lib 564 ok on rerun; vestige-spacetime 22 ok; phase_1 28 ok
- One pre-existing parallel flake (`receipt_and_final_capsule_persist_atomically_without_raw_replay_material`) reproduced, then locked

## Non-goals

- Do not revert #170
- Do not put Solo Continuity / Operator GTM on this PR
- Do not auto-apply similar tags
- Do not change the 90-day access-log prune window