### PR TITLE
ci: publish server.json to the official MCP Registry on GitHub Release

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,222 @@
+# Publish repo-root server.json to the official MCP Registry after a GitHub
+# Release is created. Sibling of release.yml — binary build/upload jobs are
+# unchanged and do not get id-token: write.
+#
+# Official docs (confirmed 2026-08-28 against v1.8.1):
+#   https://modelcontextprotocol.io/registry/github-actions
+#   mcp-publisher login github-oidc
+#   mcp-publisher publish
+#
+# The GitHub Release asset named mcp-publisher is the CLI. `go install
+# github.com/modelcontextprotocol/registry/cmd/publisher@v1.8.1` produces a
+# binary named `publisher`; CI uses the documented release tarball instead.
+#
+# npm is NOT published by this repo's CI. The official registry validates the
+# published vestige-mcp-server package (mcpName + version), so this job fails
+# if that version is missing on npm. Publish npm first, then create the GitHub
+# Release — or re-run this workflow after npm is up.
+#
+# Merging this workflow does not publish anything. 2.3.0 is already listed
+# (isLatest) and must not be republished; this is for the next tag. Re-runs of
+# an already-listed version skip publish.
+
+name: Publish MCP Registry
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g. v2.4.0). npm vestige-mcp-server@that-version must already exist unless dry_run.'
+        required: true
+        type: string
+      dry_run:
+        description: 'Validate server.json and authenticate with GitHub OIDC; do not publish'
+        required: false
+        type: boolean
+        default: false
+
+# Least privilege at workflow scope; the job grants id-token: write for OIDC.
+permissions: {}
+
+concurrency:
+  group: mcp-registry-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  MCP_REGISTRY_URL: https://registry.modelcontextprotocol.io
+  MCP_SERVER_NAME: io.github.samvallad33/vestige
+  NPM_PACKAGE: vestige-mcp-server
+  # Pin the publisher CLI. Official docs use releases/latest; we pin + SHA-256
+  # so a compromised latest asset cannot mint an OIDC token as this repo.
+  MCP_PUBLISHER_VERSION: "1.8.1"
+  MCP_PUBLISHER_TARBALL: mcp-publisher_linux_amd64.tar.gz
+  MCP_PUBLISHER_SHA256: a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc
+
+jobs:
+  publish:
+    name: Publish server.json
+    if: github.repository == 'samvallad33/vestige'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Resolve version and require server.json match
+        id: version
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          EXPECTED_NAME: ${{ env.MCP_SERVER_NAME }}
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          tag = os.environ["RELEASE_TAG"].removeprefix("refs/tags/")
+          expected = tag[1:] if tag.startswith("v") else tag
+          if not expected:
+              raise SystemExit("Release tag is empty")
+
+          server_path = Path("server.json")
+          if not server_path.is_file():
+              raise SystemExit("server.json is missing at repo root")
+
+          server = json.loads(server_path.read_text())
+          name = server.get("name")
+          version = server.get("version")
+          expected_name = os.environ["EXPECTED_NAME"]
+          if name != expected_name:
+              raise SystemExit(
+                  f"server.json name {name!r} does not match {expected_name!r}"
+              )
+          if version != expected:
+              raise SystemExit(
+                  f"server.json version {version} does not match tag {tag} "
+                  f"(expected {expected})"
+              )
+
+          packages = server.get("packages") or []
+          if not packages:
+              raise SystemExit("server.json has no packages[] entry")
+          for index, package in enumerate(packages):
+              pkg_version = package.get("version")
+              if pkg_version != expected:
+                  raise SystemExit(
+                      f"server.json packages[{index}].version {pkg_version} "
+                      f"does not match tag {tag} (expected {expected})"
+                  )
+              identifier = package.get("identifier")
+              registry_type = package.get("registryType")
+              if registry_type == "npm" and identifier != os.environ["NPM_PACKAGE"]:
+                  raise SystemExit(
+                      f"server.json packages[{index}].identifier {identifier!r} "
+                      f"does not match npm package {os.environ['NPM_PACKAGE']!r}"
+                  )
+
+          Path(os.environ["GITHUB_OUTPUT"]).open("a").write(
+              f"tag={tag}\nversion={expected}\n"
+          )
+          print(f"server.json version {version} matches tag {tag}")
+          PY
+
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          curl -fsSL -o "${MCP_PUBLISHER_TARBALL}" \
+            "https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}/${MCP_PUBLISHER_TARBALL}"
+          echo "${MCP_PUBLISHER_SHA256}  ${MCP_PUBLISHER_TARBALL}" | sha256sum -c -
+          tar -xzf "${MCP_PUBLISHER_TARBALL}" mcp-publisher
+          chmod +x mcp-publisher
+          ./mcp-publisher --help
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate ./server.json
+
+      - name: Login to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc --registry "${MCP_REGISTRY_URL}"
+
+      - name: Publish server.json
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "dry_run=true: OIDC login and server.json validation succeeded; skipping publish."
+            echo "This does not republish ${MCP_SERVER_NAME}@${RELEASE_VERSION}."
+            exit 0
+          fi
+
+          encoded_name="$(python3 -c 'import os, urllib.parse; print(urllib.parse.quote(os.environ["MCP_SERVER_NAME"], safe=""))')"
+          registry_status="$(curl -sS -o /tmp/mcp-registry-version.json -w "%{http_code}" \
+            "${MCP_REGISTRY_URL}/v0.1/servers/${encoded_name}/versions/${RELEASE_VERSION}")"
+          if [ "${registry_status}" = "200" ]; then
+            echo "MCP Registry already lists ${MCP_SERVER_NAME}@${RELEASE_VERSION}; skipping publish."
+            echo "Refusing to republish (2.3.0 and any later listed version stay as-is)."
+            exit 0
+          fi
+          if [ "${registry_status}" != "404" ]; then
+            echo "MCP Registry version lookup returned HTTP ${registry_status}:"
+            cat /tmp/mcp-registry-version.json
+            exit 1
+          fi
+
+          python3 <<'PY'
+          import json
+          import os
+          import sys
+          import time
+          import urllib.error
+          import urllib.request
+
+          version = os.environ["RELEASE_VERSION"]
+          package = os.environ["NPM_PACKAGE"]
+          expected_name = os.environ["MCP_SERVER_NAME"]
+          url = f"https://registry.npmjs.org/{package}/{version}"
+          last_error = "npm lookup did not run"
+
+          for attempt in range(1, 7):
+              try:
+                  with urllib.request.urlopen(url, timeout=30) as response:
+                      payload = json.load(response)
+              except urllib.error.HTTPError as error:
+                  last_error = f"HTTP {error.code}"
+                  if error.code != 404:
+                      raise SystemExit(f"npm registry returned HTTP {error.code} for {url}")
+              except urllib.error.URLError as error:
+                  last_error = str(error.reason)
+              else:
+                  mcp_name = payload.get("mcpName")
+                  if mcp_name != expected_name:
+                      raise SystemExit(
+                          f"npm {package}@{version} mcpName {mcp_name!r} does not match "
+                          f"{expected_name!r}. The official registry will reject publish."
+                      )
+                  print(f"npm {package}@{version} is published with mcpName={mcp_name}")
+                  break
+              print(
+                  f"npm {package}@{version} not available yet ({last_error}); "
+                  f"attempt {attempt}/6",
+                  file=sys.stderr,
+              )
+              if attempt == 6:
+                  raise SystemExit(
+                      f"npm package {package}@{version} is not on registry.npmjs.org.\n"
+                      "The official MCP Registry validates npm mcpName + version, so this "
+                      "job must run only after that version exists on npm.\n"
+                      f"Publish {package}@{version}, then re-run this workflow "
+                      "(Actions → Publish MCP Registry → Run workflow)."
+                  )
+              time.sleep(20)
+          PY
+
+          ./mcp-publisher publish ./server.json
+          echo "Published ${MCP_SERVER_NAME}@${RELEASE_VERSION} to ${MCP_REGISTRY_URL}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Official MCP Registry publish from GitHub Releases
+
+Creating a GitHub Release now publishes repo-root `server.json` to
+https://registry.modelcontextprotocol.io via GitHub OIDC
+(`mcp-publisher login github-oidc`). No stored PAT. npm
+`vestige-mcp-server@<version>` must already exist; the job fails rather
+than racing the registry's npm `mcpName` check. Already-listed versions
+(including 2.3.0) are not republished.
+
 ### Fixed — Memory PR write gate wired into the real tool path (#117)
 
 `gate_writes` — the risk gate that quarantines risky memory writes and opens

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,34 @@ cargo build --release -p vestige-mcp
 
 The release profile uses `lto = true`, `codegen-units = 1`, `opt-level = "z"`, and `strip = true` for minimum binary size.
 
