### PR TITLE
Fix MCP install copy so Cursor and Claude Desktop start vestige-mcp

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -49,6 +49,7 @@ Qwen3 currently uses Hugging Face Hub's Candle loader directly, so use the stand
 | `VESTIGE_TRACE` | `on` | Agent Black Box trace recording. **On by default**: every MCP tool call writes rows to `agent_traces`/`agent_runs` in your local database. Set `0`/`false`/`off`/`no` to turn the recorder off. Read once per process, so changing it mid-process has no effect |
 | `VESTIGE_TRACE_RETENTION_DAYS` | `30` | How long Black Box traces are kept. The consolidation cycle deletes trace events older than this and drops any `agent_runs` roll-up left with no events. `0` keeps traces forever (sweep disabled); unset, empty, negative, or malformed values fall back to `30` |
 | `VESTIGE_DISABLE_VECTOR_SEARCH` | unset (vector search on) | Kill switch for the HNSW vector index. Set to `1`/`true`/`yes`/`on`/`enable`/`enabled` to force semantic/vector search off and fall back to keyword search. Useful on older x86 CPUs — the index also disables itself automatically when AVX2+FMA are missing |
+| `ORT_DYLIB_PATH` | unset | Intel Mac (`x86_64-apple-darwin`) only: absolute path to Homebrew `libonnxruntime.dylib`. Resolve with `brew --prefix onnxruntime` (do not hardcode `/opt/homebrew` vs `/usr/local`). GUI clients (Cursor, Claude Desktop) do not inherit `.zshrc` — set this in the MCP JSON `env` block. See [Intel Mac install](INSTALL-INTEL-MAC.md) |
 
 > **Storage location precedence:** `--data-dir <path>` wins over `VESTIGE_DATA_DIR`; if neither is set, Vestige uses your OS's per-user data directory: `~/Library/Application Support/com.vestige.core/` on macOS, `~/.local/share/vestige/core/` on Linux, `%APPDATA%\vestige\core\` on Windows. Custom paths are directories, are created if missing, expand a leading `~`, and store the database at `<dir>/vestige.db`.
 
@@ -196,7 +197,7 @@ limit = 50
 
 ```bash
 vestige-mcp --data-dir /custom/path   # Custom storage location
-VESTIGE_DATA_DIR=~/.vestige vestige-mcp # Env fallback storage location
+VESTIGE_DATA_DIR="$HOME/.vestige" vestige-mcp # Env fallback (shell); GUI JSON does not expand ~
 VESTIGE_DATA_DIR=./.vestige vestige stats # Point the CLI at the same custom DB
 vestige-mcp --help                     # Show all options
 ```
@@ -260,25 +261,60 @@ Add to `~/.claude/settings.json`:
 
 ### Claude Desktop (macOS)
 
+Claude Desktop is a GUI app: it does not inherit your shell PATH and does not expand `~` in JSON. After `npm install -g vestige-mcp-server@latest`, paste the absolute path from `which vestige-mcp`. nvm/fnm/Homebrew npm will not be `/usr/local/bin`.
+
 Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 ```json
 {
   "mcpServers": {
     "vestige": {
-      "command": "vestige-mcp"
+      "command": "<absolute path from which vestige-mcp>"
     }
   }
 }
 ```
 
+Per-project memory — live storage flag is `--data-dir`, and the directory must be absolute:
+
+```json
+{
+  "mcpServers": {
+    "vestige": {
+      "command": "<absolute path from which vestige-mcp>",
+      "args": ["--data-dir", "/Users/you/projects/my-app/.vestige"]
+    }
+  }
+}
+```
+
+**Intel Mac:** Claude Desktop does not inherit `.zshrc`. Put `ORT_DYLIB_PATH` in the MCP `env` block. Run `brew --prefix onnxruntime` and paste the result — do not hardcode `/opt/homebrew` vs `/usr/local`. See [Intel Mac install](INSTALL-INTEL-MAC.md).
+
+```json
+{
+  "mcpServers": {
+    "vestige": {
+      "command": "<absolute path from which vestige-mcp>",
+      "args": [],
+      "env": {
+        "ORT_DYLIB_PATH": "<brew --prefix onnxruntime>/lib/libonnxruntime.dylib"
+      }
+    }
+  }
+}
+```
+
+Drop-in skeleton: [`claude-desktop-config.json`](claude-desktop-config.json).
+
 ### Claude Desktop (Windows)