+## Publishing a GitHub Release
+
+Version tags (`vX.Y.Z`) drive two independent workflows:
+
+1. **Release** (`.github/workflows/release.yml`) — builds and uploads
+   binaries. Intel Mac and Windows feature flags live only there; do not
+   fold registry publish into those jobs.
+2. **Publish MCP Registry**
+   (`.github/workflows/publish-mcp-registry.yml`) — authenticates with
+   `mcp-publisher login github-oidc` and publishes repo-root
+   `server.json` to `https://registry.modelcontextprotocol.io`.
+
+npm is **not** published by CI. The official registry checks `mcpName`
+(`io.github.samvallad33/vestige`) on the published `vestige-mcp-server`
+package, so `vestige-mcp-server@X.Y.Z` must already exist on npm
+**before** this job can succeed. If npm is late, the registry job fails
+with an error; publish npm, then re-run **Publish MCP Registry**.
+
+GitHub OIDC for `io.github.samvallad33/*` is automatic from this
+repository (`id-token: write` on the registry job). No PAT, no GitHub
+App, and no extra org/repo OIDC trust binding is required.
+
+`server.json` version (and each `packages[].version`) must match the
+release tag with a leading `v` stripped. An already-listed version is
+skipped rather than republished. Merging the workflow does not publish;
+the next tag is the first automated publish. Dry-run: Actions → Publish
+MCP Registry → Run workflow, with `dry_run` enabled.
+
 ## Code Style
 
 ### Rust


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

GitHub Releases and npm are already at 2.3.0, but the official MCP Registry lagged (2.2.0, and 2.2.1 never listed) until a manual `mcp-publisher` publish. `.github/workflows/release.yml` builds binaries and uploads assets; it does not publish `server.json`.

This adds a **sibling** workflow so the next tag publishes `server.json` to https://registry.modelcontextprotocol.io via GitHub OIDC. **Merging this PR does not republish 2.3.0.** 2.3.0 is already listed (`isLatest`); this is for the next tag.

## What changed

- New workflow: `.github/workflows/publish-mcp-registry.yml`
  - Same trigger as the binary release workflow: `release: types: [created]`, plus `workflow_dispatch` for retry / dry-run
  - Job permissions: `id-token: write`, `contents: read` — no PAT, no secrets
  - `mcp-publisher login github-oidc --registry https://registry.modelcontextprotocol.io` then `mcp-publisher publish ./server.json`
  - Pins `mcp-publisher` **v1.8.1** (official GitHub Actions docs use `releases/latest`; we pin + SHA-256). The release binary is named `mcp-publisher`. `go install github.com/modelcontextprotocol/registry/cmd/publisher@v1.8.1` would produce a binary named `publisher`; CI does not use that path and does not clone extra remotes.
  - Fails if `server.json` version (and each `packages[].version`) does not match the release tag with a leading `v` stripped
  - Fails if `vestige-mcp-server@X.Y.Z` is not on npm (the registry validates npm `mcpName` + version). Short retry for npm replication lag, then a hard error with re-run instructions.
  - Skips publish if that exact version is already on the MCP Registry (so 2.3.0 and later listed versions are not republished)
  - `dry_run` input: validate + OIDC login only, no publish
- `.github/workflows/release.yml` is **untouched** — Intel Mac `ort-dynamic`, Windows `vector-search` / cargo flags, and version-check gates are unchanged.
- CONTRIBUTING + CHANGELOG note the npm-first ordering and that merging this does not publish.

## npm race

npm publish is **not** in this repo's CI. The official registry will reject a `server.json` whose npm package/version/`mcpName` is missing.

**Release order for the next tag:**

1. Publish `vestige-mcp-server@X.Y.Z` to npm (`mcpName` is already `io.github.samvallad33/vestige`)
2. Create the GitHub Release / tag (`vX.Y.Z`)
3. Binary **Release** workflow uploads assets; **Publish MCP Registry** publishes `server.json`

If npm is late, the registry job fails. Publish npm, then re-run **Publish MCP Registry**.

## GitHub OIDC trust

None beyond this workflow. Namespace `io.github.samvallad33/vestige` is authorized by GitHub Actions OIDC from `samvallad33/vestige` (`id-token: write`). No PAT, no GitHub App, no org OIDC provider, no extra repo trust binding.

If login fails with "Authentication failed", confirm Actions are allowed to mint OIDC tokens (default for this public repo) and that the job has `id-token: write`.

## How to verify

**Do not** create a 2.3.0 re-release and **do not** run this workflow without `dry_run` against 2.3.0 expecting a new listing. 2.3.0 is already `isLatest`.

### Dry-run (after merge, no publish)

1. Actions → **Publish MCP Registry** → Run workflow
2. Tag: `v2.3.0`
3. Enable **dry_run**
4. Expect: checkout, version match, pinned binary SHA-256, `mcp-publisher validate` pass, `login github-oidc` pass, **skip publish**

That is the OIDC proof without touching the registry listing.

### Next tag (real publish)

1. Bump versions including `server.json` to the new version
2. Publish `vestige-mcp-server@X.Y.Z` to npm
3. Create GitHub Release `vX.Y.Z`
4. Confirm **Publish MCP Registry** is green
5. Confirm listing:

```bash
curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.samvallad33/vestige"
```

Local checks already run on this branch: `server.json` version-match vs `v2.3.0` passes / vs `v9.9.9` fails; `mcp-publisher` v1.8.1 SHA-256 matches; `mcp-publisher validate ./server.json` → valid; registry GET for 2.3.0 returns 200 (`isLatest`).

## Risk

- Workflow YAML cannot execute OIDC in this PR; dry-run after merge is the live auth check.
- If `mcp-publisher` v1.8.1 is later incompatible with the registry, bump `MCP_PUBLISHER_VERSION` and `MCP_PUBLISHER_SHA256` together.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-460e8350-1695-4511-9e48-861bc0ce86e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-460e8350-1695-4511-9e48-861bc0ce86e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