+
+Same GUI PATH rule: paste the absolute path from `where vestige-mcp`. Official install is npm, not cargo.
 
 Add to `%APPDATA%\Claude\claude_desktop_config.json`:
 ```json
 {
   "mcpServers": {
     "vestige": {
-      "command": "vestige-mcp"
+      "command": "<absolute path from where vestige-mcp>"
     }
   }
 }

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -13,7 +13,7 @@ Vestige is local-first: one binary, your data on your disk, no account, no cloud
 Install is one command and connecting is one JSON block. The canonical, always-current
 steps live in the README so this guide never drifts from them:
 
-- **[Install + connect →](../README.md#-get-it-running-in-60-seconds)**
+- **[Install + connect →](../README.md#install)**
 - Using a specific editor? Pick your per-agent guide —
   [Cursor](integrations/cursor.md), [VS Code](integrations/vscode.md),
   [Windsurf](integrations/windsurf.md), [JetBrains](integrations/jetbrains.md),
@@ -68,7 +68,7 @@ vestige backfill --contrast
 
 `--contrast` shows you, side by side, what a plain similarity search returns versus
 the real causal cause. That contrast is the whole pitch — more on the mechanism in
-**[the README](../README.md#-the-thing-nothing-else-does-memory-with-hindsight)**.
+**[the README](../README.md#backward-reach-the-backfill-feature)**.
 
 You can also just talk to your agent normally; it will write and recall memories for
 you through MCP. The CLI is for when you want to drive it directly.
@@ -120,7 +120,7 @@ including multi-instance setups, are in **[Storage Modes](STORAGE.md)** and
 | Understand a specific feature or the research | [The Science](SCIENCE.md) |
 | Tune knobs, env vars, ports | [Configuration](CONFIGURATION.md) |
 | Global vs per-project vs multi-instance | [Storage Modes](STORAGE.md) |
-| Make your agent use memory automatically | [README → automatic memory](../README.md#-make-your-ai-use-memory-automatically) |
+| Make your agent use memory automatically | [README → automatic memory](../README.md#optional-make-the-agent-use-memory-automatically) |
 | Ask a real question | [FAQ](FAQ.md) |
 
 Welcome. Vestige gets more useful the longer you use it — that's the point.

--- a/docs/INSTALL-INTEL-MAC.md
+++ b/docs/INSTALL-INTEL-MAC.md
@@ -6,6 +6,9 @@ x86_64 macOS prebuilts after ONNX Runtime v1.23.0, so we use the
 `ort-dynamic` feature to runtime-link against the version you install locally.
 This keeps Vestige working on Intel Mac without waiting for a dead upstream.
 
+As of Vestige 2.3.0 this is still the Intel Mac path. Homebrew ONNX Runtime
+remains required; there is no pure-Rust Intel backend in the current release.
+
 ## Prerequisite
 
 Install ONNX Runtime via Homebrew:
@@ -20,20 +23,48 @@ brew install onnxruntime
 # 1. Install the binary
 npm install -g vestige-mcp-server@latest
 
-# 2. Point the binary at Homebrew's libonnxruntime
+# 2. Point the binary at Homebrew's libonnxruntime (CLI / terminal clients)
 echo 'export ORT_DYLIB_PATH="'"$(brew --prefix onnxruntime)"'/lib/libonnxruntime.dylib"' >> ~/.zshrc
 source ~/.zshrc
 
 # 3. Verify
 vestige-mcp --version
 
-# 4. Connect to Claude Code
+# 4. Connect to Claude Code (inherits the shell env if you launched it from a terminal)
 claude mcp add vestige vestige-mcp -s user
 ```
 
 `ORT_DYLIB_PATH` is how the `ort` crate's `load-dynamic` feature finds the
 shared library at runtime. Without it the binary starts but fails on the first
 embedding call with a "could not find libonnxruntime" error.
+
+## GUI clients (Cursor, Claude Desktop)
+
+Cursor and Claude Desktop **do not inherit `.zshrc`**. Exporting `ORT_DYLIB_PATH`
+in your shell is not enough for those apps. Put it in the MCP JSON `env` block,
+and paste the absolute `vestige-mcp` path from `which vestige-mcp`.
+
+Run `brew --prefix onnxruntime` and paste the result. Do not hardcode
+`/opt/homebrew` vs `/usr/local`.
+
+```json
+{
+  "mcpServers": {
+    "vestige": {
+      "command": "<absolute path from which vestige-mcp>",
+      "args": [],
+      "env": {
+        "ORT_DYLIB_PATH": "<brew --prefix onnxruntime>/lib/libonnxruntime.dylib"
+      }
+    }
+  }
+}
+```
+
+| Client | Config file |
+|--------|-------------|
+| Cursor | `~/.cursor/mcp.json` ([guide](integrations/cursor.md)) |
+| Claude Desktop | `~/Library/Application Support/Claude/claude_desktop_config.json` ([guide](CONFIGURATION.md#claude-desktop-macos)) |
 
 ## Building from source
 
@@ -50,9 +81,9 @@ export ORT_DYLIB_PATH="$(brew --prefix onnxruntime)/lib/libonnxruntime.dylib"
 ## Troubleshooting
 
 **`dyld: Library not loaded: libonnxruntime.dylib`** — `ORT_DYLIB_PATH` is not
-set for the shell that spawned `vestige-mcp`. Claude Code / Codex inherits the
-env vars from whatever launched it; export `ORT_DYLIB_PATH` in `~/.zshrc` or
-`~/.bashrc` and restart the client.
+set for the process that spawned `vestige-mcp`. Terminal clients pick it up from
+`~/.zshrc` / `~/.bashrc`. Cursor and Claude Desktop do not: put `ORT_DYLIB_PATH`
+in the MCP JSON `env` block (see above) and restart the app.
 
 **`error: ort-sys does not provide prebuilt binaries for the target
 x86_64-apple-darwin`** — you hit this only if you ran `cargo build` without the
@@ -64,9 +95,3 @@ rebuild.
 nothing** — upgrade brew (`brew update`) and retry. Older brew formulae used
 `onnx-runtime` (hyphenated). If your brew still has the hyphenated formula,
 substitute accordingly in the commands above.
-
-## Long-term
-
-Intel Mac will move to a fully pure-Rust backend (`ort-candle`) in Vestige
-v2.1, removing the Homebrew prerequisite entirely. Track progress at
-[issue #41](https://github.com/samvallad33/vestige/issues/41).

--- a/docs/claude-desktop-config.json
+++ b/docs/claude-desktop-config.json
@@ -1,11 +1,7 @@
 {
   "mcpServers": {
     "vestige": {
-      "command": "vestige-mcp",
-      "args": ["--project", "."],
-      "env": {
-        "VESTIGE_DATA_DIR": "~/.vestige"
-      }
+      "command": "<absolute path from which vestige-mcp>"
     }
   }
 }

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -8,6 +8,8 @@ Cursor has native MCP support. Add Vestige and your AI assistant remembers your 
 
 ## Setup
 
+After `npm install -g vestige-mcp-server@latest`, the `vestige-mcp` binary is on your **shell** PATH. Cursor's GUI does not reliably inherit that PATH and does not expand `~`. Paste the absolute path; do not guess `/usr/local/bin`.
+
 ### 1. Create or edit the config file
 
 **Global (all projects):**
@@ -23,30 +25,50 @@ mkdir -p ~/.cursor
 open -e ~/.cursor/mcp.json
 ```
 
-### 2. Add Vestige
+### 2. Resolve the binary, then add Vestige
+
+```bash
+which vestige-mcp          # macOS / Linux
+where vestige-mcp          # Windows
+```
+
+nvm, fnm, and Homebrew npm almost never install into `/usr/local/bin`. Paste whatever the command above prints.
 
 ```json
 {
   "mcpServers": {
     "vestige": {
-      "command": "/usr/local/bin/vestige-mcp",
-      "args": [],
-      "env": {}
+      "command": "<absolute path from which vestige-mcp>",
+      "args": []
     }
   }
 }
 ```
 
-> **Use absolute paths.** Cursor does not reliably resolve relative paths or `~`. Run `which vestige-mcp` to find your binary location.
+**Windows:** same shape. Official install is npm, not cargo — paste the absolute path from `where vestige-mcp`. A `.cargo\bin` path is only correct if you built from source.
 
-**Windows:**
 ```json
 {
   "mcpServers": {
     "vestige": {
-      "command": "C:\\Users\\you\\.cargo\\bin\\vestige-mcp.exe",
+      "command": "<absolute path from where vestige-mcp>",
+      "args": []
+    }
+  }
+}
+```
+
+**Intel Mac:** Cursor does not inherit `.zshrc`. Put `ORT_DYLIB_PATH` in this same `env` block. Run `brew --prefix onnxruntime` and paste the result — do not hardcode `/opt/homebrew` vs `/usr/local`. See [Intel Mac install](../INSTALL-INTEL-MAC.md).
+
+```json
+{
+  "mcpServers": {
+    "vestige": {
+      "command": "<absolute path from which vestige-mcp>",
       "args": [],
-      "env": {}
+      "env": {
+        "ORT_DYLIB_PATH": "<brew --prefix onnxruntime>/lib/libonnxruntime.dylib"
+      }
     }
   }
 }
@@ -62,7 +84,7 @@ Open Cursor's AI chat and ask:
 
 > "What MCP tools do you have access to?"
 
-You should see Vestige's tools listed (search, smart_ingest, memory, etc.).
+You should see Vestige's tools listed (`smart_ingest`, `recall`, `backfill`).
 
 ---
 
@@ -82,15 +104,14 @@ It remembers.
 
 ## Project-Specific Memory
 
-To isolate memory per project, use `--data-dir`:
+To isolate memory per project, pass `--data-dir` with an **absolute** directory (Cursor does not expand `~` or relative paths in `args`):
 
 ```json
 {
   "mcpServers": {
     "vestige": {
-      "command": "/usr/local/bin/vestige-mcp",
-      "args": ["--data-dir", "/Users/you/projects/my-app/.vestige"],
-      "env": {}
+      "command": "<absolute path from which vestige-mcp>",
+      "args": ["--data-dir", "/Users/you/projects/my-app/.vestige"]
     }
   }
 }
@@ -105,9 +126,10 @@ Or place a `.cursor/mcp.json` in the project root for project-level config.
 <details>
 <summary>Vestige tools not appearing</summary>
 
-1. Verify the binary exists:
+1. Verify the binary exists and copy that exact path into `command`:
    ```bash
-   which vestige-mcp
+   which vestige-mcp          # macOS / Linux
+   where vestige-mcp          # Windows
    ```
 2. Test the binary manually:
    ```bash


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Docs-only. After `npm install -g vestige-mcp-server@latest`, Cursor and Claude Desktop configs copied from these docs should actually start `vestige-mcp`.

Verified against the live binary (`crates/vestige-mcp/src/main.rs` CLI parser, `server.rs` tool list, README headings). `--project` is not a flag (unknown args exit 1). Live storage flag is `--data-dir`. Advertised tools include `recall`, `smart_ingest`, and `backfill` (`search` is a hidden v2.2 alias). Official Monday path is npm (`vestige-mcp` on PATH), not cargo.

## Monday failures and fixes

1. **Cursor pasted `/usr/local/bin/vestige-mcp` and the server never started.** nvm/fnm/Homebrew npm almost never install there, and the Cursor GUI does not inherit shell PATH or expand `~`. The guide now says run `which vestige-mcp` (Windows: `where vestige-mcp`) and paste that absolute path. Primary JSON is `command` + empty `args`.

2. **Windows example used `C:\Users\you\.cargo\bin\vestige-mcp.exe` as the npm path.** Cargo is from-source only. Windows copy now uses the same absolute-path-from-`where` shape.

3. **Claude Desktop drop-in used `args: ["--project", "."]`.** That flag does not exist; the process exits. Replaced with `{ "command": "<absolute path from which vestige-mcp>" }`. Per-project memory is `args: ["--data-dir", "<absolute dir>"]`.

4. **Drop-in set `VESTIGE_DATA_DIR: "~/.vestige"`.** Claude Desktop does not expand `~` in JSON env. Removed. Default OS data dir is fine; custom dirs use `--data-dir` with an absolute path.

5. **Claude Desktop docs used a bare `vestige-mcp` command.** Same GUI PATH problem as Cursor. macOS path stays `~/Library/Application Support/Claude/claude_desktop_config.json`; Windows stays `%APPDATA%\Claude\claude_desktop_config.json`. Both now require the absolute binary path.

6. **Verify copy listed `search`.** Updated to current tools: `smart_ingest`, `recall`, `backfill`.

7. **GETTING-STARTED.md linked to dead README anchors** (`#-get-it-running-in-60-seconds`, `#-the-thing-nothing-else-does-memory-with-hindsight`, `#-make-your-ai-use-memory-automatically`). Retargeted to live headings: `#install`, `#backward-reach-the-backfill-feature`, `#optional-make-the-agent-use-memory-automatically`.

8. **Intel Mac `ORT_DYLIB_PATH` lived only in `.zshrc`.** Cursor and Claude Desktop do not inherit `.zshrc`, so the first embedding call failed. MCP JSON `env` examples now include `ORT_DYLIB_PATH` resolved via `brew --prefix onnxruntime` (no hardcoded `/opt/homebrew` vs `/usr/local`). Stale “pure-Rust backend in v2.1” promise dropped; 2.3.0 still uses Homebrew ONNX Runtime.

## Scope

- `docs/integrations/cursor.md`
- `docs/claude-desktop-config.json`
- `docs/CONFIGURATION.md` (Claude Desktop + `ORT_DYLIB_PATH` env row)
- `docs/GETTING-STARTED.md`
- `docs/INSTALL-INTEL-MAC.md`

No Rust, no npm packaging, no version bump, no product behavior change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1eca0b9-d61c-404f-8c46-72801f1c724e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1eca0b9-d61c-404f-8c46-72801f1c724e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

