### PR TITLE
v2.5.0: Corrections stick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,116 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-08-30 — "Corrections stick"
+
+Telling Vestige it was wrong now works.
+
+Until this release, saving a correction could do the opposite of what you
+asked. A correction is worded almost identically to the thing it corrects, so
+the write path read it as a repeat, threw it away, and made the wrong memory
+stronger. This release fixes that, adds a benchmark so retrieval claims are
+measured instead of argued, and picks up a SQLite security fix.
+
+### Fixed — A correction no longer strengthens the claim it corrects
+
+Contradiction detection existed twice in the codebase, and the two copies had
+drifted apart.
+
+The retrieval side could spot a conflict properly. The write side could not.
+It only noticed a conflict when the incoming memory carried the negative word,
+and it had no idea what to do with opposites or with two different values for
+the same fact.
+
+The write side is the one that decides whether your memory gets stored at all,
+so the weaker copy was the one guarding the door. Protecting a memory during
+search does not help if it was already discarded on the way in.
+
+Measured against the real binary, every one of these was read as agreement,
+and each one reinforced the claim it contradicted:
+
+| You saved | Over the stored | Similarity |
+|---|---|---|
+| "Always use prompt diversity" | "Never use prompt diversity" | 0.965 |
+| "prompt diversity improves accuracy" | "prompt diversity hurts accuracy" | 0.962 |
+| "runs PostgreSQL 16" | "runs PostgreSQL 14" | 0.940 |
+| "holds a Master degree" | "holds a Bachelor degree" | 0.976 |
+
+All four sit above the 0.92 near-identical threshold, which is why they
+short-circuited. Saving the same two in the opposite order worked fine, so
+this was about which one arrived second, not about the threshold being wrong.
+
+There is one detector now. Both paths use it, so they cannot drift again.
+
+Version numbers needed a further fix. Words of three characters or fewer were
+being dropped before comparison, so "version is 4.2" and "version is 5.0"
+looked like identical text with the only meaningful difference thrown away.
+
+### Fixed — A corrupt search index no longer strands your memories
+
+Startup treated a damaged full-text index as fatal and refused to open the
+database. That index is derived data. It can be rebuilt from the memories
+themselves, and it now is. Real corruption elsewhere still fails loudly.
+
+### Fixed — Vestige sees writes from your other apps (#181)
+
+If you run Claude Desktop and the CLI against the same store, one process
+could not find memories the other had just written until you restarted it.
+The in-memory vector index is now refreshed when a peer process writes.
+
+### Fixed — A capital letter no longer blanks a tag search
+
+`tag_prefix` compared case-sensitively while everything around it did not, so
+searching `Reflection` missed a memory tagged `reflection`.
+
+### Fixed — Memories that disagree are no longer suppressed for disagreeing
+
+Search applies a penalty to results that compete with each other. A memory
+contradicting another counted as competition, so the dissenting view got
+pushed down exactly when you most needed to see it. Contradiction pairs are
+now exempt, and the response says when this happened.
+
+### Added — Code memories know when the code moved (schema V31)
+
+A memory about a function can now tell you whether that function still looks
+the way it did when you saved it. Three layers are checked in order: the file
+path, the symbol, then a hash of the code itself.
+
+### Added — `server/discover`, for MCP revision 2026-07-28
+
+The current MCP revision requires it. `tools/list` is now sorted and
+cacheable, so clients stop refetching it.
+
+### Added — MemConflict benchmark harness
+
+Retrieval changes can now be measured on a public benchmark instead of
+argued about. Runs four arms, including a no-memory control and a BM25
+control, because a memory system that cannot beat plain keyword search is
+not earning its complexity.
+
+Read the per-bucket sample size before quoting a number from it. One of its
+three categories has three questions in it, and the harness warns you.
+
+### Changed — Balanced search considers more candidates
+
+The reranker's own configuration asks for 50 candidates and was being handed
+30. It now gets 50. Measured on MemConflict this improved every category with
+a real sample size, and costs about 38% more time on a 2,900-memory store.
+
+`precise` mode is unchanged. The same change cost it 103% and speed is that
+mode's whole purpose.
+
+### Security
+
+SQLite 3.51.1 to 3.53.2, covering CVE-2026-11822, a memory corruption bug in
+FTS5.
+
+### Testing
+
+A new end-to-end suite spawns the real binary and talks to it over stdio the
+way a client does, covering protocol framing, migrations under a second live
+process, and the embedding runtime. It is what caught the correction bug
+above.
+
 ## [2.4.1] - 2026-08-30 — "Linux starts"
 
 A packaging fix. v2.4.0 and every release before it shipped a Linux binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,18 @@ this was about which one arrived second, not about the threshold being wrong.
 
 There is one detector now. Both paths use it, so they cannot drift again.
 
+The shared detector itself then failed its pre-release audit and was tightened
+before tagging. Measured against a real 2,929-memory store, its negation scan
+fired on the mere presence of a word like "never" or "removed" in one of two
+long notes — flagging 83% of same-subject pairs as contradictions and turning
+84% of near-identical re-saves into duplicates instead of reinforcements. A
+negation word now only counts when the OTHER text carries its paired positive
+term ("never" against "always"), matched as whole words, and a correction
+marker ("fixed", "actually") only counts when token overlap shows the two
+texts genuinely share a subject. On the same store that brings the flag rate
+from 83% to 13%, while every correction shape in the table above is still
+detected in both orders.
+
 Version numbers needed a further fix. Words of three characters or fewer were
 being dropped before comparison, so "version is 4.2" and "version is 5.0"
 looked like identical text with the only meaningful difference thrown away.
@@ -101,6 +113,10 @@ three categories has three questions in it, and the harness warns you.
 The reranker's own configuration asks for 50 candidates and was being handed
 30. It now gets 50. Measured on MemConflict this improved every category with
 a real sample size, and costs about 38% more time on a 2,900-memory store.
+For the record: the three-question category went down (1.0 to 0.667, one
+question), and at 98 questions total the improvement is directionally
+consistent rather than statistically settled — the depth-vs-recall curve from
+T2-RAGBench is what carries the direction.
 
 `precise` mode is unchanged. The same change cost it 103% and speed is that
 mode's whole purpose.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5086,7 +5086,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vestige-core"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "vestige-mcp"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,14 +1966,17 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -2604,9 +2607,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.36.0"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3945,9 +3948,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.38.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
  "bitflags 2.11.0",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.4.1"
+version = "2.5.0"
 edition = "2024"
 license = "AGPL-3.0-only"
 repository = "https://github.com/samvallad33/vestige"

--- a/apps/dashboard/package-lock.json
+++ b/apps/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vestige/dashboard",
-  "version": "2.1.23",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vestige/dashboard",
-      "version": "2.1.23",
+      "version": "2.5.0",
       "dependencies": {
         "three": "^0.172.0"
       },

--- a/apps/dashboard/package-lock.json
+++ b/apps/dashboard/package-lock.json
@@ -1232,7 +1232,7 @@
       }
     },
     "node_modules/why-is-node-running": {
-      "version": "2.4.1",
+      "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vestige/dashboard",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/benchmarks/memconflict/.gitignore
+++ b/benchmarks/memconflict/.gitignore
@@ -1,0 +1,7 @@
+# Datasets are fetched at run time and hash-verified, never vendored.
+data/
+
+# Live Vestige databases created by benchmark runs.
+*datadir-*/
+
+__pycache__/

--- a/benchmarks/memconflict/DATASET.lock.json
+++ b/benchmarks/memconflict/DATASET.lock.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Pinned upstream dataset revision. Do not edit by hand; regenerate with fetch_dataset.py --repin.",
+  "name": "MemConflict",
+  "paper": "arXiv:2605.20926",
+  "paper_url": "https://arxiv.org/abs/2605.20926",
+  "repo": "https://github.com/TaoZhen1110/MemConflict",
+  "revision": "ec51d5d36e87f7665d1337f3a88cbde95fc2a964",
+  "files": {
+    "Data/Step4_4.jsonl": {
+      "sha256": "8ef9ec8589eccb86f63ab3a819a9180217405351a8d5846866721ea74babe092",
+      "bytes": 39671712,
+      "instances": 30,
+      "questions": 3750
+    }
+  },
+  "license": "upstream repository declares no LICENSE file as of this revision; data is fetched at run time and is NOT vendored into this repo",
+  "retrieved_utc": "2026-08-30"
+}

--- a/benchmarks/memconflict/LONGMEMEVAL.lock.json
+++ b/benchmarks/memconflict/LONGMEMEVAL.lock.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Pinned LongMemEval_S revision. Sanity check only -- see docs/BENCHMARKS.md.",
+  "name": "LongMemEval_S (cleaned)",
+  "paper": "LongMemEval: Benchmarking Chat Assistants on Long-Term Interactive Memory (ICLR 2025)",
+  "code_repo": "https://github.com/xiaowu0162/LongMemEval",
+  "license": "MIT",
+  "hf_dataset": "xiaowu0162/longmemeval-cleaned",
+  "revision": "98d7416c24c778c2fee6e6f3006e7a073259d48f",
+  "_deprecation_note": "The ORIGINAL xiaowu0162/longmemeval dataset is DEPRECATED upstream. It is replaced by longmemeval-cleaned, which removes noisy history sessions that interfere with answer correctness. Any Vestige LongMemEval result computed against the original dataset is invalid on those grounds alone.",
+  "files": {
+    "longmemeval_s_cleaned.json": {
+      "url": "https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/resolve/98d7416c24c778c2fee6e6f3006e7a073259d48f/longmemeval_s_cleaned.json",
+      "sha256": "d6f21ea9d60a0d56f34a05b609c79c88a451d2ae03597821ea3d5a9678c3a442",
+      "bytes": 277383467,
+      "questions": 500
+    }
+  },
+  "retrieved_utc": "2026-08-30"
+}

--- a/benchmarks/memconflict/README.md
+++ b/benchmarks/memconflict/README.md
@@ -1,0 +1,99 @@
+# MemConflict benchmark harness
+
+Retrieval benchmark for Vestige against
+[MemConflict](https://arxiv.org/abs/2605.20926) (arXiv:2605.20926), with
+mandatory no-memory, random, and BM25 controls.
+
+**Read [`../../docs/BENCHMARKS.md`](../../docs/BENCHMARKS.md) before quoting any
+number from this harness.** It documents what is and is not measured, and why
+absolute values here are not comparable to the paper's published tables.
+
+## Quick start
+
+```sh
+cargo build -p vestige-mcp
+python3 benchmarks/memconflict/fetch_dataset.py
+python3 benchmarks/memconflict/run.py --instances 2 --sessions 25 --top-k 5
+```
+
+No `pip install`. The harness is standard library only, by design: a benchmark
+that needs a dependency resolver is a benchmark that stops reproducing.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `DATASET.lock.json` | Pinned upstream revision + SHA-256 of every data file. |
+| `fetch_dataset.py` | Downloads the pinned data and verifies hashes. Hard-fails on mismatch. |
+| `judge.py` | Faithful port of upstream `Evaluation/eval_scoring.py` rule-based judge. No LLM. |
+| `bm25.py` | Okapi BM25 control. Pure stdlib. |
+| `mcp_client.py` | JSON-RPC-over-stdio client for `vestige-mcp`. |
+| `run.py` | Orchestrator. Runs every arm, writes results JSON. |
+| `LONGMEMEVAL.lock.json` | Pinned LongMemEval_S (cleaned) revision + hash. |
+| `longmemeval.py` | LongMemEval_S **sanity check only** — see below. |
+| `results/` | Timestamped run outputs. |
+
+## The four arms
+
+All four run every time. None can be silently dropped.
+
+- **`nomem`** — no retrieval. The floor.
+- **`random`** — K random memories, seeded. The blob-inflation control: the
+  judge awards partial credit for token overlap, so any K memories score above
+  zero by chance. Beat this or you are reporting corpus statistics.
+- **`bm25`** — Okapi BM25 on the identical corpus. The earned-complexity bar.
+- **`vestige`** — live `recall()` over MCP.
+
+Same corpus, same reader, same judge, same K for every arm. One variable
+changes: retrieval.
+
+## Useful flags
+
+```
+--instances N        simulated users to evaluate (default 1)
+--sessions N         max sessions ingested per user (default 10)
+--top-k N            memories retrieved per question, identical for all arms (default 5)
+--recall-mode        lookup (default) | reason
+--warmup SECONDS     embedding warmup before first tools/call (default 45)
+--arms a,b,c         subset of arms; use for fast offline iteration
+--seed N             seed for the random control (default 1234)
+--out PATH           results JSON path
+```
+
+Static-conflict questions (the ones that exercise CRS) first appear around
+session 10-17 depending on the instance. `--sessions 25` is the practical
+floor for covering all three conflict types.
+
+Fast offline iteration, no server needed:
+
+```sh
+python3 benchmarks/memconflict/run.py --arms nomem,random,bm25 --instances 1 --sessions 12
+```
+
+## Gotchas
+
+- **Do not skip the warmup.** The embedding service warms up asynchronously
+  after `initialize` returns. Calling a tool early silently measures a degraded
+  keyword-only path. Confirm a run was healthy by checking `semanticScore` is
+  non-null in retrieval output.
+- **stdin must stay open** for the server's lifetime; closing it ends the run.
+- Each simulated user gets its own `scope` namespace so memories cannot bleed
+  between users.
+- Run size is bounded by ingest throughput (~7 memory units/s on the reference
+  machine).
+
+
+## LongMemEval_S sanity check
+
+```sh
+python3 benchmarks/memconflict/longmemeval.py --questions 5
+```
+
+**Not a headline benchmark and never quotable as a LongMemEval score.** It runs
+the same four arms on an independent dataset and reports one thing:
+`evidence_recall@k` — does the retrieved text contain the gold answer string?
+It exists to catch a silently broken harness, not to score the product.
+
+It pins `longmemeval-cleaned`. The original `xiaowu0162/longmemeval` dataset is
+**deprecated upstream** (it contains noisy history sessions that interfere with
+answer correctness), so any number computed against the original is invalid.

--- a/benchmarks/memconflict/bm25.py
+++ b/benchmarks/memconflict/bm25.py
@@ -1,0 +1,69 @@
+"""Okapi BM25 control retriever. Pure stdlib, no dependencies.
+
+This is a MANDATORY control, not an optional extra. MemDelta (arXiv:2606.29914)
+found that agent memory systems routinely fail to beat controlled baselines --
+agent self-memory scored 42% against 47% for basic retrieval on LongMemEval-S.
+A memory system that does not beat BM25 on the same corpus, with the same
+reader and the same judge, has not earned its complexity.
+
+Standard BM25 with k1=1.5, b=0.75. Tokenisation is intentionally simple and
+shared with nothing else in the harness, so the control stays a control.
+"""
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from typing import Dict, List, Sequence, Tuple
+
+K1 = 1.5
+B = 0.75
+_TOKEN = re.compile(r"[a-z0-9]+")
+
+
+def tokenize(text: str) -> List[str]:
+    return _TOKEN.findall(text.lower())
+
+
+class BM25:
+    def __init__(self, documents: Sequence[str], k1: float = K1, b: float = B) -> None:
+        self.k1 = k1
+        self.b = b
+        self.documents = list(documents)
+        self.doc_tokens = [tokenize(d) for d in self.documents]
+        self.doc_len = [len(t) for t in self.doc_tokens]
+        self.n = len(self.documents)
+        self.avgdl = (sum(self.doc_len) / self.n) if self.n else 0.0
+
+        self.tf: List[Counter] = [Counter(t) for t in self.doc_tokens]
+        df: Counter = Counter()
+        for toks in self.doc_tokens:
+            for term in set(toks):
+                df[term] += 1
+        self.idf: Dict[str, float] = {}
+        for term, freq in df.items():
+            # Robertson/Sparck-Jones idf with +1 smoothing (always positive).
+            self.idf[term] = math.log(1.0 + (self.n - freq + 0.5) / (freq + 0.5))
+
+    def score(self, query: str, index: int) -> float:
+        if not self.n:
+            return 0.0
+        q_terms = tokenize(query)
+        tf = self.tf[index]
+        dl = self.doc_len[index] or 1
+        total = 0.0
+        for term in q_terms:
+            f = tf.get(term, 0)
+            if not f:
+                continue
+            idf = self.idf.get(term, 0.0)
+            denom = f + self.k1 * (1.0 - self.b + self.b * dl / (self.avgdl or 1.0))
+            total += idf * (f * (self.k1 + 1.0)) / denom
+        return total
+
+    def top_k(self, query: str, k: int) -> List[Tuple[int, float]]:
+        scored = [(i, self.score(query, i)) for i in range(self.n)]
+        scored = [(i, s) for i, s in scored if s > 0.0]
+        # Deterministic: sort by score desc, then by document index asc.
+        scored.sort(key=lambda x: (-x[1], x[0]))
+        return scored[:k]

--- a/benchmarks/memconflict/fetch_dataset.py
+++ b/benchmarks/memconflict/fetch_dataset.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Fetch the pinned MemConflict dataset revision and verify its hash.
+
+The dataset is NOT vendored into this repository. It is downloaded from the
+upstream GitHub repo at the exact commit pinned in DATASET.lock.json and
+verified by SHA-256 before use. If the hash does not match, this script fails
+loudly rather than benchmarking against unknown data.
+
+Usage:
+    python3 fetch_dataset.py                 # fetch + verify into ./data/
+    python3 fetch_dataset.py --verify-only   # verify an existing copy
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import sys
+import urllib.request
+
+HERE = pathlib.Path(__file__).resolve().parent
+LOCK = HERE / "DATASET.lock.json"
+DATA_DIR = HERE / "data"
+RAW = "https://raw.githubusercontent.com/TaoZhen1110/MemConflict/{rev}/{path}"
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_lock() -> dict:
+    return json.loads(LOCK.read_text())
+
+
+def local_path_for(rel: str) -> pathlib.Path:
+    return DATA_DIR / pathlib.Path(rel).name
+
+
+def fetch(verify_only: bool = False) -> pathlib.Path:
+    lock = load_lock()
+    rev = lock["revision"]
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    primary = None
+    for rel, meta in lock["files"].items():
+        dest = local_path_for(rel)
+        if not dest.exists():
+            if verify_only:
+                sys.exit(f"FAIL: {dest} missing (run without --verify-only to download)")
+            url = RAW.format(rev=rev, path=rel)
+            print(f"downloading {url}\n         -> {dest}", flush=True)
+            urllib.request.urlretrieve(url, dest)
+
+        actual = sha256_file(dest)
+        expected = meta["sha256"]
+        if actual != expected:
+            sys.exit(
+                f"FAIL: hash mismatch for {dest}\n"
+                f"  expected {expected}\n"
+                f"  actual   {actual}\n"
+                "Refusing to benchmark against unverified data."
+            )
+        size = dest.stat().st_size
+        if size != meta["bytes"]:
+            sys.exit(f"FAIL: size mismatch for {dest}: {size} != {meta['bytes']}")
+        print(f"OK  {dest.name}  sha256={actual[:16]}...  bytes={size}")
+        if primary is None:
+            primary = dest
+
+    print(f"\ndataset pinned at revision {rev}")
+    return primary
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--verify-only", action="store_true")
+    args = ap.parse_args()
+    fetch(verify_only=args.verify_only)

--- a/benchmarks/memconflict/judge.py
+++ b/benchmarks/memconflict/judge.py
@@ -1,0 +1,190 @@
+"""Rule-based MemConflict judge.
+
+This is a deliberate, faithful port of the *rule-based fallback judge* that
+ships in the upstream MemConflict repository at the pinned revision:
+
+    Evaluation/eval_scoring.py
+      - normalize_text
+      - extract_normalized_answer_variants
+      - answers_match_strict
+      - extract_meaningful_tokens  (+ FALLBACK_STOPWORDS)
+      - compute_partial_credit_score
+      - has_update_order_signal
+      - has_conflict_recognition_signal
+      - build_rule_based_result
+
+WHY THE RULE-BASED JUDGE AND NOT THE LLM JUDGE
+----------------------------------------------
+Upstream's headline tables (Table 3 / Table 4 of arXiv:2605.20926) were
+produced with an LLM judge (gpt-5.0-mini). We deliberately do NOT use an LLM
+judge here, for two reasons:
+
+  1. Reproducibility. An LLM judge makes the harness non-deterministic, costly,
+     and dependent on a model snapshot that will drift. A stranger could not
+     reproduce our numbers.
+  2. Confound control. MemDelta (arXiv:2606.29914) shows that swapping the
+     model in a memory evaluation moves the result by double-digit points and
+     can reverse system rankings. Holding the judge fixed and deterministic is
+     the entire point of the mandatory controls in this harness.
+
+THE COST OF THAT CHOICE, STATED PLAINLY
+---------------------------------------
+Numbers produced by this judge are NOT comparable to the published Table 3
+numbers. They are only comparable *across the arms in this harness*, which all
+run through the identical judge. Never place our AA next to upstream's AA in
+the same table or sentence.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List
+
+# --- verbatim port: normalize_text -----------------------------------------
+
+
+def normalize_text(text: Any) -> str:
+    if text is None:
+        return ""
+    normalized = str(text)
+    normalized = normalized.replace("_", " ").replace("-", " ").lower()
+    normalized = re.sub(r"[\"'`]", " ", normalized)
+    normalized = re.sub("[^\\w\\s\u4e00-\u9fff]", " ", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return normalized
+
+
+def extract_normalized_answer_variants(text: Any) -> List[str]:
+    raw_text = str(text or "").strip()
+    if not raw_text:
+        return []
+
+    variants: List[str] = []
+    separators = ["||", "\n", ";"]
+
+    def add_variant(candidate: str) -> None:
+        normalized = normalize_text(candidate)
+        if normalized and normalized not in variants:
+            variants.append(normalized)
+
+    add_variant(raw_text)
+    for separator in separators:
+        if separator not in raw_text:
+            continue
+        for part in raw_text.split(separator):
+            add_variant(part)
+    return variants
+
+
+def answers_match_strict(gold_answer: Any, model_answer: Any) -> bool:
+    gold_variants = extract_normalized_answer_variants(gold_answer)
+    model_variants = extract_normalized_answer_variants(model_answer)
+    if not gold_variants or not model_variants:
+        return False
+    return any(g == m for g in gold_variants for m in model_variants)
+
+
+FALLBACK_STOPWORDS = {
+    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+    "to", "from", "of", "in", "on", "at", "for", "with", "by", "as",
+    "and", "or", "but", "if", "then", "than", "that", "this", "these", "those",
+    "it", "they", "them", "their", "he", "she", "his", "her", "you", "your",
+    "user", "users", "now", "current", "currently", "recently", "about",
+    "did", "does", "do", "has", "have", "had", "what", "where", "when", "which",
+}
+
+
+def extract_meaningful_tokens(text: Any) -> List[str]:
+    normalized = normalize_text(text)
+    if not normalized:
+        return []
+    tokens: List[str] = []
+    for token in normalized.split():
+        if len(token) <= 1:
+            continue
+        if token in FALLBACK_STOPWORDS:
+            continue
+        tokens.append(token)
+    return tokens
+
+
+def compute_partial_credit_score(gold_answer: Any, model_answer: Any) -> float:
+    if answers_match_strict(gold_answer, model_answer):
+        return 1.0
+
+    gold_variants = extract_normalized_answer_variants(gold_answer)
+    model_variants = extract_normalized_answer_variants(model_answer)
+    if not gold_variants or not model_variants:
+        return 0.0
+
+    best_overlap_ratio = 0.0
+    best_shared_count = 0
+    for gold_variant in gold_variants:
+        gold_tokens = set(extract_meaningful_tokens(gold_variant))
+        if not gold_tokens:
+            continue
+        for model_variant in model_variants:
+            model_tokens = set(extract_meaningful_tokens(model_variant))
+            if not model_tokens:
+                continue
+            shared = gold_tokens & model_tokens
+            shared_count = len(shared)
+            overlap_ratio = shared_count / max(1, len(gold_tokens))
+            if overlap_ratio > best_overlap_ratio:
+                best_overlap_ratio = overlap_ratio
+            if shared_count > best_shared_count:
+                best_shared_count = shared_count
+
+            if gold_variant in model_variant and len(gold_variant) >= 8:
+                return 0.5
+            if model_variant in gold_variant and len(model_variant) >= 8:
+                return 0.5
+
+    if best_shared_count >= 2 or best_overlap_ratio >= 0.5:
+        return 0.5
+    return 0.0
+
+
+def has_update_order_signal(model_answer: Any) -> bool:
+    normalized = normalize_text(model_answer)
+    if not normalized:
+        return False
+    change_markers = ["changed", "change", "updated", "update", "switched"]
+    order_markers = [("from", "to"), ("previously", "now"), ("used to", "now"), ("before", "now")]
+    has_change = any(m in normalized for m in change_markers)
+    has_order = any(l in normalized and r in normalized for l, r in order_markers)
+    return has_change and has_order
+
+
+def has_conflict_recognition_signal(model_answer: Any) -> bool:
+    normalized = normalize_text(model_answer)
+    if not normalized:
+        return False
+    keywords = ["inconsisten", "conflict", "contradict", "cannot confirm", "uncertain", "mismatch"]
+    return any(k in normalized for k in keywords)
+
+
+# --- harness-side scoring ---------------------------------------------------
+
+
+def score_question(question: Dict[str, Any], model_answer: str) -> Dict[str, Any]:
+    """Score one (question, reader-output) pair with the rule-based judge.
+
+    Returns a dict of metric_name -> value, plus which metrics are applicable
+    for this conflict type. Metrics that do not apply are omitted entirely
+    (never scored as 0), so averages are always taken over the correct
+    denominator.
+    """
+    ctype = question.get("conflict_type", "unknown")
+    gold = str(question.get("answer", "")).strip()
+    aa = compute_partial_credit_score(gold, model_answer)
+
+    out: Dict[str, Any] = {"conflict_type": ctype, "answer_accuracy": aa}
+
+    if ctype == "dynamic_conflict":
+        out["uocs"] = 1.0 if (aa >= 0.5 and has_update_order_signal(model_answer)) else 0.0
+    elif ctype == "static_conflict":
+        out["crs_lex"] = 1.0 if has_conflict_recognition_signal(model_answer) else 0.0
+    elif ctype == "conditional_conflict":
+        # Upstream binarises conditional AA at the 0.5 threshold.
+        out["answer_accuracy"] = 1.0 if aa >= 0.5 else 0.0
+    return out

--- a/benchmarks/memconflict/longmemeval.py
+++ b/benchmarks/memconflict/longmemeval.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""LongMemEval_S sanity check. NOT a headline benchmark.
+
+Purpose: confirm the retrieval plumbing behaves sensibly on a second, entirely
+independent dataset. It exists to catch a harness that is silently broken -- a
+retriever that returns nothing, an ingest path that drops content, an embedding
+service that never warmed up. It is NOT evidence of end-to-end task quality and
+its numbers must never be quoted as a LongMemEval score.
+
+Metric: `evidence_recall@k` -- does the concatenation of the top-k retrieved
+memories contain the gold answer string (normalised)? This is deliberately
+reader-independent and unambiguous. It asks one question: did retrieval put the
+answer in front of the reader? A real LongMemEval score additionally requires a
+reader/judge and would be a different, much larger claim.
+
+    python3 benchmarks/memconflict/longmemeval.py --questions 3
+
+IMPORTANT: the original `xiaowu0162/longmemeval` dataset is DEPRECATED upstream
+and replaced by `longmemeval-cleaned`, which removes noisy history sessions that
+interfere with answer correctness. This harness pins the CLEANED release. A
+LongMemEval number computed against the deprecated original is invalid.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import random as _random
+import statistics
+import sys
+import time
+import urllib.request
+from typing import Any, Dict, List
+
+HERE = pathlib.Path(__file__).resolve().parent
+REPO = HERE.parent.parent
+sys.path.insert(0, str(HERE))
+
+import bm25 as bm25_mod  # noqa: E402
+import judge as judge_mod  # noqa: E402
+from mcp_client import VestigeMCP, VestigeMCPError  # noqa: E402
+
+LOCK = HERE / "LONGMEMEVAL.lock.json"
+DATA_DIR = HERE / "data"
+
+
+def fetch() -> pathlib.Path:
+    lock = json.loads(LOCK.read_text())
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    name, meta = next(iter(lock["files"].items()))
+    dest = DATA_DIR / name
+    if not dest.exists():
+        print(f"downloading {meta['url']}\n         -> {dest}", flush=True)
+        urllib.request.urlretrieve(meta["url"], dest)
+    h = hashlib.sha256()
+    with dest.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    if h.hexdigest() != meta["sha256"]:
+        sys.exit(
+            f"FAIL: hash mismatch for {dest}\n  expected {meta['sha256']}\n"
+            f"  actual   {h.hexdigest()}\nRefusing to run on unverified data."
+        )
+    print(f"OK  {dest.name}  sha256={h.hexdigest()[:16]}...  bytes={dest.stat().st_size}")
+    return dest
+
+
+def session_units(sessions: List[Any], dates: List[str]) -> List[str]:
+    """User turns only, date-stamped -- same convention as the MemConflict harness."""
+    units: List[str] = []
+    for idx, session in enumerate(sessions):
+        date = dates[idx] if idx < len(dates) else ""
+        for turn in session or []:
+            if not isinstance(turn, dict) or turn.get("role") != "user":
+                continue
+            text = (turn.get("content") or "").strip()
+            if text:
+                units.append(f"[{date}] {text}")
+    return units
+
+
+def evidence_recall(gold: str, retrieved: List[str]) -> float:
+    g = judge_mod.normalize_text(gold)
+    if not g:
+        return 0.0
+    blob = judge_mod.normalize_text("\n".join(retrieved))
+    return 1.0 if g and g in blob else 0.0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--questions", type=int, default=3, help="questions to evaluate (500 available)")
+    ap.add_argument("--top-k", type=int, default=5)
+    ap.add_argument("--warmup", type=float, default=45.0)
+    ap.add_argument("--seed", type=int, default=1234)
+    ap.add_argument("--binary", default=str(REPO / "target" / "debug" / "vestige-mcp"))
+    ap.add_argument("--arms", default="nomem,random,bm25,vestige")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    selected = [a.strip() for a in args.arms.split(",") if a.strip()]
+    path = fetch()
+    print("loading dataset (277MB, this takes a moment) ...", flush=True)
+    data = json.loads(path.read_text())
+    items = data[: args.questions]
+    started = time.time()
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime(started))
+    exact_command = f"python3 {pathlib.Path(__file__).relative_to(REPO)} " + " ".join(sys.argv[1:])
+
+    print("=" * 78)
+    print("LongMemEval_S SANITY CHECK  (not a headline benchmark)")
+    print("=" * 78)
+    print(f"command: {exact_command}")
+    print(f"metric : evidence_recall@{args.top_k} -- is the gold answer inside the retrieved text?")
+    print(f"items  : {len(items)} of {len(data)}\n")
+
+    client = None
+    scores: Dict[str, List[float]] = {a: [] for a in selected}
+    try:
+        if "vestige" in selected:
+            data_dir = HERE / "results" / f"lme-datadir-{stamp}"
+            client = VestigeMCP(args.binary, str(data_dir), warmup_seconds=args.warmup)
+            client.start()
+            print(f"initialize + mandatory {args.warmup:.0f}s embedding warmup ...", flush=True)
+            client.initialize()
+            print(f"server: {client.server_info}\n")
+
+        for qi, item in enumerate(items, 1):
+            units = session_units(item.get("haystack_sessions") or [], item.get("haystack_dates") or [])
+            question, gold = item.get("question", ""), item.get("answer", "")
+            print(f"[{qi}/{len(items)}] {item.get('question_type')} :: {question[:60]}")
+            print(f"   units={len(units)} gold={gold[:50]!r}", flush=True)
+
+            rng = _random.Random(f"{args.seed}:{item.get('question_id')}")
+            scope = f"lme_{item.get('question_id','q')}"
+
+            if "vestige" in selected and client:
+                for start in range(0, len(units), 20):
+                    batch = [{"content": u, "node_type": "event", "tags": [scope]}
+                             for u in units[start:start + 20]]
+                    try:
+                        client.call_tool("smart_ingest",
+                                         {"items": batch, "scope": scope,
+                                          "batchMergePolicy": "force_create"}, timeout=600)
+                    except VestigeMCPError as exc:
+                        print(f"   ingest error: {exc}"[:160])
+
+            for arm in selected:
+                if arm == "nomem":
+                    got: List[str] = []
+                elif arm == "random":
+                    got = rng.sample(units, min(args.top_k, len(units))) if units else []
+                elif arm == "bm25":
+                    idx = bm25_mod.BM25(units)
+                    got = [units[i] for i, _ in idx.top_k(question, args.top_k)]
+                else:
+                    try:
+                        payload = client.call_tool(
+                            "recall",
+                            {"query": question, "mode": "lookup",
+                             "limit": args.top_k, "scope": scope}, timeout=300)
+                        got = [r.get("content", "") for r in (payload.get("results") or [])][: args.top_k]
+                    except VestigeMCPError as exc:
+                        print(f"   recall error: {exc}"[:160])
+                        got = []
+                s = evidence_recall(gold, got)
+                scores[arm].append(s)
+                print(f"     {arm:<8} evidence_recall={s:.0f}")
+    finally:
+        if client:
+            client.close()
+
+    print("\n" + "=" * 78)
+    print(f"evidence_recall@{args.top_k}  (n={len(items)} -- far too few to be a benchmark result)")
+    print("=" * 78)
+    summary = {}
+    for arm in selected:
+        v = statistics.fmean(scores[arm]) if scores[arm] else 0.0
+        summary[arm] = round(v, 4)
+        print(f"  {arm:<9}{v:.4f}")
+
+    out = pathlib.Path(args.out) if args.out else HERE / "results" / f"longmemeval-{stamp}.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps({
+        "benchmark": "LongMemEval_S (cleaned) -- SANITY CHECK ONLY",
+        "exact_command": exact_command,
+        "dataset": json.loads(LOCK.read_text()),
+        "questions_evaluated": len(items),
+        "questions_available": len(data),
+        "metric": f"evidence_recall@{args.top_k}",
+        "results": summary,
+        "per_question": {a: scores[a] for a in selected},
+        "caveats": [
+            "SANITY CHECK ONLY. Not a LongMemEval score and must never be quoted as one.",
+            "evidence_recall only asks whether the gold answer string appears in the retrieved text. It involves no reader and no judge.",
+            "A previous Vestige LongMemEval run was invalidated and must not be cited.",
+            "The original longmemeval dataset is deprecated upstream; this pins longmemeval-cleaned.",
+        ],
+    }, indent=2))
+    print(f"\nwritten: {out}")
+    print(f"reproduce: {exact_command}")
+    print("\nSANITY CHECK ONLY -- do not quote these as LongMemEval scores.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/memconflict/mcp_client.py
+++ b/benchmarks/memconflict/mcp_client.py
@@ -1,0 +1,208 @@
+"""Minimal JSON-RPC-over-stdio client for the vestige-mcp server.
+
+Protocol notes learned from the real server (v2.4.1):
+
+  * Framing is line-delimited JSON on stdout (not LSP Content-Length framing).
+  * Order is: initialize -> notifications/initialized -> tools/call.
+  * stdin MUST stay open for the lifetime of the session. Closing it ends the
+    server mid-run.
+  * The embedding service warms up asynchronously AFTER initialize returns.
+    Issuing tools/call before it is ready silently measures a degraded
+    keyword-only fallback path, which would make every retrieval number wrong
+    in a way that does not look wrong. We therefore block for a mandatory
+    warmup window and record the observed warmup in the results file.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import queue
+import subprocess
+import threading
+import time
+from typing import Any, Dict, Optional
+
+DEFAULT_WARMUP_SECONDS = 45.0
+
+
+class VestigeMCPError(RuntimeError):
+    pass
+
+
+class VestigeMCP:
+    def __init__(
+        self,
+        binary: str,
+        data_dir: str,
+        warmup_seconds: float = DEFAULT_WARMUP_SECONDS,
+        timeout: float = 300.0,
+        extra_env: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self.binary = str(pathlib.Path(binary).resolve())
+        self.data_dir = str(pathlib.Path(data_dir).resolve())
+        self.warmup_seconds = warmup_seconds
+        self.timeout = timeout
+        self._id = 0
+        self._proc: Optional[subprocess.Popen] = None
+        self._out: "queue.Queue[Optional[str]]" = queue.Queue()
+        self._stderr_lines: list[str] = []
+        self._extra_env = dict(extra_env or {})
+        self.server_info: Dict[str, Any] = {}
+        self.observed_warmup: Dict[str, Any] = {}
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def __enter__(self) -> "VestigeMCP":
+        self.start()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+    def start(self) -> None:
+        pathlib.Path(self.data_dir).mkdir(parents=True, exist_ok=True)
+        env = dict(os.environ)
+        env["VESTIGE_DATA_DIR"] = self.data_dir
+        env["VESTIGE_DASHBOARD_ENABLED"] = "false"
+        env["VESTIGE_HTTP_ENABLED"] = "0"
+        env.update(self._extra_env)
+
+        self._proc = subprocess.Popen(
+            [self.binary],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            text=True,
+            bufsize=1,
+        )
+        threading.Thread(target=self._pump_stdout, daemon=True).start()
+        threading.Thread(target=self._pump_stderr, daemon=True).start()
+
+
+    def _pump_stdout(self) -> None:
+        assert self._proc and self._proc.stdout
+        for line in self._proc.stdout:
+            line = line.strip()
+            if line:
+                self._out.put(line)
+        self._out.put(None)
+
+    def _pump_stderr(self) -> None:
+        assert self._proc and self._proc.stderr
+        for line in self._proc.stderr:
+            self._stderr_lines.append(line.rstrip())
+
+    def close(self) -> None:
+        if self._proc is None:
+            return
+        try:
+            if self._proc.stdin:
+                self._proc.stdin.close()
+            self._proc.terminate()
+            self._proc.wait(timeout=15)
+        except Exception:
+            try:
+                self._proc.kill()
+            except Exception:
+                pass
+        self._proc = None
+
+    # -- transport ---------------------------------------------------------
+
+    def _send(self, payload: Dict[str, Any]) -> None:
+        if not self._proc or not self._proc.stdin:
+            raise VestigeMCPError("server not running")
+        self._proc.stdin.write(json.dumps(payload) + "\n")
+        self._proc.stdin.flush()
+
+    def _await_id(self, want_id: int, timeout: float) -> Dict[str, Any]:
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise VestigeMCPError(f"timeout waiting for response id={want_id}")
+            try:
+                line = self._out.get(timeout=remaining)
+            except queue.Empty:
+                raise VestigeMCPError(f"timeout waiting for response id={want_id}")
+            if line is None:
+                tail = "\n".join(self._stderr_lines[-20:])
+                raise VestigeMCPError(f"server exited early. stderr tail:\n{tail}")
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # non-JSON noise on stdout is ignored
+            if msg.get("id") == want_id:
+                return msg
+
+    def request(self, method: str, params: Optional[Dict[str, Any]] = None,
+                timeout: Optional[float] = None) -> Dict[str, Any]:
+        self._id += 1
+        rid = self._id
+        self._send({"jsonrpc": "2.0", "id": rid, "method": method, "params": params or {}})
+        msg = self._await_id(rid, timeout if timeout is not None else self.timeout)
+        if "error" in msg:
+            raise VestigeMCPError(f"{method} failed: {msg['error']}")
+        return msg.get("result", {})
+
+    def notify(self, method: str, params: Optional[Dict[str, Any]] = None) -> None:
+        self._send({"jsonrpc": "2.0", "method": method, "params": params or {}})
+
+    # -- MCP handshake -----------------------------------------------------
+
+    def initialize(self) -> Dict[str, Any]:
+        result = self.request(
+            "initialize",
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "vestige-memconflict-harness", "version": "1.0"},
+            },
+            timeout=120.0,
+        )
+        self.server_info = result.get("serverInfo", {})
+        self.notify("notifications/initialized")
+
+        # Mandatory embedding warmup. See module docstring.
+        t0 = time.monotonic()
+        time.sleep(self.warmup_seconds)
+        self.observed_warmup = {
+            "requested_seconds": self.warmup_seconds,
+            "actual_seconds": round(time.monotonic() - t0, 2),
+            "embedding_ready_signal": self.embedding_log_signal(),
+        }
+        return result
+
+    def embedding_log_signal(self) -> Optional[str]:
+        """Best-effort: surface any embedding-related server log line.
+
+        Recorded in results so a reader can confirm the run did not silently
+        fall back to keyword-only retrieval.
+        """
+        for line in reversed(self._stderr_lines):
+            low = line.lower()
+            if "embed" in low or "model" in low:
+                return line[-300:]
+        return None
+
+    def stderr_tail(self, n: int = 40) -> list[str]:
+        return self._stderr_lines[-n:]
+
+    # -- tools -------------------------------------------------------------
+
+    def call_tool(self, name: str, arguments: Dict[str, Any],
+                  timeout: Optional[float] = None) -> Any:
+        result = self.request(
+            "tools/call", {"name": name, "arguments": arguments}, timeout=timeout
+        )
+        content = result.get("content") or []
+        for block in content:
+            if block.get("type") == "text":
+                text = block.get("text", "")
+                try:
+                    return json.loads(text)
+                except json.JSONDecodeError:
+                    return text
+        return result

--- a/benchmarks/memconflict/results/longmemeval-20260830T173700Z.json
+++ b/benchmarks/memconflict/results/longmemeval-20260830T173700Z.json
@@ -1,0 +1,60 @@
+{
+  "benchmark": "LongMemEval_S (cleaned) -- SANITY CHECK ONLY",
+  "exact_command": "python3 benchmarks/memconflict/longmemeval.py --questions 3",
+  "dataset": {
+    "_comment": "Pinned LongMemEval_S revision. Sanity check only -- see docs/BENCHMARKS.md.",
+    "name": "LongMemEval_S (cleaned)",
+    "paper": "LongMemEval: Benchmarking Chat Assistants on Long-Term Interactive Memory (ICLR 2025)",
+    "code_repo": "https://github.com/xiaowu0162/LongMemEval",
+    "license": "MIT",
+    "hf_dataset": "xiaowu0162/longmemeval-cleaned",
+    "revision": "98d7416c24c778c2fee6e6f3006e7a073259d48f",
+    "_deprecation_note": "The ORIGINAL xiaowu0162/longmemeval dataset is DEPRECATED upstream. It is replaced by longmemeval-cleaned, which removes noisy history sessions that interfere with answer correctness. Any Vestige LongMemEval result computed against the original dataset is invalid on those grounds alone.",
+    "files": {
+      "longmemeval_s_cleaned.json": {
+        "url": "https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/resolve/98d7416c24c778c2fee6e6f3006e7a073259d48f/longmemeval_s_cleaned.json",
+        "sha256": "d6f21ea9d60a0d56f34a05b609c79c88a451d2ae03597821ea3d5a9678c3a442",
+        "bytes": 277383467,
+        "questions": 500
+      }
+    },
+    "retrieved_utc": "2026-08-30"
+  },
+  "questions_evaluated": 3,
+  "questions_available": 500,
+  "metric": "evidence_recall@5",
+  "results": {
+    "nomem": 0.0,
+    "random": 0.0,
+    "bm25": 0.6667,
+    "vestige": 0.6667
+  },
+  "per_question": {
+    "nomem": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "random": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "bm25": [
+      1.0,
+      1.0,
+      0.0
+    ],
+    "vestige": [
+      0.0,
+      1.0,
+      1.0
+    ]
+  },
+  "caveats": [
+    "SANITY CHECK ONLY. Not a LongMemEval score and must never be quoted as one.",
+    "evidence_recall only asks whether the gold answer string appears in the retrieved text. It involves no reader and no judge.",
+    "A previous Vestige LongMemEval run was invalidated and must not be cited.",
+    "The original longmemeval dataset is deprecated upstream; this pins longmemeval-cleaned."
+  ]
+}

--- a/benchmarks/memconflict/results/memconflict-20260830T173831Z.json
+++ b/benchmarks/memconflict/results/memconflict-20260830T173831Z.json
@@ -1,0 +1,4947 @@
+{
+  "benchmark": "MemConflict",
+  "harness_version": "1.0",
+  "generated_utc": "2026-08-30T17:38:31Z",
+  "wall_seconds": 267.2,
+  "exact_command": "python3 benchmarks/memconflict/run.py --instances 2 --sessions 25 --top-k 5",
+  "reproduce": [
+    "cargo build -p vestige-mcp",
+    "python3 benchmarks/memconflict/fetch_dataset.py",
+    "python3 benchmarks/memconflict/run.py --instances 2 --sessions 25 --top-k 5"
+  ],
+  "dataset": {
+    "source": "https://github.com/TaoZhen1110/MemConflict",
+    "paper": "arXiv:2605.20926",
+    "revision": "ec51d5d36e87f7665d1337f3a88cbde95fc2a964",
+    "files": {
+      "Data/Step4_4.jsonl": {
+        "sha256": "8ef9ec8589eccb86f63ab3a819a9180217405351a8d5846866721ea74babe092",
+        "bytes": 39671712,
+        "instances": 30,
+        "questions": 3750
+      }
+    },
+    "instances_evaluated": 2,
+    "sessions_per_instance_cap": 25
+  },
+  "vestige": {
+    "commit": "146db7e7499a5512f3f880c03dc92157b2a45a5d",
+    "branch": "fix/v242-sqlite-and-tier1",
+    "dirty": true,
+    "server_info": {
+      "name": "vestige",
+      "version": "2.4.1"
+    },
+    "binary": "/Users/entity002/vestige-v240-fixes/target/debug/vestige-mcp"
+  },
+  "config": {
+    "arms": [
+      "nomem",
+      "random",
+      "bm25",
+      "vestige"
+    ],
+    "top_k": 5,
+    "recall_mode": "lookup",
+    "seed": 1234,
+    "contradiction_limit": 200,
+    "reader": "deterministic concatenation of top-k retrieved memory texts",
+    "judge": "rule-based port of upstream Evaluation/eval_scoring.py (no LLM)",
+    "warmup": {
+      "requested_seconds": 45.0,
+      "actual_seconds": 45.01,
+      "embedding_ready_signal": "2026-08-30T17:38:33.774487Z  INFO Periodic auto-consolidation complete nodes_processed=0 decay_applied=0 embeddings_generated=0 duplicates_merged=0 activations_computed=0 duration_ms=5"
+    }
+  },
+  "machine": {
+    "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
+    "machine": "arm64",
+    "processor": "arm",
+    "python": "3.14.4",
+    "cpu_count": 10,
+    "memory_bytes": 68719476736,
+    "cpu_brand": "Apple M1 Max"
+  },
+  "results": {
+    "nomem": {
+      "n_questions": 98,
+      "reader_chars_mean": 0.0,
+      "n_retrieved_mean": 0.0,
+      "per_conflict_type": {
+        "dynamic_conflict": {
+          "n": 88,
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        },
+        "static_conflict": {
+          "n": 7,
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        },
+        "conditional_conflict": {
+          "n": 3,
+          "answer_accuracy": 0.0
+        }
+      },
+      "macro_answer_accuracy": 0.0,
+      "micro_answer_accuracy": 0.0
+    },
+    "random": {
+      "n_questions": 98,
+      "reader_chars_mean": 686.6,
+      "n_retrieved_mean": 5.0,
+      "per_conflict_type": {
+        "dynamic_conflict": {
+          "n": 88,
+          "answer_accuracy": 0.0966,
+          "uocs": 0.0
+        },
+        "static_conflict": {
+          "n": 7,
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        },
+        "conditional_conflict": {
+          "n": 3,
+          "answer_accuracy": 0.0
+        }
+      },
+      "macro_answer_accuracy": 0.0322,
+      "micro_answer_accuracy": 0.0867
+    },
+    "bm25": {
+      "n_questions": 98,
+      "reader_chars_mean": 735.5,
+      "n_retrieved_mean": 5.0,
+      "per_conflict_type": {
+        "dynamic_conflict": {
+          "n": 88,
+          "answer_accuracy": 0.25,
+          "uocs": 0.1932
+        },
+        "static_conflict": {
+          "n": 7,
+          "answer_accuracy": 0.2143,
+          "crs_lex": 0.0
+        },
+        "conditional_conflict": {
+          "n": 3,
+          "answer_accuracy": 1.0
+        }
+      },
+      "macro_answer_accuracy": 0.4881,
+      "micro_answer_accuracy": 0.2704
+    },
+    "vestige": {
+      "n_questions": 98,
+      "reader_chars_mean": 853.6,
+      "n_retrieved_mean": 5.0,
+      "per_conflict_type": {
+        "dynamic_conflict": {
+          "n": 88,
+          "answer_accuracy": 0.3011,
+          "uocs": 0.3636
+        },
+        "static_conflict": {
+          "n": 7,
+          "answer_accuracy": 0.3571,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "conditional_conflict": {
+          "n": 3,
+          "answer_accuracy": 0.6667
+        }
+      },
+      "macro_answer_accuracy": 0.4416,
+      "micro_answer_accuracy": 0.3163
+    }
+  },
+  "diagnostics": {
+    "vestige_ingest_errors": 0,
+    "vestige_retrieve_errors": 0,
+    "vestige_retrieval_latency_s": {
+      "n": 98,
+      "mean": 0.4349,
+      "median": 0.4237,
+      "max": 0.9931
+    },
+    "server_stderr_tail": [
+      "2026-08-30T17:38:31.761447Z  INFO Hydrated cognitive modules from persisted connections count=0",
+      "2026-08-30T17:38:31.761500Z  INFO Hydrated active synaptic tags from durable storage count=0",
+      "2026-08-30T17:38:31.761504Z  INFO CognitiveEngine initialized and hydrated",
+      "2026-08-30T17:38:31.761555Z  INFO Autopilot spawned (event-subscriber + prospective poller, supervised)",
+      "2026-08-30T17:38:31.761557Z  INFO Dashboard disabled by VESTIGE_DASHBOARD_ENABLED=false",
+      "2026-08-30T17:38:31.761558Z  INFO HTTP MCP transport disabled; set VESTIGE_HTTP_ENABLED=1 or pass --http to enable",
+      "2026-08-30T17:38:31.761588Z  INFO Starting MCP server on stdio...",
+      "2026-08-30T17:38:31.762200Z  INFO Client requested supported protocol version 2024-11-05, using it",
+      "2026-08-30T17:38:31.762210Z  INFO MCP session initialized with protocol version 2024-11-05",
+      "2026-08-30T17:38:32.256036Z  INFO Legacy Nomic embedding service initialized successfully",
+      "[vestige] Cross-encoder reranker loaded (Jina Reranker v1 Turbo)",
+      "2026-08-30T17:38:33.763126Z  INFO No previous consolidation found \u2014 running first auto-consolidation",
+      "2026-08-30T17:38:33.774487Z  INFO Periodic auto-consolidation complete nodes_processed=0 decay_applied=0 embeddings_generated=0 duplicates_merged=0 activations_computed=0 duration_ms=5",
+      "2026-08-30T17:40:48.080861Z  INFO Inline consolidation triggered (scheduler) tool_calls=100 decay_applied=929 duplicates_merged=65 activations_computed=20 duration_ms=7428",
+      "2026-08-30T17:42:22.276461Z  INFO Inline consolidation triggered (scheduler) tool_calls=200 decay_applied=1784 duplicates_merged=106 activations_computed=31 duration_ms=10368"
+    ]
+  },
+  "caveats": [
+    "Absolute scores are NOT comparable to arXiv:2605.20926 Table 3: that table used an LLM judge (gpt-5.0-mini) and a different reader; this harness uses a deterministic rule-based judge and a non-LLM reader.",
+    "Only cross-arm differences within a single run are meaningful.",
+    "crs_struct uses Vestige's dedicated contradictions API and has no counterpart in the bm25/random/nomem arms; it is reported for vestige only and is NOT a head-to-head win over the controls.",
+    "recall(mode='contradictions') accepts no scope parameter, so the CRS-struct probe is NOT namespace-isolated and may scan memories from other simulated users in the same run.",
+    "Small subsets have wide error bars. Check per_conflict_type n before reading any difference as signal; macro_answer_accuracy weights a 3-question conflict type equally with an 88-question one.",
+    "Vestige merges near-duplicate ingested units into composite nodes (marked [MERGED]) even under batchMergePolicy=force_create, so its retrieval units are larger than the raw units the bm25/random arms index. Content is preserved, but check reader_chars_mean before comparing answer accuracy across arms.",
+    "CauseBench is retracted and must never be cited."
+  ],
+  "per_question": {
+    "nomem": [
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_006",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_007",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_006",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_007",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_006",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_007",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 14,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      }
+    ],
+    "random": [
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 866,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 790,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 535,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 617,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 922,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 639,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 566,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 867,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 683,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 785,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 768,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 706,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 642,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 503,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 639,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 752,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 589,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 456,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 740,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 860,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 632,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 747,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 885,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 710,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 690,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 689,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 563,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 774,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 737,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 722,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 721,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 678,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 585,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 560,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 632,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 740,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 682,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 860,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 670,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 830,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 685,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 559,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 681,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 620,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 584,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 696,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 683,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 896,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 604,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 647,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 539,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 688,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 764,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 570,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 588,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 705,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 698,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 704,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 556,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 546,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 556,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 655,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 738,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 793,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 722,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 819,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 801,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 509,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 577,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 14,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 843,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 625,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 669,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 836,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 583,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 764,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 694,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 733,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 669,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 648,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 752,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 833,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 795,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 565,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 692,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 739,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 750,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 718,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 691,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 526,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 800,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 675,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 590,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 576,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 573,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 888,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 535,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 645,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 664,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      }
+    ],
+    "bm25": [
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 708,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 669,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 788,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 720,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 727,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 876,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 913,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 812,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 642,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 738,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 724,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 699,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 694,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 736,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 926,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 748,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 914,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 902,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 1005,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1005,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 956,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 1009,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 945,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 878,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 964,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 695,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 953,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 674,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 836,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 734,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 767,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 1081,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 709,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 692,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 635,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 609,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 707,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 618,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 681,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 690,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 773,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 635,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 768,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 932,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 710,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 580,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 742,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 708,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 683,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 603,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 844,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 913,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 622,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 546,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 771,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 765,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 592,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 736,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 774,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 939,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 713,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 602,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 615,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 635,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 584,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 632,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 747,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 688,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 1043,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 14,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 816,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 702,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 618,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 679,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 543,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 698,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 627,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 600,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 568,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 580,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 755,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 638,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 712,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 801,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 600,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 587,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 592,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 578,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 628,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 705,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 688,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 944,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 610,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 677,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 517,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 746,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 746,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 826,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 627,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      }
+    ],
+    "vestige": [
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 825,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 964,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 934,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 728,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 957,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 1118,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 801,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 724,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 809,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 1160,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 612,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 922,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 1388,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 902,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 791,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 919,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 898,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1013,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 911,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1030,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 773,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 911,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 823,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1066,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 779,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 955,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 873,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 915,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 937,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 1207,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1198,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 1212,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 527,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 1144,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 1289,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 837,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 884,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 791,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 1318,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 548,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 710,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 1289,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 881,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 779,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 885,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 656,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 758,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 715,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 1206,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1062,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 820,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 655,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 639,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 749,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 759,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 724,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 704,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 897,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 889,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 1026,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 632,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 646,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 656,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 537,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 641,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 617,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 819,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 834,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 826,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 14,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 810,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 717,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 725,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 703,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 787,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 711,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 775,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 820,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 851,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 705,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 794,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 758,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 930,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 565,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 986,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 825,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 820,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 745,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 762,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 841,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 978,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 1119,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 717,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 752,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 751,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 761,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 840,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 846,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 856,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      }
+    ]
+  }
+}

--- a/benchmarks/memconflict/results/memconflict-20260830T180535Z.json
+++ b/benchmarks/memconflict/results/memconflict-20260830T180535Z.json
@@ -1,0 +1,4947 @@
+{
+  "benchmark": "MemConflict",
+  "harness_version": "1.0",
+  "generated_utc": "2026-08-30T18:05:35Z",
+  "wall_seconds": 228.2,
+  "exact_command": "python3 benchmarks/memconflict/run.py --instances 2 --sessions 25 --top-k 5",
+  "reproduce": [
+    "cargo build -p vestige-mcp",
+    "python3 benchmarks/memconflict/fetch_dataset.py",
+    "python3 benchmarks/memconflict/run.py --instances 2 --sessions 25 --top-k 5"
+  ],
+  "dataset": {
+    "source": "https://github.com/TaoZhen1110/MemConflict",
+    "paper": "arXiv:2605.20926",
+    "revision": "ec51d5d36e87f7665d1337f3a88cbde95fc2a964",
+    "files": {
+      "Data/Step4_4.jsonl": {
+        "sha256": "8ef9ec8589eccb86f63ab3a819a9180217405351a8d5846866721ea74babe092",
+        "bytes": 39671712,
+        "instances": 30,
+        "questions": 3750
+      }
+    },
+    "instances_evaluated": 2,
+    "sessions_per_instance_cap": 25
+  },
+  "vestige": {
+    "commit": "b215b374901d268dfd8591a7f570906a688dd856",
+    "branch": "fix/v242-sqlite-and-tier1",
+    "dirty": true,
+    "server_info": {
+      "name": "vestige",
+      "version": "2.4.1"
+    },
+    "binary": "/Users/entity002/vestige-v240-fixes/target/debug/vestige-mcp"
+  },
+  "config": {
+    "arms": [
+      "nomem",
+      "random",
+      "bm25",
+      "vestige"
+    ],
+    "top_k": 5,
+    "recall_mode": "lookup",
+    "seed": 1234,
+    "contradiction_limit": 200,
+    "reader": "deterministic concatenation of top-k retrieved memory texts",
+    "judge": "rule-based port of upstream Evaluation/eval_scoring.py (no LLM)",
+    "warmup": {
+      "requested_seconds": 45.0,
+      "actual_seconds": 45.0,
+      "embedding_ready_signal": "2026-08-30T18:05:39.390245Z  INFO Periodic auto-consolidation complete nodes_processed=0 decay_applied=0 embeddings_generated=0 duplicates_merged=0 activations_computed=0 duration_ms=8"
+    }
+  },
+  "machine": {
+    "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
+    "machine": "arm64",
+    "processor": "arm",
+    "python": "3.14.4",
+    "cpu_count": 10,
+    "memory_bytes": 68719476736,
+    "cpu_brand": "Apple M1 Max"
+  },
+  "results": {
+    "nomem": {
+      "n_questions": 98,
+      "reader_chars_mean": 0.0,
+      "n_retrieved_mean": 0.0,
+      "per_conflict_type": {
+        "dynamic_conflict": {
+          "n": 88,
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        },
+        "static_conflict": {
+          "n": 7,
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        },
+        "conditional_conflict": {
+          "n": 3,
+          "answer_accuracy": 0.0
+        }
+      },
+      "macro_answer_accuracy": 0.0,
+      "micro_answer_accuracy": 0.0
+    },
+    "random": {
+      "n_questions": 98,
+      "reader_chars_mean": 686.6,
+      "n_retrieved_mean": 5.0,
+      "per_conflict_type": {
+        "dynamic_conflict": {
+          "n": 88,
+          "answer_accuracy": 0.0966,
+          "uocs": 0.0
+        },
+        "static_conflict": {
+          "n": 7,
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        },
+        "conditional_conflict": {
+          "n": 3,
+          "answer_accuracy": 0.0
+        }
+      },
+      "macro_answer_accuracy": 0.0322,
+      "micro_answer_accuracy": 0.0867
+    },
+    "bm25": {
+      "n_questions": 98,
+      "reader_chars_mean": 735.5,
+      "n_retrieved_mean": 5.0,
+      "per_conflict_type": {
+        "dynamic_conflict": {
+          "n": 88,
+          "answer_accuracy": 0.25,
+          "uocs": 0.1932
+        },
+        "static_conflict": {
+          "n": 7,
+          "answer_accuracy": 0.2143,
+          "crs_lex": 0.0
+        },
+        "conditional_conflict": {
+          "n": 3,
+          "answer_accuracy": 1.0
+        }
+      },
+      "macro_answer_accuracy": 0.4881,
+      "micro_answer_accuracy": 0.2704
+    },
+    "vestige": {
+      "n_questions": 98,
+      "reader_chars_mean": 828.6,
+      "n_retrieved_mean": 5.0,
+      "per_conflict_type": {
+        "dynamic_conflict": {
+          "n": 88,
+          "answer_accuracy": 0.2614,
+          "uocs": 0.2841
+        },
+        "static_conflict": {
+          "n": 7,
+          "answer_accuracy": 0.2857,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "conditional_conflict": {
+          "n": 3,
+          "answer_accuracy": 1.0
+        }
+      },
+      "macro_answer_accuracy": 0.5157,
+      "micro_answer_accuracy": 0.2857
+    }
+  },
+  "diagnostics": {
+    "vestige_ingest_errors": 0,
+    "vestige_retrieve_errors": 0,
+    "vestige_retrieval_latency_s": {
+      "n": 98,
+      "mean": 0.2645,
+      "median": 0.2607,
+      "max": 0.6623
+    },
+    "server_stderr_tail": [
+      "2026-08-30T18:05:37.370987Z  INFO CognitiveEngine initialized and hydrated",
+      "2026-08-30T18:05:37.371344Z  INFO Autopilot spawned (event-subscriber + prospective poller, supervised)",
+      "2026-08-30T18:05:37.371350Z  INFO Dashboard disabled by VESTIGE_DASHBOARD_ENABLED=false",
+      "2026-08-30T18:05:37.371353Z  INFO HTTP MCP transport disabled; set VESTIGE_HTTP_ENABLED=1 or pass --http to enable",
+      "2026-08-30T18:05:37.371639Z  INFO Starting MCP server on stdio...",
+      "2026-08-30T18:05:37.372396Z  INFO Client requested supported protocol version 2024-11-05, using it",
+      "2026-08-30T18:05:37.372405Z  INFO MCP session initialized with protocol version 2024-11-05",
+      "2026-08-30T18:05:37.826109Z  INFO Legacy Nomic embedding service initialized successfully",
+      "[vestige] Cross-encoder reranker loaded (Jina Reranker v1 Turbo)",
+      "2026-08-30T18:05:39.376664Z  INFO No previous consolidation found \u2014 running first auto-consolidation",
+      "2026-08-30T18:05:39.390245Z  INFO Periodic auto-consolidation complete nodes_processed=0 decay_applied=0 embeddings_generated=0 duplicates_merged=0 activations_computed=0 duration_ms=8",
+      "2026-08-30T18:07:41.062290Z  INFO Inline consolidation triggered (scheduler) tool_calls=100 decay_applied=927 duplicates_merged=65 activations_computed=20 duration_ms=6139",
+      "2026-08-30T18:09:01.873347Z  INFO Inline consolidation triggered (scheduler) tool_calls=200 decay_applied=1782 duplicates_merged=106 activations_computed=31 duration_ms=9474",
+      "2026-08-30T18:09:23.771613Z  INFO stdin closed (EOF), shutting down",
+      "2026-08-30T18:09:23.771629Z  INFO Vestige MCP Server shutting down"
+    ]
+  },
+  "caveats": [
+    "Absolute scores are NOT comparable to arXiv:2605.20926 Table 3: that table used an LLM judge (gpt-5.0-mini) and a different reader; this harness uses a deterministic rule-based judge and a non-LLM reader.",
+    "Only cross-arm differences within a single run are meaningful.",
+    "crs_struct uses Vestige's dedicated contradictions API and has no counterpart in the bm25/random/nomem arms; it is reported for vestige only and is NOT a head-to-head win over the controls.",
+    "recall(mode='contradictions') accepts no scope parameter, so the CRS-struct probe is NOT namespace-isolated and may scan memories from other simulated users in the same run.",
+    "Small subsets have wide error bars. Check per_conflict_type n before reading any difference as signal; macro_answer_accuracy weights a 3-question conflict type equally with an 88-question one.",
+    "Vestige merges near-duplicate ingested units into composite nodes (marked [MERGED]) even under batchMergePolicy=force_create, so its retrieval units are larger than the raw units the bm25/random arms index. Content is preserved, but check reader_chars_mean before comparing answer accuracy across arms.",
+    "CauseBench is retracted and must never be cited."
+  ],
+  "per_question": {
+    "nomem": [
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_006",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_007",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_006",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_007",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_006",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_007",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 14,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      }
+    ],
+    "random": [
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 866,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 790,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 535,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 617,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 922,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 639,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 566,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 867,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 683,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 785,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 768,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 706,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 642,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 503,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 639,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 752,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 589,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 456,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 740,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 860,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 632,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 747,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 885,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 710,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 690,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 689,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 563,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 774,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 737,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 722,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 721,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 678,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 585,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 560,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 632,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 740,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 682,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 860,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 670,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 830,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 685,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 559,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 681,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 620,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 584,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 696,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 683,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 896,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 604,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 647,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 539,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 688,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 764,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 570,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 588,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 705,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 698,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 704,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 556,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 546,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 556,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 655,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 738,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 793,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 722,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 819,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 801,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 509,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 577,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 14,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 843,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 625,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 669,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 836,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 583,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 764,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 694,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 733,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 669,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 648,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 752,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 833,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 795,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 565,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 692,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 739,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 750,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 718,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 691,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 526,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 800,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 675,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 590,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 576,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 573,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 888,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 535,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 645,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 664,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      }
+    ],
+    "bm25": [
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 708,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 669,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 788,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 720,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 727,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 876,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 913,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 812,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 642,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 738,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 724,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 699,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 694,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 736,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 926,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 748,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 914,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 902,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 1005,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1005,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 956,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 1009,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 945,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 878,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 964,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 695,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 953,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 674,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 836,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 734,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 767,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 1081,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 709,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 692,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 635,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 609,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 707,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 618,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 681,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 690,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 773,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 635,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 768,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 932,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 710,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 580,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 742,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 708,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 683,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 603,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 844,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 913,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 622,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 546,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 771,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 765,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 592,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 736,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 774,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 939,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 713,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 602,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 615,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 635,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 584,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 632,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 747,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 688,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 1043,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 14,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 816,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 702,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 618,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 679,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 543,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 698,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 627,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 600,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 568,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 580,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 755,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 638,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 712,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 801,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 600,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 587,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 592,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 578,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 628,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 705,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 688,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 944,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 610,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 677,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 517,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 746,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 746,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 826,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 627,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      }
+    ],
+    "vestige": [
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 776,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 905,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 796,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 819,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 591,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 840,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 786,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 724,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 738,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 994,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 500,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 841,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 1189,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 817,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 731,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 919,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 880,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1008,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 911,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1043,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 735,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 974,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 780,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 915,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 893,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 919,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 814,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 915,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 937,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 1308,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1293,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 1263,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 527,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 825,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 1406,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 705,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 787,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 915,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 1318,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 589,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 727,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 1239,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 865,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 1000,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 1109,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 605,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 696,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 790,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 1206,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1200,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 820,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 947,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 706,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 768,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 722,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 689,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 679,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1047,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 889,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 1026,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 593,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 641,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 490,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 641,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 652,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 617,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 741,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 783,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 907,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 14,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 860,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 640,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 725,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 702,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 787,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 711,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 805,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 744,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 674,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 705,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 657,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 826,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 897,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 582,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 784,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 836,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 760,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 745,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 676,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 841,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 825,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 830,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 550,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 658,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 794,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 704,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 760,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 846,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 856,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      }
+    ]
+  }
+}

--- a/benchmarks/memconflict/results/memconflict-20260830T181021Z.json
+++ b/benchmarks/memconflict/results/memconflict-20260830T181021Z.json
@@ -1,0 +1,4947 @@
+{
+  "benchmark": "MemConflict",
+  "harness_version": "1.0",
+  "generated_utc": "2026-08-30T18:10:21Z",
+  "wall_seconds": 256.7,
+  "exact_command": "python3 benchmarks/memconflict/run.py --instances 2 --sessions 25 --top-k 5",
+  "reproduce": [
+    "cargo build -p vestige-mcp",
+    "python3 benchmarks/memconflict/fetch_dataset.py",
+    "python3 benchmarks/memconflict/run.py --instances 2 --sessions 25 --top-k 5"
+  ],
+  "dataset": {
+    "source": "https://github.com/TaoZhen1110/MemConflict",
+    "paper": "arXiv:2605.20926",
+    "revision": "ec51d5d36e87f7665d1337f3a88cbde95fc2a964",
+    "files": {
+      "Data/Step4_4.jsonl": {
+        "sha256": "8ef9ec8589eccb86f63ab3a819a9180217405351a8d5846866721ea74babe092",
+        "bytes": 39671712,
+        "instances": 30,
+        "questions": 3750
+      }
+    },
+    "instances_evaluated": 2,
+    "sessions_per_instance_cap": 25
+  },
+  "vestige": {
+    "commit": "b215b374901d268dfd8591a7f570906a688dd856",
+    "branch": "fix/v242-sqlite-and-tier1",
+    "dirty": true,
+    "server_info": {
+      "name": "vestige",
+      "version": "2.4.1"
+    },
+    "binary": "/Users/entity002/vestige-v240-fixes/target/debug/vestige-mcp"
+  },
+  "config": {
+    "arms": [
+      "nomem",
+      "random",
+      "bm25",
+      "vestige"
+    ],
+    "top_k": 5,
+    "recall_mode": "lookup",
+    "seed": 1234,
+    "contradiction_limit": 200,
+    "reader": "deterministic concatenation of top-k retrieved memory texts",
+    "judge": "rule-based port of upstream Evaluation/eval_scoring.py (no LLM)",
+    "warmup": {
+      "requested_seconds": 45.0,
+      "actual_seconds": 45.01,
+      "embedding_ready_signal": "2026-08-30T18:10:25.315123Z  INFO Periodic auto-consolidation complete nodes_processed=0 decay_applied=0 embeddings_generated=0 duplicates_merged=0 activations_computed=0 duration_ms=9"
+    }
+  },
+  "machine": {
+    "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
+    "machine": "arm64",
+    "processor": "arm",
+    "python": "3.14.4",
+    "cpu_count": 10,
+    "memory_bytes": 68719476736,
+    "cpu_brand": "Apple M1 Max"
+  },
+  "results": {
+    "nomem": {
+      "n_questions": 98,
+      "reader_chars_mean": 0.0,
+      "n_retrieved_mean": 0.0,
+      "per_conflict_type": {
+        "dynamic_conflict": {
+          "n": 88,
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        },
+        "static_conflict": {
+          "n": 7,
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        },
+        "conditional_conflict": {
+          "n": 3,
+          "answer_accuracy": 0.0
+        }
+      },
+      "macro_answer_accuracy": 0.0,
+      "micro_answer_accuracy": 0.0
+    },
+    "random": {
+      "n_questions": 98,
+      "reader_chars_mean": 686.6,
+      "n_retrieved_mean": 5.0,
+      "per_conflict_type": {
+        "dynamic_conflict": {
+          "n": 88,
+          "answer_accuracy": 0.0966,
+          "uocs": 0.0
+        },
+        "static_conflict": {
+          "n": 7,
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        },
+        "conditional_conflict": {
+          "n": 3,
+          "answer_accuracy": 0.0
+        }
+      },
+      "macro_answer_accuracy": 0.0322,
+      "micro_answer_accuracy": 0.0867
+    },
+    "bm25": {
+      "n_questions": 98,
+      "reader_chars_mean": 735.5,
+      "n_retrieved_mean": 5.0,
+      "per_conflict_type": {
+        "dynamic_conflict": {
+          "n": 88,
+          "answer_accuracy": 0.25,
+          "uocs": 0.1932
+        },
+        "static_conflict": {
+          "n": 7,
+          "answer_accuracy": 0.2143,
+          "crs_lex": 0.0
+        },
+        "conditional_conflict": {
+          "n": 3,
+          "answer_accuracy": 1.0
+        }
+      },
+      "macro_answer_accuracy": 0.4881,
+      "micro_answer_accuracy": 0.2704
+    },
+    "vestige": {
+      "n_questions": 98,
+      "reader_chars_mean": 853.6,
+      "n_retrieved_mean": 5.0,
+      "per_conflict_type": {
+        "dynamic_conflict": {
+          "n": 88,
+          "answer_accuracy": 0.3011,
+          "uocs": 0.3636
+        },
+        "static_conflict": {
+          "n": 7,
+          "answer_accuracy": 0.3571,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "conditional_conflict": {
+          "n": 3,
+          "answer_accuracy": 0.6667
+        }
+      },
+      "macro_answer_accuracy": 0.4416,
+      "micro_answer_accuracy": 0.3163
+    }
+  },
+  "diagnostics": {
+    "vestige_ingest_errors": 0,
+    "vestige_retrieve_errors": 0,
+    "vestige_retrieval_latency_s": {
+      "n": 98,
+      "mean": 0.3957,
+      "median": 0.3881,
+      "max": 0.8229
+    },
+    "server_stderr_tail": [
+      "2026-08-30T18:10:23.298276Z  INFO CognitiveEngine initialized and hydrated",
+      "2026-08-30T18:10:23.298470Z  INFO Autopilot spawned (event-subscriber + prospective poller, supervised)",
+      "2026-08-30T18:10:23.298474Z  INFO Dashboard disabled by VESTIGE_DASHBOARD_ENABLED=false",
+      "2026-08-30T18:10:23.298475Z  INFO HTTP MCP transport disabled; set VESTIGE_HTTP_ENABLED=1 or pass --http to enable",
+      "2026-08-30T18:10:23.298567Z  INFO Starting MCP server on stdio...",
+      "2026-08-30T18:10:23.299505Z  INFO Client requested supported protocol version 2024-11-05, using it",
+      "2026-08-30T18:10:23.299512Z  INFO MCP session initialized with protocol version 2024-11-05",
+      "2026-08-30T18:10:23.746009Z  INFO Legacy Nomic embedding service initialized successfully",
+      "[vestige] Cross-encoder reranker loaded (Jina Reranker v1 Turbo)",
+      "2026-08-30T18:10:25.298525Z  INFO No previous consolidation found \u2014 running first auto-consolidation",
+      "2026-08-30T18:10:25.315123Z  INFO Periodic auto-consolidation complete nodes_processed=0 decay_applied=0 embeddings_generated=0 duplicates_merged=0 activations_computed=0 duration_ms=9",
+      "2026-08-30T18:12:52.785200Z  INFO Inline consolidation triggered (scheduler) tool_calls=100 decay_applied=929 duplicates_merged=65 activations_computed=20 duration_ms=6773",
+      "2026-08-30T18:14:08.894920Z  INFO Inline consolidation triggered (scheduler) tool_calls=200 decay_applied=1783 duplicates_merged=106 activations_computed=31 duration_ms=9724",
+      "2026-08-30T18:14:38.098517Z  INFO stdin closed (EOF), shutting down",
+      "2026-08-30T18:14:38.098531Z  INFO Vestige MCP Server shutting down"
+    ]
+  },
+  "caveats": [
+    "Absolute scores are NOT comparable to arXiv:2605.20926 Table 3: that table used an LLM judge (gpt-5.0-mini) and a different reader; this harness uses a deterministic rule-based judge and a non-LLM reader.",
+    "Only cross-arm differences within a single run are meaningful.",
+    "crs_struct uses Vestige's dedicated contradictions API and has no counterpart in the bm25/random/nomem arms; it is reported for vestige only and is NOT a head-to-head win over the controls.",
+    "recall(mode='contradictions') accepts no scope parameter, so the CRS-struct probe is NOT namespace-isolated and may scan memories from other simulated users in the same run.",
+    "Small subsets have wide error bars. Check per_conflict_type n before reading any difference as signal; macro_answer_accuracy weights a 3-question conflict type equally with an 88-question one.",
+    "Vestige merges near-duplicate ingested units into composite nodes (marked [MERGED]) even under batchMergePolicy=force_create, so its retrieval units are larger than the raw units the bm25/random arms index. Content is preserved, but check reader_chars_mean before comparing answer accuracy across arms.",
+    "CauseBench is retracted and must never be cited."
+  ],
+  "per_question": {
+    "nomem": [
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_006",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_007",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_006",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_007",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_006",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_007",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 14,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 0,
+        "answer_chars": 0,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      }
+    ],
+    "random": [
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 866,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 790,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 535,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 617,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 922,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 639,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 566,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 867,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 683,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 785,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 768,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 706,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 642,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 503,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 639,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 752,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 589,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 456,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 740,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 860,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 632,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 747,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 885,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 710,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 690,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 689,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 563,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 774,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 737,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 722,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 721,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 678,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 585,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 560,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 632,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 740,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 682,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 860,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 670,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 830,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 685,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 559,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 681,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 620,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 584,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 696,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 683,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 896,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 604,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 647,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 539,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 688,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 764,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 570,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 588,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 705,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 698,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 704,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 556,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 546,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 556,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 655,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 738,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 793,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 722,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 819,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 801,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 509,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 577,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 14,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 843,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 625,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 669,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 836,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 583,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 764,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 694,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 733,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 669,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 648,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 752,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 833,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 795,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 565,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 692,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 739,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 750,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 718,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 691,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 526,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 800,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 675,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 590,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 576,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 573,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 888,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 535,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 645,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 664,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      }
+    ],
+    "bm25": [
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 708,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 669,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 788,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 720,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 727,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 876,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 913,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 812,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 642,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 738,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 724,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 699,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 694,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 736,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 926,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 748,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 914,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 902,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 1005,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1005,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 956,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 1009,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 945,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 878,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 964,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 695,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 953,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 674,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 836,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 734,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 767,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 1081,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 709,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 692,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 635,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 609,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 707,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 618,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 681,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 690,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 773,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 635,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 768,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 932,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 710,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 580,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 742,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 708,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 683,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 603,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 844,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 913,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 622,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 546,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 771,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 765,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 592,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 736,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 774,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 939,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 713,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 602,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 615,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 635,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 584,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 632,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 747,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 688,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 1043,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 14,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 816,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 702,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 618,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 679,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 543,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 698,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 627,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 600,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 568,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 580,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 755,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 638,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 712,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 801,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 600,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 587,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 592,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 578,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 628,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 705,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 688,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 944,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 610,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 677,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 517,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 746,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 746,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 826,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 627,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      }
+    ],
+    "vestige": [
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 825,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 964,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 934,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 728,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 957,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 1118,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 5,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 801,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 724,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 809,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 1160,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 612,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 922,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 1388,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 8,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 902,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 791,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 9,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 919,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 898,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 10,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1013,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 911,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1030,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 773,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 12,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 911,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 823,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 13,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1066,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 779,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 955,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 873,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 15,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 915,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 937,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 1207,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1198,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 1212,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 527,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 1144,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 1289,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 18,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 837,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 884,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 791,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 1318,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 548,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 710,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 1289,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 881,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_006",
+        "n_retrieved": 5,
+        "answer_chars": 779,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 20,
+        "question_id": "Q_007",
+        "n_retrieved": 5,
+        "answer_chars": 885,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 656,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 758,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 715,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 1206,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 1062,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 820,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "3c2e5fe5-a0fc-7e3c-b05c-7104ad748705",
+        "session": 24,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 655,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 639,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 3,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 749,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 759,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 4,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 724,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 704,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 897,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 889,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 6,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 1026,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 632,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 8,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 646,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 10,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 656,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.0,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 537,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 641,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 11,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 617,
+        "metrics": {
+          "conflict_type": "conditional_conflict",
+          "answer_accuracy": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 819,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 12,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 834,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 13,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 826,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 14,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 810,
+        "metrics": {
+          "conflict_type": "static_conflict",
+          "answer_accuracy": 0.5,
+          "crs_lex": 0.0,
+          "crs_struct": 0.0
+        },
+        "extra": {
+          "contradiction_probe": {
+            "found": 0,
+            "analyzed": 200
+          }
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 717,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 15,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 725,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 703,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 16,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 787,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 711,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 775,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 820,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 17,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 851,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 705,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 794,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 758,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 930,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 18,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 565,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 986,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 825,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 820,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 19,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 745,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 762,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 841,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_003",
+        "n_retrieved": 5,
+        "answer_chars": 978,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_004",
+        "n_retrieved": 5,
+        "answer_chars": 1119,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 20,
+        "question_id": "Q_005",
+        "n_retrieved": 5,
+        "answer_chars": 717,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 752,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 21,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 751,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 761,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 22,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 840,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_001",
+        "n_retrieved": 5,
+        "answer_chars": 846,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.0,
+          "uocs": 0.0
+        }
+      },
+      {
+        "instance": "9841f645-49ad-3de3-9010-cef938781102",
+        "session": 23,
+        "question_id": "Q_002",
+        "n_retrieved": 5,
+        "answer_chars": 856,
+        "metrics": {
+          "conflict_type": "dynamic_conflict",
+          "answer_accuracy": 0.5,
+          "uocs": 1.0
+        }
+      }
+    ]
+  }
+}

--- a/benchmarks/memconflict/run.py
+++ b/benchmarks/memconflict/run.py
@@ -1,0 +1,674 @@
+#!/usr/bin/env python3
+"""MemConflict retrieval benchmark for Vestige, with mandatory controls.
+
+One command, pinned data, deterministic judge, JSON results.
+
+    python3 benchmarks/memconflict/run.py --instances 2 --sessions 12
+
+WHAT THIS MEASURES
+------------------
+Whether a retrieval arm surfaces the evidence needed to answer a
+conflict-sensitive question about a simulated user's multi-session history,
+and -- for static conflicts -- whether the system RECOGNISES that the store
+holds contradictory claims.
+
+THE ARMS (all four run every time; none is optional)
+---------------------------------------------------
+  nomem    No retrieval at all. The reader receives an empty string.
+           This is the true floor. Any metric that scores above ~0 here is
+           measuring the judge, not the memory system.
+  random   K memory units chosen uniformly at random from the same corpus,
+           with a fixed seed. This is the blob-inflation control: the judge
+           awards partial credit for token overlap, and a concatenation of
+           any K memories shares tokens with the gold answer by chance.
+           If an arm cannot beat `random`, its score is corpus statistics.
+  bm25     Okapi BM25 over the identical corpus. The "earned complexity" bar.
+  vestige  recall(mode=...) against the live MCP server.
+
+Every arm is fed to the SAME deterministic reader and the SAME judge, so the
+only variable between arms is retrieval. That is the MemDelta discipline:
+change one component at a time.
+
+THE READER
+----------
+Deliberately not an LLM. The reader concatenates the top-K retrieved memory
+texts and hands that to the judge. This removes the model confound entirely
+and keeps the harness free and deterministic. The cost is that absolute
+numbers are NOT comparable to any published table; only cross-arm differences
+within a single run are meaningful. K is held identical across arms so no arm
+gets a longer blob than another.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import platform
+import random as _random
+import subprocess
+import statistics
+import sys
+import time
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+HERE = pathlib.Path(__file__).resolve().parent
+REPO = HERE.parent.parent
+sys.path.insert(0, str(HERE))
+
+import bm25 as bm25_mod  # noqa: E402
+import judge as judge_mod  # noqa: E402
+from mcp_client import VestigeMCP, VestigeMCPError  # noqa: E402
+
+ARMS = ("nomem", "random", "bm25", "vestige")
+CONFLICT_TYPES = ("dynamic_conflict", "static_conflict", "conditional_conflict")
+
+
+# --------------------------------------------------------------------------
+# dataset
+# --------------------------------------------------------------------------
+
+def load_instances(path: pathlib.Path, limit: Optional[int]) -> List[Dict[str, Any]]:
+    rows = []
+    with path.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+            if limit and len(rows) >= limit:
+                break
+    return rows
+
+
+def session_units(session: Dict[str, Any]) -> List[str]:
+    """The memory units contributed by one session.
+
+    One unit per user utterance, date-stamped. Assistant turns are excluded:
+    they are the agent's own words, not facts about the user, and including
+    them would pad every arm's corpus with paraphrase.
+    """
+    date = session.get("Date", "")
+    dialogue = session.get("Session_Dialogue") or {}
+    units: List[str] = []
+    # dialogue_turn_N keys must be walked in numeric order, not string order.
+    def turn_no(k: str) -> int:
+        try:
+            return int(k.rsplit("_", 1)[1])
+        except (IndexError, ValueError):
+            return 0
+
+    for key in sorted(dialogue.keys(), key=turn_no):
+        for msg in dialogue[key] or []:
+            if msg.get("role") != "user":
+                continue
+            text = (msg.get("content") or "").strip()
+            if text:
+                units.append(f"[{date}] {text}")
+    return units
+
+
+def iter_sessions(instance: Dict[str, Any], max_sessions: Optional[int]) -> Iterable[Dict[str, Any]]:
+    chain = instance.get("Full_Session_Chain") or []
+    chain = sorted(chain, key=lambda s: s.get("Session_ID", 0))
+    if max_sessions:
+        chain = chain[:max_sessions]
+    return chain
+
+
+# --------------------------------------------------------------------------
+# readers / arms
+# --------------------------------------------------------------------------
+
+def reader(texts: List[str]) -> str:
+    """Deterministic reader: concatenate retrieved memory texts."""
+    return "\n".join(t for t in texts if t)
+
+
+class NoMemArm:
+    name = "nomem"
+
+    def reset(self, instance_id: str) -> None:
+        pass
+
+    def add(self, units: List[str]) -> None:
+        pass
+
+    def retrieve(self, question: str, k: int) -> Tuple[List[str], Dict[str, Any]]:
+        return [], {}
+
+
+class RandomArm:
+    name = "random"
+
+    def __init__(self, seed: int) -> None:
+        self.seed = seed
+        self.corpus: List[str] = []
+        self.rng = _random.Random(seed)
+
+    def reset(self, instance_id: str) -> None:
+        self.corpus = []
+        # Re-seed per instance so results do not depend on instance order.
+        self.rng = _random.Random(f"{self.seed}:{instance_id}")
+
+    def add(self, units: List[str]) -> None:
+        self.corpus.extend(units)
+
+    def retrieve(self, question: str, k: int) -> Tuple[List[str], Dict[str, Any]]:
+        if not self.corpus:
+            return [], {}
+        n = min(k, len(self.corpus))
+        return self.rng.sample(self.corpus, n), {}
+
+
+class BM25Arm:
+    name = "bm25"
+
+    def __init__(self) -> None:
+        self.corpus: List[str] = []
+        self._index: Optional[bm25_mod.BM25] = None
+
+    def reset(self, instance_id: str) -> None:
+        self.corpus = []
+        self._index = None
+
+    def add(self, units: List[str]) -> None:
+        self.corpus.extend(units)
+        self._index = None  # invalidate; rebuilt lazily on next retrieve
+
+    def retrieve(self, question: str, k: int) -> Tuple[List[str], Dict[str, Any]]:
+        if not self.corpus:
+            return [], {}
+        if self._index is None:
+            self._index = bm25_mod.BM25(self.corpus)
+        hits = self._index.top_k(question, k)
+        return [self.corpus[i] for i, _ in hits], {}
+
+
+class VestigeArm:
+    name = "vestige"
+
+    def __init__(self, client: VestigeMCP, mode: str, contradiction_probe: bool,
+                 contradiction_limit: int = 200) -> None:
+        self.client = client
+        self.mode = mode
+        self.contradiction_probe = contradiction_probe
+        self.contradiction_limit = contradiction_limit
+        self.scope = "default"
+        self.ingest_errors = 0
+        self.retrieve_errors = 0
+        self.scope_bleed = 0
+        self.latencies: List[float] = []
+
+    def reset(self, instance_id: str) -> None:
+        # Per-instance namespace isolation so one simulated user's memories
+        # cannot be retrieved while evaluating another.
+        self.scope = f"mc_{instance_id.replace('-', '')[:24]}"
+
+    def add(self, units: List[str]) -> None:
+        # smart_ingest batch mode caps at 20 items per call.
+        for start in range(0, len(units), 20):
+            chunk = units[start:start + 20]
+            items = [
+                {"content": text, "node_type": "event", "tags": [self.scope]}
+                for text in chunk
+            ]
+            try:
+                self.client.call_tool(
+                    "smart_ingest",
+                    {"items": items, "scope": self.scope, "batchMergePolicy": "force_create"},
+                    timeout=600.0,
+                )
+            except VestigeMCPError:
+                self.ingest_errors += 1
+
+    @staticmethod
+    def _texts_from_recall(payload: Any) -> List[str]:
+        """Pull memory CONTENT out of a recall payload.
+
+        Deliberately extracts only stored memory text, never the tool's own
+        framing, headers, labels or field names. Scoring the envelope would
+        let the harness award conflict-recognition credit for a canned string
+        the server always emits.
+        """
+        out: List[str] = []
+        if isinstance(payload, str):
+            return [payload]
+        if not isinstance(payload, dict):
+            return out
+        for key in ("results", "memories", "nodes", "matches"):
+            for item in payload.get(key) or []:
+                if isinstance(item, dict):
+                    text = item.get("content") or item.get("preview") or item.get("text")
+                    if text:
+                        out.append(str(text))
+                elif isinstance(item, str):
+                    out.append(item)
+        return out
+
+    def retrieve(self, question: str, k: int) -> Tuple[List[str], Dict[str, Any]]:
+        extra: Dict[str, Any] = {}
+        t0 = time.monotonic()
+        try:
+            payload = self.client.call_tool(
+                "recall",
+                {"query": question, "mode": self.mode, "limit": k, "scope": self.scope},
+                timeout=300.0,
+            )
+            texts = self._texts_from_recall(payload)[:k]
+        except VestigeMCPError as exc:
+            self.retrieve_errors += 1
+            extra["error"] = str(exc)[:200]
+            texts = []
+        self.latencies.append(time.monotonic() - t0)
+        return texts, extra
+
+    def probe_contradictions(self, topic: str, limit: int = 200) -> Dict[str, Any]:
+        """Structural contradiction signal (Vestige-only capability).
+
+        Returns the count of contradiction pairs the server reports for this
+        topic. Scored structurally -- we never keyword-match the response --
+        so the metric cannot be satisfied by the tool merely saying the word
+        "contradiction".
+        """
+        try:
+            payload = self.client.call_tool(
+                "recall",
+                # NOTE: the contradictions tool accepts no `scope` parameter, so
+                # this probe is NOT scope-isolated. `limit` defaults to 50 in the
+                # tool; we pass the maximum (200) so the capability is measured at
+                # its best, never handicapped by the harness.
+                {"mode": "contradictions", "topic": topic, "limit": limit},
+                timeout=300.0,
+            )
+        except VestigeMCPError as exc:
+            return {"error": str(exc)[:200], "found": 0}
+        if not isinstance(payload, dict):
+            return {"found": 0}
+        return {
+            "found": int(payload.get("contradictionsFound") or 0),
+            "analyzed": int(payload.get("memoriesAnalyzed") or 0),
+        }
+
+
+# --------------------------------------------------------------------------
+# aggregation
+# --------------------------------------------------------------------------
+
+def aggregate(records: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Aggregate per-question scores.
+
+    Metrics are averaged only over the questions where they apply. A metric
+    that does not apply to a conflict type is absent, never zero, so the
+    denominator is always correct.
+    """
+    def mean_of(key: str, ctype: Optional[str] = None) -> Optional[float]:
+        vals = [
+            r["metrics"][key]
+            for r in records
+            if key in r["metrics"] and (ctype is None or r["metrics"]["conflict_type"] == ctype)
+        ]
+        return round(statistics.fmean(vals), 4) if vals else None
+
+    def count(ctype: str) -> int:
+        return sum(1 for r in records if r["metrics"]["conflict_type"] == ctype)
+
+    per_type = {}
+    for ctype in CONFLICT_TYPES:
+        n = count(ctype)
+        if not n:
+            continue
+        per_type[ctype] = {"n": n, "answer_accuracy": mean_of("answer_accuracy", ctype)}
+    if "dynamic_conflict" in per_type:
+        per_type["dynamic_conflict"]["uocs"] = mean_of("uocs", "dynamic_conflict")
+    if "static_conflict" in per_type:
+        per_type["static_conflict"]["crs_lex"] = mean_of("crs_lex", "static_conflict")
+        crs_struct = mean_of("crs_struct", "static_conflict")
+        if crs_struct is not None:
+            per_type["static_conflict"]["crs_struct"] = crs_struct
+
+    # Macro-average over conflict types present, matching the paper's
+    # "Average AA" column (a mean of the three type-level means, NOT a
+    # micro-average over questions, which the type imbalance would dominate).
+    type_means = [v["answer_accuracy"] for v in per_type.values() if v["answer_accuracy"] is not None]
+    chars = [r.get("answer_chars", 0) for r in records]
+    retrieved = [r.get("n_retrieved", 0) for r in records]
+    return {
+        "n_questions": len(records),
+        # Blob-size fairness check. The judge awards partial credit for token
+        # overlap, so an arm that hands it more text has a structural advantage
+        # that has nothing to do with retrieval quality. If these differ
+        # materially between arms, the AA comparison is confounded -- say so
+        # rather than reporting the winner.
+        "reader_chars_mean": round(statistics.fmean(chars), 1) if chars else 0.0,
+        "n_retrieved_mean": round(statistics.fmean(retrieved), 2) if retrieved else 0.0,
+        "per_conflict_type": per_type,
+        "macro_answer_accuracy": round(statistics.fmean(type_means), 4) if type_means else None,
+        "micro_answer_accuracy": mean_of("answer_accuracy"),
+    }
+
+
+# --------------------------------------------------------------------------
+# environment capture
+# --------------------------------------------------------------------------
+
+def git_rev(repo: pathlib.Path) -> Dict[str, Any]:
+    def sh(*args: str) -> Optional[str]:
+        try:
+            return subprocess.run(
+                args, cwd=repo, capture_output=True, text=True, timeout=20
+            ).stdout.strip() or None
+        except Exception:
+            return None
+    return {
+        "commit": sh("git", "rev-parse", "HEAD"),
+        "branch": sh("git", "rev-parse", "--abbrev-ref", "HEAD"),
+        "dirty": bool(sh("git", "status", "--porcelain")),
+    }
+
+
+def machine_info() -> Dict[str, Any]:
+    info = {
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "python": sys.version.split()[0],
+        "cpu_count": None,
+        "memory_bytes": None,
+    }
+    try:
+        import os
+        info["cpu_count"] = os.cpu_count()
+    except Exception:
+        pass
+    try:
+        out = subprocess.run(["sysctl", "-n", "hw.memsize"], capture_output=True, text=True, timeout=10)
+        if out.returncode == 0:
+            info["memory_bytes"] = int(out.stdout.strip())
+    except Exception:
+        pass
+    try:
+        out = subprocess.run(["sysctl", "-n", "machdep.cpu.brand_string"], capture_output=True, text=True, timeout=10)
+        if out.returncode == 0 and out.stdout.strip():
+            info["cpu_brand"] = out.stdout.strip()
+    except Exception:
+        pass
+    return info
+
+
+# --------------------------------------------------------------------------
+# main
+# --------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--dataset", default=str(HERE / "data" / "Step4_4.jsonl"))
+    ap.add_argument("--binary", default=str(REPO / "target" / "debug" / "vestige-mcp"))
+    ap.add_argument("--instances", type=int, default=1, help="number of simulated users to evaluate")
+    ap.add_argument("--sessions", type=int, default=10, help="max sessions ingested per user")
+    ap.add_argument("--top-k", type=int, default=5, help="retrieved memories per question (same for every arm)")
+    ap.add_argument("--recall-mode", default="lookup", choices=["lookup", "reason"])
+    ap.add_argument("--warmup", type=float, default=45.0, help="embedding warmup seconds before first tools/call")
+    ap.add_argument("--seed", type=int, default=1234)
+    ap.add_argument("--arms", default=",".join(ARMS))
+    ap.add_argument("--data-dir", default=None, help="VESTIGE_DATA_DIR (default: a temp dir under results/)")
+    ap.add_argument("--out", default=None, help="results JSON path")
+    ap.add_argument("--no-contradiction-probe", action="store_true")
+    ap.add_argument("--contradiction-limit", type=int, default=200,
+                    help="memories the contradictions tool analyses (tool max is 200)")
+    args = ap.parse_args()
+
+    selected = [a.strip() for a in args.arms.split(",") if a.strip()]
+    for a in selected:
+        if a not in ARMS:
+            sys.exit(f"unknown arm {a!r}; choose from {ARMS}")
+
+    dataset = pathlib.Path(args.dataset)
+    if not dataset.exists():
+        sys.exit(f"dataset not found at {dataset}\nRun: python3 {HERE / 'fetch_dataset.py'}")
+
+    lock = json.loads((HERE / "DATASET.lock.json").read_text())
+    started = time.time()
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime(started))
+    out_path = pathlib.Path(args.out) if args.out else HERE / "results" / f"memconflict-{stamp}.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    exact_command = f"python3 {pathlib.Path(__file__).relative_to(REPO)} " + " ".join(sys.argv[1:])
+    print("=" * 78)
+    print("MemConflict retrieval benchmark (Vestige)")
+    print("=" * 78)
+    print(f"command : {exact_command}")
+    print(f"dataset : {dataset.name} @ {lock['revision'][:12]}")
+    print(f"arms    : {', '.join(selected)}")
+    print(f"top_k   : {args.top_k}   sessions/user: {args.sessions}   users: {args.instances}")
+    print()
+
+    instances = load_instances(dataset, args.instances)
+    print(f"loaded {len(instances)} instance(s)")
+
+    client: Optional[VestigeMCP] = None
+    arms: Dict[str, Any] = {}
+    if "nomem" in selected:
+        arms["nomem"] = NoMemArm()
+    if "random" in selected:
+        arms["random"] = RandomArm(args.seed)
+    if "bm25" in selected:
+        arms["bm25"] = BM25Arm()
+
+    warmup_record: Dict[str, Any] = {}
+    try:
+        if "vestige" in selected:
+            data_dir = args.data_dir or str(HERE / "results" / f"datadir-{stamp}")
+            binary = pathlib.Path(args.binary)
+            if not binary.exists():
+                sys.exit(f"vestige-mcp binary not found at {binary}\nBuild it: cargo build -p vestige-mcp")
+            print(f"starting vestige-mcp: {binary}")
+            print(f"VESTIGE_DATA_DIR={data_dir}")
+            client = VestigeMCP(str(binary), data_dir, warmup_seconds=args.warmup)
+            client.start()
+            print(f"initialize + mandatory {args.warmup:.0f}s embedding warmup ...", flush=True)
+            client.initialize()
+            warmup_record = client.observed_warmup
+            print(f"server: {client.server_info}")
+            print(f"warmup: {warmup_record}")
+            arms["vestige"] = VestigeArm(
+                client, args.recall_mode, not args.no_contradiction_probe,
+                args.contradiction_limit,
+            )
+
+        records: Dict[str, List[Dict[str, Any]]] = {a: [] for a in selected}
+
+        for inst_no, inst in enumerate(instances, 1):
+            inst_id = inst.get("ID", f"inst{inst_no}")
+            print(f"\n[{inst_no}/{len(instances)}] instance {inst_id}")
+            for arm in arms.values():
+                arm.reset(inst_id)
+
+            sessions = list(iter_sessions(inst, args.sessions))
+            total_units = 0
+            asked = 0
+            for s in sessions:
+                units = session_units(s)
+                total_units += len(units)
+                for arm in arms.values():
+                    arm.add(units)
+
+                questions = s.get("Session_Questions") or []
+                for q in questions:
+                    qtext = q.get("question", "")
+                    for name, arm in arms.items():
+                        texts, extra = arm.retrieve(qtext, args.top_k)
+                        answer = reader(texts)
+                        metrics = judge_mod.score_question(q, answer)
+
+                        if (name == "vestige" and metrics["conflict_type"] == "static_conflict"
+                                and not args.no_contradiction_probe):
+                            probe = arm.probe_contradictions(qtext, arm.contradiction_limit)
+                            metrics["crs_struct"] = 1.0 if probe.get("found", 0) > 0 else 0.0
+                            extra = {**extra, "contradiction_probe": probe}
+
+                        records[name].append({
+                            "instance": inst_id,
+                            "session": s.get("Session_ID"),
+                            "question_id": q.get("question_id"),
+                            "n_retrieved": len(texts),
+                            "answer_chars": len(answer),
+                            "metrics": metrics,
+                            **({"extra": extra} if extra else {}),
+                        })
+                    asked += 1
+                print(f"  session {s.get('Session_ID'):>3}  units={len(units):>3}  "
+                      f"cum_units={total_units:>4}  questions={len(questions)}", flush=True)
+            print(f"  -> {asked} questions asked over {total_units} memory units")
+
+        summary = {arm: aggregate(recs) for arm, recs in records.items() if recs}
+
+    finally:
+        if client is not None:
+            client.close()
+
+    vestige_arm = arms.get("vestige")
+    results = {
+        "benchmark": "MemConflict",
+        "harness_version": "1.0",
+        "generated_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(started)),
+        "wall_seconds": round(time.time() - started, 1),
+        "exact_command": exact_command,
+        "reproduce": [
+            "cargo build -p vestige-mcp",
+            "python3 benchmarks/memconflict/fetch_dataset.py",
+            exact_command,
+        ],
+        "dataset": {
+            "source": lock["repo"],
+            "paper": lock["paper"],
+            "revision": lock["revision"],
+            "files": lock["files"],
+            "instances_evaluated": len(instances),
+            "sessions_per_instance_cap": args.sessions,
+        },
+        "vestige": {
+            **git_rev(REPO),
+            "server_info": client.server_info if client else None,
+            "binary": str(pathlib.Path(args.binary).resolve()),
+        },
+        "config": {
+            "arms": selected,
+            "top_k": args.top_k,
+            "recall_mode": args.recall_mode,
+            "seed": args.seed,
+            "contradiction_limit": args.contradiction_limit,
+            "reader": "deterministic concatenation of top-k retrieved memory texts",
+            "judge": "rule-based port of upstream Evaluation/eval_scoring.py (no LLM)",
+            "warmup": warmup_record,
+        },
+        "machine": machine_info(),
+        "results": summary,
+        "diagnostics": {
+            "vestige_ingest_errors": vestige_arm.ingest_errors if vestige_arm else None,
+            "vestige_retrieve_errors": vestige_arm.retrieve_errors if vestige_arm else None,
+            "vestige_retrieval_latency_s": (
+                {
+                    "n": len(vestige_arm.latencies),
+                    "mean": round(statistics.fmean(vestige_arm.latencies), 4),
+                    "median": round(statistics.median(vestige_arm.latencies), 4),
+                    "max": round(max(vestige_arm.latencies), 4),
+                }
+                if vestige_arm and vestige_arm.latencies else None
+            ),
+            "server_stderr_tail": client.stderr_tail(15) if client else None,
+        },
+        "caveats": [
+            "Absolute scores are NOT comparable to arXiv:2605.20926 Table 3: that table used an LLM judge (gpt-5.0-mini) and a different reader; this harness uses a deterministic rule-based judge and a non-LLM reader.",
+            "Only cross-arm differences within a single run are meaningful.",
+            "crs_struct uses Vestige's dedicated contradictions API and has no counterpart in the bm25/random/nomem arms; it is reported for vestige only and is NOT a head-to-head win over the controls.",
+            "recall(mode='contradictions') accepts no scope parameter, so the CRS-struct probe is NOT namespace-isolated and may scan memories from other simulated users in the same run.",
+            "Small subsets have wide error bars. Check per_conflict_type n before reading any difference as signal; macro_answer_accuracy weights a 3-question conflict type equally with an 88-question one.",
+            "Vestige merges near-duplicate ingested units into composite nodes (marked [MERGED]) even under batchMergePolicy=force_create, so its retrieval units are larger than the raw units the bm25/random arms index. Content is preserved, but check reader_chars_mean before comparing answer accuracy across arms.",
+            "CauseBench is retracted and must never be cited.",
+        ],
+        "per_question": {arm: recs for arm, recs in records.items()},
+    }
+    out_path.write_text(json.dumps(results, indent=2))
+
+    # ---- console report --------------------------------------------------
+    print("\n" + "=" * 78)
+    print("RESULTS  (higher is better; all arms share one reader and one judge)")
+    print("=" * 78)
+    # Per-type question counts are printed in the header so a small-n subset
+    # can never be mistaken for a solid result.
+    counts = {}
+    for arm in selected:
+        s_ = summary.get(arm)
+        if s_:
+            counts = {ct: v["n"] for ct, v in s_["per_conflict_type"].items()}
+            break
+    print(f"questions by conflict type: "
+          f"dynamic={counts.get('dynamic_conflict', 0)}  "
+          f"static={counts.get('static_conflict', 0)}  "
+          f"conditional={counts.get('conditional_conflict', 0)}")
+    small = [ct for ct, n in counts.items() if n < 10]
+    if small:
+        print(f"WARNING small sample (n<10): {', '.join(small)} "
+              f"-- macroAA weights these equally with large types; differences here are noise")
+    print()
+    hdr = f"{'arm':<9}{'n':>5}{'macroAA':>10}{'microAA':>10}{'dynAA':>8}{'UOCS':>8}{'statAA':>8}{'CRSlex':>8}{'condAA':>8}{'chars':>8}"
+    print(hdr)
+    print("-" * len(hdr))
+    for arm in selected:
+        s = summary.get(arm)
+        if not s:
+            continue
+        pt = s["per_conflict_type"]
+        def g(ct: str, key: str) -> str:
+            v = pt.get(ct, {}).get(key)
+            return f"{v:.4f}" if isinstance(v, float) else "  -  "
+        print(f"{arm:<9}{s['n_questions']:>5}"
+              f"{s['macro_answer_accuracy'] if s['macro_answer_accuracy'] is not None else 0:>10.4f}"
+              f"{s['micro_answer_accuracy'] if s['micro_answer_accuracy'] is not None else 0:>10.4f}"
+              f"{g('dynamic_conflict','answer_accuracy'):>8}"
+              f"{g('dynamic_conflict','uocs'):>8}"
+              f"{g('static_conflict','answer_accuracy'):>8}"
+              f"{g('static_conflict','crs_lex'):>8}"
+              f"{g('conditional_conflict','answer_accuracy'):>8}"
+              f"{s['reader_chars_mean']:>8.0f}")
+
+    live = [(a, summary[a]["reader_chars_mean"]) for a in selected
+            if a in summary and a != "nomem"]
+    if len(live) >= 2:
+        biggest = max(live, key=lambda x: x[1])
+        smallest = min(live, key=lambda x: x[1])
+        if smallest[1] > 0 and biggest[1] / smallest[1] >= 1.25:
+            print(f"\nCONFOUND WARNING: '{biggest[0]}' hands the judge {biggest[1]:.0f} chars/question "
+                  f"vs '{smallest[0]}' at {smallest[1]:.0f} "
+                  f"({biggest[1]/smallest[1]:.2f}x).")
+            print("  The judge awards partial credit for token overlap, so the larger blob has a")
+            print("  structural advantage unrelated to retrieval quality. Treat the AA gap between")
+            print("  these two arms as CONFOUNDED, not as a result.")
+
+    vs = summary.get("vestige", {}).get("per_conflict_type", {}).get("static_conflict", {})
+    if "crs_struct" in vs:
+        print(f"\nvestige CRS-struct (contradictions API, vestige-only): {vs['crs_struct']:.4f}")
+        print("  controls have no contradiction channel; this is a capability report, not a head-to-head win.")
+
+    bm = summary.get("bm25", {})
+    vm = summary.get("vestige", {})
+    for label, key in (("macro AA", "macro_answer_accuracy"), ("micro AA", "micro_answer_accuracy")):
+        b, v = bm.get(key), vm.get(key)
+        if b is None or v is None:
+            continue
+        delta = v - b
+        verdict = "BEATS" if delta > 0 else ("TIES" if abs(delta) < 1e-9 else "LOSES TO")
+        print(f"\nvestige {verdict} bm25 on {label} by {delta:+.4f}  (vestige {v:.4f} vs bm25 {b:.4f})")
+        if delta <= 0:
+            print("  A memory system that cannot beat naive BM25 has not earned its complexity.")
+    if small:
+        print("\n  NOTE: macro and micro disagree only because macroAA gives a small "
+              "conflict type\n        the same weight as a large one. Report both, or neither.")
+
+    print(f"\nresults written: {out_path}")
+    print(f"reproduce with : {exact_command}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/crates/vestige-core/Cargo.toml
+++ b/crates/vestige-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vestige-core"
-version = "2.4.1"
+version = "2.5.0"
 edition = "2024"
 rust-version = "1.91"
 authors = ["Vestige Team"]

--- a/crates/vestige-core/Cargo.toml
+++ b/crates/vestige-core/Cargo.toml
@@ -117,7 +117,7 @@ thiserror = "2"
 
 # Database - SQLite with FTS5 full-text search and JSON
 # Note: "bundled" or "bundled-sqlcipher" added via feature flags above
-rusqlite = { version = "0.38", features = ["chrono", "serde_json"] }
+rusqlite = { version = "0.40", features = ["chrono", "serde_json"] }
 
 # Platform-specific directories
 directories = "6"

--- a/crates/vestige-core/src/advanced/contradiction.rs
+++ b/crates/vestige-core/src/advanced/contradiction.rs
@@ -13,15 +13,26 @@
 //! two call sites is how each establishes that the two texts are *about the
 //! same subject*, which [`SubjectIdentity`] names explicitly.
 
-/// Explicit polarity flips: one text takes a negative stance, the other the
-/// paired positive one.
+/// Explicit polarity flips: one text takes the negative stance AND the other
+/// text takes the paired positive one. Both sides are required.
+///
+/// The pairing is load-bearing, not decorative. An earlier revision scanned
+/// for the asymmetric PRESENCE of the negative term alone, and on real memory
+/// content that misread ordinary prose as contradiction: measured against a
+/// 2,929-memory store, bare asymmetric presence fired on 64% of same-subject
+/// pairs (any long note saying "never", "wrong" or "removed" that its
+/// neighbour happened not to), and blocked reinforcement of 84% of
+/// near-identical pairs — recreating, at the shared detector, the exact
+/// defect the write path's pre-unification comment warned about. Requiring
+/// the paired positive term on the opposite side drops that to 6% while
+/// still detecting every measured correction shape.
 ///
 /// Bare triggers with no paired positive term ("not ", "instead of", "rather
-/// than") are deliberately absent: they match ordinary complementary phrasing
-/// and made benign additive notes ("Do not forget to configure X") read as
-/// corrections.
+/// than") are deliberately absent for the same reason, and ("don't", "do")
+/// was removed because "do" is too common a word for its presence to carry
+/// any signal.
 const NEGATION_PAIRS: &[(&str, &str)] = &[
-    ("don't", "do"),
+    ("don't use", "use"),
     ("never", "always"),
     ("avoid", "use"),
     ("wrong", "right"),
@@ -98,20 +109,31 @@ impl SubjectIdentity {
             Self::AlreadyEstablished => 0,
         }
     }
-
-    /// Shared substantive words required before a correction *marker* counts.
-    /// Higher than the base floor because these phrases appear in plenty of
-    /// memories that revise nothing.
-    fn min_shared_words_for_correction_signal(self) -> usize {
-        match self {
-            Self::FromTextOverlap => 6,
-            Self::AlreadyEstablished => 0,
-        }
-    }
 }
 
 fn substantive_words(lowered: &str) -> std::collections::HashSet<&str> {
     lowered.split_whitespace().filter(|w| w.len() > 3).collect()
+}
+
+/// Every word as a whole token, punctuation trimmed from the ends, SHORT WORDS
+/// KEPT. Used for the negation-pair test, where the paired positive term is
+/// often short ("use", "added") and substring matching would find it inside
+/// unrelated words ("because", "loaded").
+fn all_words(lowered: &str) -> std::collections::HashSet<&str> {
+    lowered
+        .split_whitespace()
+        .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()))
+        .filter(|w| !w.is_empty())
+        .collect()
+}
+
+/// Whole-word match for single terms, substring match for phrases.
+fn has_term(lowered: &str, words: &std::collections::HashSet<&str>, term: &str) -> bool {
+    if term.contains(' ') {
+        lowered.contains(term)
+    } else {
+        words.contains(term)
+    }
 }
 
 /// Tokens used for the divergence test.
@@ -147,10 +169,21 @@ pub fn appears_contradictory(a: &str, b: &str, identity: SubjectIdentity) -> boo
         return false;
     }
 
-    // Polarity flip: one side carries a negative stance the other lacks.
-    for (neg, _opp) in NEGATION_PAIRS {
-        if (a_lower.contains(neg) && !b_lower.contains(neg))
-            || (b_lower.contains(neg) && !a_lower.contains(neg))
+    // Polarity flip: one side carries the negative stance AND the other side
+    // carries the paired positive one, with neither side carrying both. When
+    // the negative term textually contains its positive ("don't use" contains
+    // "use"), the firing side necessarily carries the positive too, so that
+    // side is exempt from the both-terms exclusion.
+    let a_all = all_words(&a_lower);
+    let b_all = all_words(&b_lower);
+    for (neg, opp) in NEGATION_PAIRS {
+        let a_neg = has_term(&a_lower, &a_all, neg);
+        let b_neg = has_term(&b_lower, &b_all, neg);
+        let a_opp = has_term(&a_lower, &a_all, opp);
+        let b_opp = has_term(&b_lower, &b_all, opp);
+        let neg_carries_opp = neg.contains(opp);
+        if (a_neg && b_opp && !b_neg && (neg_carries_opp || !a_opp))
+            || (b_neg && a_opp && !a_neg && (neg_carries_opp || !b_opp))
         {
             return true;
         }
@@ -177,16 +210,16 @@ pub fn appears_contradictory(a: &str, b: &str, identity: SubjectIdentity) -> boo
     // are asserting different things in the same slot. If one IS a subset, it
     // is an elaboration ("works in Leeds" versus "works in Leeds and London")
     // and must not be flagged.
+    let a_tokens = divergence_tokens(&a_lower);
+    let b_tokens = divergence_tokens(&b_lower);
+    let shared = a_tokens.intersection(&b_tokens).count();
+    let union = a_tokens.union(&b_tokens).count();
+    let overlap = if union == 0 {
+        0.0
+    } else {
+        shared as f32 / union as f32
+    };
     {
-        let a_tokens = divergence_tokens(&a_lower);
-        let b_tokens = divergence_tokens(&b_lower);
-        let shared = a_tokens.intersection(&b_tokens).count();
-        let union = a_tokens.union(&b_tokens).count();
-        let overlap = if union == 0 {
-            0.0
-        } else {
-            shared as f32 / union as f32
-        };
         let a_only = a_tokens.difference(&b_tokens).count();
         let b_only = b_tokens.difference(&a_tokens).count();
         // Both sides distinctive => divergence, not elaboration.
@@ -200,8 +233,17 @@ pub fn appears_contradictory(a: &str, b: &str, identity: SubjectIdentity) -> boo
         }
     }
 
-    // Explicit revision marker, present in exactly one side.
-    if shared_words >= identity.min_shared_words_for_correction_signal() {
+    // Explicit revision marker, present in exactly one side — but only when
+    // token overlap proves the two texts share a subject. These phrases
+    // ("fixed", "actually", "no longer") occur constantly in memories that
+    // revise nothing; a shared-word COUNT was measured to be no defence on
+    // real content, because paragraph-length memories trivially share 6+
+    // words with any same-topic neighbour. The overlap RATIO is the defence:
+    // at >= 0.5 the marker adds zero false positives on a 2,929-memory store
+    // while still catching the short reworded correction ("Actually, the
+    // correct approach is Redis" against "The approach is Redis" sits at
+    // exactly 0.5).
+    if overlap >= 0.5 {
         for signal in CORRECTION_SIGNALS {
             if a_lower.contains(signal) != b_lower.contains(signal) {
                 return true;
@@ -318,6 +360,73 @@ mod tests {
             ),
             "retrieval path: too little shared vocabulary to risk a false positive"
         );
+    }
+
+    /// The write path must see the short phrasal correction the strict floor
+    /// cannot: "Don't use X" against "Use X" shares too few substantive words
+    /// for the retrieval gate, but the embedding gate has already established
+    /// subject identity at write time.
+    #[test]
+    fn short_phrasal_negation_is_seen_by_the_write_path() {
+        let pair = ("Don't use synchronous code", "Use synchronous code for simplicity");
+        for (x, y) in [pair, (pair.1, pair.0)] {
+            assert!(
+                appears_contradictory(x, y, SubjectIdentity::AlreadyEstablished),
+                "write path must catch the phrasal don't-use correction"
+            );
+        }
+    }
+
+    /// REGRESSION (v2.5.0 audit, measured on a 2,929-memory store): the bare
+    /// asymmetric presence of a negation word fired on 64% of same-subject
+    /// pairs and blocked 84% of near-identical reinforcements. A negation
+    /// word with no paired positive on the OTHER side is ordinary prose, not
+    /// a contradiction — even at zero shared-word floor.
+    #[test]
+    fn bare_negation_word_presence_is_not_a_contradiction() {
+        let cases = [
+            (
+                "The deploy pipeline never ran on weekends before the cron migration",
+                "The deploy pipeline runs from the cron scheduler after the migration",
+            ),
+            (
+                "We removed the legacy flag parser during the cleanup sprint",
+                "The config loader caches parsed flags between restarts",
+            ),
+            (
+                "That approach is wrong for streaming workloads at scale",
+                "Streaming workloads need backpressure handling at scale",
+            ),
+        ];
+        for (a, b) in cases {
+            assert!(
+                !appears_contradictory(a, b, SubjectIdentity::AlreadyEstablished),
+                "unpaired negation word must not read as contradiction: {a:?}"
+            );
+            assert!(!appears_contradictory(b, a, SubjectIdentity::AlreadyEstablished));
+        }
+    }
+
+    /// REGRESSION (v2.5.0 audit): "fixed", "actually", "no longer" appear
+    /// constantly in memories that revise nothing. A correction marker only
+    /// counts when token overlap proves the texts share a subject.
+    #[test]
+    fn correction_signals_need_subject_overlap() {
+        let a = "We fixed the flaky retry loop in the uploader last sprint";
+        let b = "The dashboard uses websockets for live updates with a retry loop";
+        assert!(!appears_contradictory(a, b, SubjectIdentity::AlreadyEstablished));
+        assert!(!appears_contradictory(b, a, SubjectIdentity::AlreadyEstablished));
+    }
+
+    /// Two instances of the same template with different values ("different
+    /// lead, same pitch") are DIFFERENT facts. The divergence branch fires so
+    /// the gate creates a second memory instead of reinforcing the first one
+    /// into a merged falsehood.
+    #[test]
+    fn template_instances_with_different_values_diverge() {
+        let a = "Premium lead — Alice Chen | Spotify. Route: linkedin outreach";
+        let b = "Premium lead — Dana Smith | Spotify. Route: linkedin outreach";
+        assert!(appears_contradictory(a, b, SubjectIdentity::AlreadyEstablished));
     }
 
     /// Unrelated memories that merely share a topic word must never pair up.

--- a/crates/vestige-core/src/advanced/contradiction.rs
+++ b/crates/vestige-core/src/advanced/contradiction.rs
@@ -1,0 +1,337 @@
+//! Shared contradiction detection for the write path and the retrieval path.
+//!
+//! This module exists because the two paths had *separate* implementations of
+//! the same concept and they drifted. The retrieval side (`cross_reference`)
+//! grew negation symmetry, antonym pairs and a divergence test; the write side
+//! (`prediction_error`) kept a single directional negation scan. The result was
+//! that `smart_ingest` could not see a correction that retrieval could see
+//! perfectly well — and the write path is the one that decides whether the
+//! dissenting memory is *stored at all*. Retrieval-side protection cannot
+//! protect a memory that was destroyed one stage earlier.
+//!
+//! There is now one implementation. The only legitimate difference between the
+//! two call sites is how each establishes that the two texts are *about the
+//! same subject*, which [`SubjectIdentity`] names explicitly.
+
+/// Explicit polarity flips: one text takes a negative stance, the other the
+/// paired positive one.
+///
+/// Bare triggers with no paired positive term ("not ", "instead of", "rather
+/// than") are deliberately absent: they match ordinary complementary phrasing
+/// and made benign additive notes ("Do not forget to configure X") read as
+/// corrections.
+const NEGATION_PAIRS: &[(&str, &str)] = &[
+    ("don't", "do"),
+    ("never", "always"),
+    ("avoid", "use"),
+    ("wrong", "right"),
+    ("incorrect", "correct"),
+    ("deprecated", "recommended"),
+    ("outdated", "current"),
+    ("removed", "added"),
+    ("disabled", "enabled"),
+];
+
+/// Opposite-direction claims with NO negation word in either text.
+///
+/// Requiring both sides to be present, in opposite texts, is a far stricter
+/// test than asymmetric presence, and it catches the class the negation scan
+/// structurally cannot: "prompt diversity HURTS accuracy" against "prompt
+/// diversity IMPROVES accuracy" contains no negation at all.
+const ANTONYM_PAIRS: &[(&str, &str)] = &[
+    ("hurts", "improves"),
+    ("hurt", "improved"),
+    ("degrades", "enhances"),
+    ("decreases", "increases"),
+    ("reduces", "raises"),
+    ("worse", "better"),
+    ("slower", "faster"),
+    ("fails", "succeeds"),
+    ("breaks", "fixes"),
+    ("unsafe", "safe"),
+    ("unstable", "stable"),
+    ("unsupported", "supported"),
+];
+
+/// Phrases that mark one text as explicitly revising the other.
+const CORRECTION_SIGNALS: &[&str] = &[
+    "actually",
+    "correction",
+    "update:",
+    "updated:",
+    "fixed",
+    "was wrong",
+    "changed to",
+    "now uses",
+    "replaced by",
+    "superseded",
+    "no longer",
+    "instead of",
+    "switched to",
+    "migrated to",
+];
+
+/// How the caller has established that two texts are about the same subject.
+///
+/// This is the *only* thing that legitimately differs between the write path
+/// and the retrieval path, so it is a parameter rather than a second copy of
+/// the detector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubjectIdentity {
+    /// Nothing is known beyond the text itself, so subject identity must be
+    /// inferred from shared substantive vocabulary. Used at retrieval time,
+    /// where a pair is drawn from thousands of unrelated memories and a false
+    /// positive is expensive.
+    FromTextOverlap,
+    /// The caller has already proven the two texts are about the same subject
+    /// by other means — at write time the candidate arrives from an embedding
+    /// similarity gate, so requiring lexical overlap *as well* would discard
+    /// exactly the corrections that are short and reworded.
+    AlreadyEstablished,
+}
+
+impl SubjectIdentity {
+    /// Shared substantive words required before any shape is considered.
+    fn min_shared_words(self) -> usize {
+        match self {
+            Self::FromTextOverlap => 4,
+            Self::AlreadyEstablished => 0,
+        }
+    }
+
+    /// Shared substantive words required before a correction *marker* counts.
+    /// Higher than the base floor because these phrases appear in plenty of
+    /// memories that revise nothing.
+    fn min_shared_words_for_correction_signal(self) -> usize {
+        match self {
+            Self::FromTextOverlap => 6,
+            Self::AlreadyEstablished => 0,
+        }
+    }
+}
+
+fn substantive_words(lowered: &str) -> std::collections::HashSet<&str> {
+    lowered.split_whitespace().filter(|w| w.len() > 3).collect()
+}
+
+/// Tokens used for the divergence test.
+///
+/// Unlike [`substantive_words`], short tokens containing a digit are kept. A
+/// version conflict ("PostgreSQL 14" against "PostgreSQL 16") puts the entire
+/// discriminating signal in a two-character token, so a length filter alone
+/// makes the two texts look identical and the conflict invisible.
+fn divergence_tokens(lowered: &str) -> std::collections::HashSet<String> {
+    lowered
+        .split_whitespace()
+        .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()).to_string())
+        .filter(|w| w.len() > 3 || w.chars().any(|c| c.is_ascii_digit()))
+        .filter(|w| !w.is_empty())
+        .collect()
+}
+
+/// Do these two texts appear to assert incompatible things?
+///
+/// Symmetric in `a` and `b`: a correction is a correction regardless of which
+/// side arrived first. The write path previously tested only "is the NEW text
+/// the negative one", so ingesting "Always use X" over a stored "Never use X"
+/// was read as agreement and *strengthened the claim being corrected*.
+pub fn appears_contradictory(a: &str, b: &str, identity: SubjectIdentity) -> bool {
+    let a_lower = a.to_lowercase();
+    let b_lower = b.to_lowercase();
+
+    let a_words = substantive_words(&a_lower);
+    let b_words = substantive_words(&b_lower);
+    let shared_words = a_words.intersection(&b_words).count();
+
+    if shared_words < identity.min_shared_words() {
+        return false;
+    }
+
+    // Polarity flip: one side carries a negative stance the other lacks.
+    for (neg, _opp) in NEGATION_PAIRS {
+        if (a_lower.contains(neg) && !b_lower.contains(neg))
+            || (b_lower.contains(neg) && !a_lower.contains(neg))
+        {
+            return true;
+        }
+    }
+
+    // Opposite directions, no negation in either.
+    for (neg, opp) in ANTONYM_PAIRS {
+        let a_neg = a_lower.contains(neg);
+        let b_neg = b_lower.contains(neg);
+        let a_opp = a_lower.contains(opp);
+        let b_opp = b_lower.contains(opp);
+        if (a_neg && b_opp && !b_neg && !a_opp) || (b_neg && a_opp && !a_neg && !b_opp) {
+            return true;
+        }
+    }
+
+    // Mutually exclusive VALUES for the same attribute — the most common
+    // real-world contradiction, which neither test above can see. "Priya holds
+    // a Bachelor degree" against "Priya holds a Master of Science degree"
+    // contains no negation and no antonym, yet both cannot be true.
+    //
+    // The distinguishing signal is DIVERGENCE versus ELABORATION. If the texts
+    // overlap heavily but NEITHER's vocabulary is a subset of the other's, they
+    // are asserting different things in the same slot. If one IS a subset, it
+    // is an elaboration ("works in Leeds" versus "works in Leeds and London")
+    // and must not be flagged.
+    {
+        let a_tokens = divergence_tokens(&a_lower);
+        let b_tokens = divergence_tokens(&b_lower);
+        let shared = a_tokens.intersection(&b_tokens).count();
+        let union = a_tokens.union(&b_tokens).count();
+        let overlap = if union == 0 {
+            0.0
+        } else {
+            shared as f32 / union as f32
+        };
+        let a_only = a_tokens.difference(&b_tokens).count();
+        let b_only = b_tokens.difference(&a_tokens).count();
+        // Both sides distinctive => divergence, not elaboration.
+        let diverges = a_only > 0 && b_only > 0;
+        // Keep the divergence small relative to the shared core: two memories
+        // that merely touch the same topic diverge in many terms, whereas a
+        // same-attribute conflict differs in only a few.
+        let small_divergence = (a_only + b_only) <= shared;
+        if overlap >= 0.6 && diverges && small_divergence {
+            return true;
+        }
+    }
+
+    // Explicit revision marker, present in exactly one side.
+    if shared_words >= identity.min_shared_words_for_correction_signal() {
+        for signal in CORRECTION_SIGNALS {
+            if a_lower.contains(signal) != b_lower.contains(signal) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The four shapes measured against the real binary, every one of which the
+    /// old write-path detector read as agreement and reinforced. Similarities
+    /// are the values observed through the live embedding service, all above
+    /// the 0.92 near-identical threshold, which is why they short-circuited.
+    #[test]
+    fn write_path_sees_every_measured_correction_shape() {
+        let established = SubjectIdentity::AlreadyEstablished;
+        let cases = [
+            (
+                "Always use prompt diversity for AIMO submissions",
+                "Never use prompt diversity for AIMO submissions",
+                "negation flip, positive arriving second (0.965)",
+            ),
+            (
+                "Prompt diversity improves accuracy at high temperature",
+                "Prompt diversity hurts accuracy at high temperature",
+                "antonym, no negation in either (0.962)",
+            ),
+            (
+                "The production database runs PostgreSQL 16",
+                "The production database runs PostgreSQL 14",
+                "mutually exclusive version values (0.940)",
+            ),
+            (
+                "Priya holds a Master degree in computer science from Leeds",
+                "Priya holds a Bachelor degree in computer science from Leeds",
+                "mutually exclusive attribute values (0.976)",
+            ),
+        ];
+        for (new, old, shape) in cases {
+            assert!(
+                appears_contradictory(new, old, established),
+                "must detect {shape}"
+            );
+            assert!(
+                appears_contradictory(old, new, established),
+                "must be symmetric: {shape}"
+            );
+        }
+    }
+
+    /// The reason the write-path detector was narrow in the first place. These
+    /// must keep NOT firing, or ingestion starts demoting correct memories.
+    #[test]
+    fn benign_additive_notes_are_not_corrections() {
+        let established = SubjectIdentity::AlreadyEstablished;
+        let cases = [
+            (
+                "Do not forget to configure the async runtime for the worker pool",
+                "Use the async runtime for the worker pool",
+            ),
+            (
+                "You cannot skip the migration step",
+                "Run the migration step before deploying",
+            ),
+            (
+                "Use async/await for performance",
+                "Use async patterns when needed",
+            ),
+            // Strict elaboration: one side's vocabulary is a subset of the other's.
+            (
+                "Vestige uses FSRS-6 with 21 parameters for scheduling",
+                "Vestige uses FSRS-6 for scheduling",
+            ),
+        ];
+        for (a, b) in cases {
+            assert!(
+                !appears_contradictory(a, b, established),
+                "additive/elaborating note must not read as a contradiction: {a:?}"
+            );
+            assert!(
+                !appears_contradictory(b, a, established),
+                "…in either order: {b:?}"
+            );
+        }
+    }
+
+    /// Retrieval draws pairs from thousands of unrelated memories, so it still
+    /// requires lexical evidence that the two are about the same subject. The
+    /// write path has that from the embedding gate and must not re-require it.
+    #[test]
+    fn subject_identity_gate_differs_between_the_two_call_sites() {
+        let short_correction = (
+            "Actually, the correct approach is Redis",
+            "The approach is Redis",
+        );
+        assert!(
+            appears_contradictory(
+                short_correction.0,
+                short_correction.1,
+                SubjectIdentity::AlreadyEstablished
+            ),
+            "write path: embedding already established subject identity"
+        );
+        assert!(
+            !appears_contradictory(
+                short_correction.0,
+                short_correction.1,
+                SubjectIdentity::FromTextOverlap
+            ),
+            "retrieval path: too little shared vocabulary to risk a false positive"
+        );
+    }
+
+    /// Unrelated memories that merely share a topic word must never pair up.
+    #[test]
+    fn unrelated_memories_are_not_contradictions() {
+        for identity in [
+            SubjectIdentity::FromTextOverlap,
+            SubjectIdentity::AlreadyEstablished,
+        ] {
+            assert!(!appears_contradictory(
+                "FSRS-6 upgrade research sources for the scheduler rewrite",
+                "The dashboard renders the memory graph with WebGPU particles",
+                identity
+            ));
+        }
+    }
+}

--- a/crates/vestige-core/src/advanced/mod.rs
+++ b/crates/vestige-core/src/advanced/mod.rs
@@ -19,6 +19,7 @@
 pub mod adaptive_embedding;
 pub mod chains;
 pub mod compression;
+pub mod contradiction;
 pub mod cross_project;
 pub mod dreams;
 pub mod importance;
@@ -36,6 +37,7 @@ pub use chains::{
     ReasoningChain,
 };
 pub use compression::{CompressedMemory, CompressionConfig, CompressionStats, MemoryCompressor};
+pub use contradiction::{SubjectIdentity, appears_contradictory};
 pub use cross_project::{
     ApplicableKnowledge, CrossProjectLearner, ProjectContext, UniversalPattern,
 };

--- a/crates/vestige-core/src/advanced/prediction_error.rs
+++ b/crates/vestige-core/src/advanced/prediction_error.rs
@@ -817,8 +817,12 @@ mod tests {
         candidate.embedding = vec![0.82, (1.0_f32 - 0.82_f32.powi(2)).sqrt()];
         candidate.content = "The approach is to retain the storage policy node.".to_string();
 
+        // A same-subject revision: enough token overlap for the correction
+        // marker to count, and a marker on exactly one side. (A marker with no
+        // shared subject no longer fires — that shape was measured to be a
+        // false positive on real content.)
         let decision = gate.evaluate(
-            "Actually, the correct approach is to write a dated session summary.",
+            "Actually, the correct approach is to retire the storage policy node.",
             &new_embedding,
             &[candidate],
         );
@@ -884,8 +888,8 @@ mod tests {
         ));
 
         assert!(gate.detect_contradiction(
-            "Actually, the correct approach is...",
-            "The approach is to..."
+            "Actually, the correct approach is Redis",
+            "The approach is Redis"
         ));
 
         assert!(!gate.detect_contradiction(

--- a/crates/vestige-core/src/advanced/prediction_error.rs
+++ b/crates/vestige-core/src/advanced/prediction_error.rs
@@ -577,59 +577,24 @@ impl PredictionErrorGate {
         }
     }
 
-    /// Detect if two pieces of content appear contradictory
+    /// Detect if two pieces of content appear contradictory.
     ///
-    /// Uses simple heuristics; could be enhanced with NLI model
+    /// Delegates to the shared detector in [`crate::advanced::contradiction`],
+    /// which the retrieval path uses as well. This function previously carried
+    /// its own, narrower copy: it fired only when the NEW content held the
+    /// negative term, had no antonym branch and no mutually-exclusive-value
+    /// branch. Ingesting "Always use X" over a stored "Never use X" therefore
+    /// read as agreement and *reinforced the claim being corrected* — measured
+    /// at 0.965 similarity against a 0.92 near-identical threshold, with the
+    /// same pair in the reverse order correctly kept. Subject identity is
+    /// already established here by the caller's embedding-similarity gate, so
+    /// no lexical-overlap floor is applied on top of it.
     fn detect_contradiction(&self, new_content: &str, old_content: &str) -> bool {
-        let new_lower = new_content.to_lowercase();
-        let old_lower = old_content.to_lowercase();
-
-        // Check for explicit negation patterns — a real polarity FLIP, not the
-        // mere presence of a negation word. We require the negation term in the
-        // new content AND its paired positive term in the old content (old: "use
-        // X"; new: "avoid X"). The previous logic fired whenever the new content
-        // merely contained a negation word the old one lacked, so ordinary
-        // additive notes ("Do not forget to configure X" — contains "not ") were
-        // misread as corrections and demoted a correct memory. Bare triggers with
-        // no paired positive term ("not ", "instead of", "rather than") are
-        // dropped for the same reason: they match complementary phrasing.
-        let negation_pairs = [
-            ("don't use", "use"),
-            ("don't", "do"),
-            ("never", "always"),
-            ("avoid", "use"),
-            ("wrong", "right"),
-            ("incorrect", "correct"),
-            ("deprecated", "recommended"),
-            ("outdated", "current"),
-        ];
-
-        for (neg, pos) in negation_pairs.iter() {
-            if new_lower.contains(neg) && old_lower.contains(pos) && !old_lower.contains(neg) {
-                return true;
-            }
-        }
-
-        // Check for correction phrases
-        let correction_phrases = [
-            "actually",
-            "correction",
-            "update:",
-            "fixed",
-            "was wrong",
-            "should be",
-            "better approach",
-            "improved",
-            "the right way",
-        ];
-
-        for phrase in correction_phrases.iter() {
-            if new_lower.contains(phrase) {
-                return true;
-            }
-        }
-
-        false
+        crate::advanced::contradiction::appears_contradictory(
+            new_content,
+            old_content,
+            crate::advanced::contradiction::SubjectIdentity::AlreadyEstablished,
+        )
     }
 
     /// Get statistics

--- a/crates/vestige-core/src/codebase/anchor.rs
+++ b/crates/vestige-core/src/codebase/anchor.rs
@@ -1,0 +1,1413 @@
+//! Self-verifying source anchors for code memory.
+//!
+//! # The defect this exists to fix
+//!
+//! A code memory used to anchor to source with nothing but a file path. The
+//! `codebase` MCP tool printed the caller's `files` array into the memory's
+//! markdown body (`crates/vestige-mcp/src/tools/codebase_unified.rs`) and the
+//! in-process [`crate::codebase::CodeEntity`] type carried
+//! `file_path: Option<PathBuf>` plus `line_number: Option<u32>`
+//! (`crates/vestige-core/src/codebase/types.rs`). Neither shape can answer the
+//! only question that matters at retrieval time:
+//!
+//! > Does the code this memory describes still exist, and does it still say
+//! > the same thing?
+//!
+//! Because nothing could answer it, a memory that had rotted was served with
+//! exactly the same confidence as one that was still true. That is the actual
+//! failure: not that a memory goes wrong, but that going wrong is invisible.
+//!
+//! # Why symbols alone are not enough
+//!
+//! Anchoring to a symbol instead of a line is strictly better - `state.py:552`
+//! rots within a week, `state.py::load_config` survives an insertion above it.
+//! But symbols get renamed, moved between files, and - worst of all - *kept*
+//! while their body is rewritten. A symbol-only anchor still cannot detect the
+//! dangerous case where the name resolves but the behavior the memory
+//! described is gone.
+//!
+//! So an anchor stores three layers, weakest to strongest:
+//!
+//! 1. `file_path` - where to look.
+//! 2. `symbol` - what to look for. Survives line drift.
+//! 3. `content_hash` - a blake3 hash of the *normalized anchored span*.
+//!    Survives renames and relocation, and is the only layer that can tell
+//!    "same name, different code" from "still true".
+//!
+//! Line numbers are still recorded, but only as a reporting hint. They are
+//! never the identity: a span that moved but hashes identically is
+//! [`AnchorStatus::Moved`], which is fresh, not stale.
+//!
+//! # Preservation, not deletion
+//!
+//! Verification never edits or deletes a memory. A stale anchor is *reported*
+//! as stale so the reader can see it; the memory itself is left exactly as the
+//! user wrote it. Deleting would hide the problem instead of fixing it.
+//!
+//! # Migration safety
+//!
+//! Every code memory written before this module existed has no anchor row at
+//! all, and anchors captured against an unreadable file have a `NULL`
+//! `content_hash`. Both degrade to [`AnchorStatus::Unverifiable`] - explicitly
+//! "we cannot check this", never "this is wrong". Telling someone their
+//! correct memory is stale would be a worse bug than the one being fixed.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::storage::{Result as StorageResult, SqliteMemoryStore};
+
+/// Domain separator so an anchor hash can never collide with another blake3
+/// use in the codebase (embeddings, connector content hashes, security
+/// fingerprints).
+const ANCHOR_HASH_DOMAIN: &str = "vestige:code-anchor:v1\n";
+
+/// Hex characters kept from the blake3 digest. 32 hex chars = 128 bits, far
+/// beyond what a collision between two source spans would ever need, and short
+/// enough to print in a tool response.
+const ANCHOR_HASH_LEN: usize = 32;
+
+/// Files larger than this are not hashed. A 4 MB minified bundle is not a
+/// meaningful anchor target, and reading one on every `get_context` would make
+/// retrieval slow enough that users disable verification - which is the same
+/// as not having it.
+pub const MAX_ANCHORED_FILE_BYTES: u64 = 2 * 1024 * 1024;
+
+/// Upper bound on how many lines one anchor may cover. A memory about "this
+/// whole 3000-line file" is not an anchor, it is a file reference, and hashing
+/// it would mark the memory stale on every unrelated edit.
+pub const MAX_SPAN_LINES: usize = 400;
+
+/// Cap on the relocation scan. Beyond this the file is large enough that a
+/// full window scan is not worth the retrieval latency; the anchor degrades to
+/// an honest [`AnchorStatus::Unverifiable`] rather than a guessed verdict.
+const MAX_RELOCATION_WINDOWS: usize = 50_000;
+
+/// How many lines after a definition line to keep looking for the opening
+/// brace of its block (a wrapped signature).
+const BRACE_LOOKAHEAD: usize = 6;
+
+/// Tokens that make a line containing `symbol` look like a *definition* rather
+/// than a call site. Deliberately cross-language: this module must work on a
+/// repository it has never seen without a parser for every language in it.
+const DEFINITION_KEYWORDS: &[&str] = &[
+    "fn",
+    "func",
+    "function",
+    "def",
+    "class",
+    "struct",
+    "enum",
+    "trait",
+    "impl",
+    "interface",
+    "type",
+    "const",
+    "static",
+    "let",
+    "var",
+    "val",
+    "public",
+    "private",
+    "protected",
+    "export",
+    "module",
+    "package",
+    "namespace",
+    "sub",
+    "procedure",
+];
+
+// ============================================================================
+// STATUS
+// ============================================================================
+
+/// The verdict of checking one anchor against the source tree as it is *now*.
+///
+/// The split that matters is `is_stale()`: only [`Drifted`](Self::Drifted) and
+/// [`Missing`](Self::Missing) accuse a memory of being wrong, and both require
+/// positive evidence (a stored hash that no longer matches). Everything else
+/// is either fresh or an honest admission that we cannot tell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnchorStatus {
+    /// The anchored span still hashes identically, at the recorded position.
+    Verified,
+    /// The anchored span still hashes identically but lives at a different
+    /// line now. The memory is *fresh*; only the coordinate moved. This is the
+    /// case a line-number anchor would have reported as a false alarm.
+    Moved,
+    /// The anchor target is still findable (the file exists, and the symbol
+    /// name is still present) but the anchored content no longer matches. The
+    /// memory may describe code that has since changed underneath it. This is
+    /// the dangerous case the user found by hand.
+    Drifted,
+    /// The anchored content is gone and the symbol cannot be found - or the
+    /// file itself no longer exists.
+    Missing,
+    /// We cannot check this anchor: it predates content hashing, no span could
+    /// be captured, or the file is unreadable/too large today. Never an
+    /// accusation - an unverifiable memory may be perfectly correct.
+    Unverifiable,
+}
+
+impl AnchorStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Verified => "verified",
+            Self::Moved => "moved",
+            Self::Drifted => "drifted",
+            Self::Missing => "missing",
+            Self::Unverifiable => "unverifiable",
+        }
+    }
+
+    /// Parse the persisted string form. Deliberately not `FromStr`: this is
+    /// a storage detail, not a user-facing parse.
+    pub fn parse_status(raw: &str) -> Option<Self> {
+        match raw {
+            "verified" => Some(Self::Verified),
+            "moved" => Some(Self::Moved),
+            "drifted" => Some(Self::Drifted),
+            "missing" => Some(Self::Missing),
+            "unverifiable" => Some(Self::Unverifiable),
+            _ => None,
+        }
+    }
+
+    /// Does this verdict mean the memory should be shown with a staleness
+    /// warning? Only positive evidence of divergence counts. "We could not
+    /// check" is never staleness.
+    pub fn is_stale(&self) -> bool {
+        matches!(self, Self::Drifted | Self::Missing)
+    }
+
+    /// Does this verdict confirm the memory still matches the code?
+    pub fn is_fresh(&self) -> bool {
+        matches!(self, Self::Verified | Self::Moved)
+    }
+}
+
+// ============================================================================
+// ANCHOR
+// ============================================================================
+
+/// What the caller asked to anchor to, before it is resolved against the tree.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AnchorDraft {
+    /// Repository-relative (or absolute) path to the anchored file.
+    pub file_path: String,
+    /// Symbol the memory is about, if any.
+    pub symbol: Option<String>,
+    /// Optional caller-supplied kind ("fn", "class", ...), for display only.
+    pub symbol_kind: Option<String>,
+    /// Explicit 1-based start line, when the caller knows the exact span.
+    pub start_line: Option<u32>,
+    /// Explicit 1-based inclusive end line.
+    pub end_line: Option<u32>,
+}
+
+impl AnchorDraft {
+    pub fn new(file_path: impl Into<String>) -> Self {
+        Self {
+            file_path: file_path.into(),
+            ..Default::default()
+        }
+    }
+
+    pub fn with_symbol(mut self, symbol: impl Into<String>) -> Self {
+        self.symbol = Some(symbol.into());
+        self
+    }
+
+    pub fn with_lines(mut self, start: u32, end: u32) -> Self {
+        self.start_line = Some(start);
+        self.end_line = Some(end);
+        self
+    }
+
+    /// Parse the compact `path#symbol` / `path:start-end` forms accepted by the
+    /// `codebase` tool's `files` array, so existing callers get real anchoring
+    /// without a schema change on their side. A plain path stays a plain path.
+    pub fn parse(raw: &str) -> Self {
+        let raw = raw.trim();
+        if let Some((path, symbol)) = raw.split_once('#')
+            && !path.is_empty()
+            && !symbol.is_empty()
+        {
+            return Self::new(path).with_symbol(symbol);
+        }
+        // `path:12-40` and `path:12`. Guarded so a Windows drive letter
+        // (`C:\src\x.rs`) and a plain path with a colon are left alone.
+        if let Some((path, tail)) = raw.rsplit_once(':')
+            && path.len() > 1
+            && !tail.is_empty()
+        {
+            let (start_raw, end_raw) = match tail.split_once('-') {
+                Some((a, b)) => (a, b),
+                None => (tail, tail),
+            };
+            if let (Ok(start), Ok(end)) = (start_raw.parse::<u32>(), end_raw.parse::<u32>())
+                && start >= 1
+                && end >= start
+            {
+                return Self::new(path).with_lines(start, end);
+            }
+        }
+        Self::new(raw)
+    }
+}
+
+/// A persisted, self-verifying anchor from one memory to one place in source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodeAnchor {
+    pub id: String,
+    pub node_id: String,
+    pub file_path: String,
+    pub symbol: Option<String>,
+    pub symbol_kind: Option<String>,
+    /// Capture-time first line of the anchored span (1-based). Reporting hint
+    /// only - a shifted line never makes a memory stale on its own.
+    pub start_line: Option<u32>,
+    /// Capture-time last line of the anchored span (1-based, inclusive).
+    pub end_line: Option<u32>,
+    /// Number of normalized lines the hash covers.
+    pub span_lines: Option<u32>,
+    /// blake3 of the normalized span. `None` means unverifiable, not stale.
+    pub content_hash: Option<String>,
+    pub captured_at: DateTime<Utc>,
+    pub last_verified_at: Option<DateTime<Utc>>,
+    pub last_status: Option<AnchorStatus>,
+}
+
+impl CodeAnchor {
+    /// Is there enough stored information to actually re-check this anchor?
+    pub fn is_verifiable(&self) -> bool {
+        self.content_hash.is_some() && self.span_lines.is_some_and(|n| n > 0)
+    }
+}
+
+/// The result of checking one anchor against the tree as it is now.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnchorVerification {
+    pub anchor_id: String,
+    pub node_id: String,
+    pub file_path: String,
+    pub symbol: Option<String>,
+    pub status: AnchorStatus,
+    /// Human-readable reason, written to be read by whoever is about to trust
+    /// (or not trust) the memory.
+    pub detail: String,
+    pub recorded_line: Option<u32>,
+    /// Where the anchored content or symbol lives now, when we found it.
+    pub current_line: Option<u32>,
+    pub checked_at: DateTime<Utc>,
+}
+
+impl AnchorVerification {
+    pub fn is_stale(&self) -> bool {
+        self.status.is_stale()
+    }
+}
+
+// ============================================================================
+// NORMALIZATION AND HASHING
+// ============================================================================
+
+/// Normalize source for hashing: drop blank lines, trim each remaining line,
+/// and keep its original 1-based line number.
+///
+/// Whitespace insensitivity is deliberate. Re-indenting a function (moving it
+/// into a new module, changing a nesting level, a formatter pass) does not
+/// change what the code says, and marking a correct memory stale for it would
+/// train users to ignore the warning - which would destroy the feature's only
+/// value. Any token change still changes the hash.
+fn normalize(source: &str) -> Vec<(u32, &str)> {
+    source
+        .lines()
+        .enumerate()
+        .filter_map(|(idx, line)| {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(((idx + 1) as u32, trimmed))
+            }
+        })
+        .collect()
+}
+
+/// Hash an already-normalized run of lines.
+fn hash_normalized(lines: &[&str]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(ANCHOR_HASH_DOMAIN.as_bytes());
+    for line in lines {
+        hasher.update(line.as_bytes());
+        hasher.update(b"\n");
+    }
+    hasher.finalize().to_hex()[..ANCHOR_HASH_LEN].to_string()
+}
+
+/// Hash the normalized form of an arbitrary source span. Public so a caller can
+/// hash a snippet it already holds without going through the filesystem.
+pub fn hash_span(source: &str) -> Option<(String, u32, u32, u32)> {
+    let normalized = normalize(source);
+    if normalized.is_empty() {
+        return None;
+    }
+    let texts: Vec<&str> = normalized.iter().map(|(_, t)| *t).collect();
+    let first = normalized.first().expect("non-empty").0;
+    let last = normalized.last().expect("non-empty").0;
+    Some((
+        hash_normalized(&texts),
+        first,
+        last,
+        normalized.len() as u32,
+    ))
+}
+
+// ============================================================================
+// SYMBOL LOCATION
+// ============================================================================
+
+fn is_ident_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '$'
+}
+
+/// Whole-word (identifier-boundary) search for `needle` in `haystack`.
+fn contains_symbol(haystack: &str, needle: &str) -> bool {
+    symbol_offsets(haystack, needle).next().is_some()
+}
+
+fn symbol_offsets<'a>(haystack: &'a str, needle: &'a str) -> impl Iterator<Item = usize> + 'a {
+    haystack.match_indices(needle).filter_map(move |(at, _)| {
+        let before_ok = haystack[..at]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !is_ident_char(c));
+        let after_ok = haystack[at + needle.len()..]
+            .chars()
+            .next()
+            .is_none_or(|c| !is_ident_char(c));
+        if before_ok && after_ok {
+            Some(at)
+        } else {
+            None
+        }
+    })
+}
+
+/// Statement keywords that make `<word> symbol(` a *call*, not a definition.
+/// Without these, `return load_config(path)` reads as a C-style signature.
+const CALL_LEAD_KEYWORDS: &[&str] = &[
+    "return", "await", "yield", "if", "while", "for", "new", "throw", "raise", "assert", "print",
+    "else", "elif", "match", "case", "in", "and", "or", "not",
+];
+
+/// Does this line look like it *defines* `symbol`, as opposed to calling it?
+///
+/// Language-agnostic heuristic, in preference order:
+///
+/// 1. A definition keyword appears as a word before the symbol
+///    (`pub fn load_config`, `def load_config`, `export class Foo`). This one
+///    rule covers Rust, Python, TS/JS, Go, Java, C#, Ruby and PHP.
+/// 2. Binding shapes: `symbol =`, `symbol:`, `symbol<`, `symbol {`, as long as
+///    the symbol is not being read off something else (`obj.symbol`).
+/// 3. `symbol(` only when the prefix looks like a return type or modifier
+///    (`int load_config(`), never a bare call statement (`load_config(x);`)
+///    and never a call in expression position (`x = load_config(`,
+///    `return load_config(`).
+fn line_defines_symbol(line: &str, symbol: &str) -> bool {
+    let Some(at) = symbol_offsets(line, symbol).next() else {
+        return false;
+    };
+    let prefix = &line[..at];
+    // A definition keyword only defines *this* symbol when no binding operator
+    // sits between them: in `let c = load_config(path)` the `let` defines `c`,
+    // and `load_config` is a call on the right-hand side.
+    if !prefix.contains('=')
+        && prefix
+            .split(|c: char| !is_ident_char(c))
+            .any(|word| DEFINITION_KEYWORDS.contains(&word))
+    {
+        return true;
+    }
+
+    let prefix_trimmed = prefix.trim();
+    // `obj.symbol(...)`, `(symbol)`, `[symbol]` are never definitions.
+    if prefix_trimmed.starts_with(['.', '(', '[']) || prefix_trimmed.ends_with('.') {
+        return false;
+    }
+
+    let rest = line[at + symbol.len()..].trim_start();
+    if rest.starts_with(['=', ':', '<', '{']) {
+        return true;
+    }
+    if !rest.starts_with('(') {
+        return false;
+    }
+
+    // C-style `int load_config(...)`: the prefix must look like a type or
+    // modifier, i.e. end in an identifier and not be a statement keyword.
+    let last_word = prefix_trimmed
+        .rsplit(|c: char| !is_ident_char(c))
+        .next()
+        .unwrap_or("");
+    !last_word.is_empty()
+        && prefix_trimmed.ends_with(is_ident_char)
+        && !CALL_LEAD_KEYWORDS.contains(&last_word)
+}
+
+/// First line (1-based) that looks like the definition of `symbol`.
+pub fn find_symbol_definition(source: &str, symbol: &str) -> Option<u32> {
+    source
+        .lines()
+        .enumerate()
+        .find(|(_, line)| line_defines_symbol(line, symbol))
+        .map(|(idx, _)| (idx + 1) as u32)
+}
+
+/// First line (1-based) mentioning `symbol` at all. Used only to distinguish
+/// [`AnchorStatus::Drifted`] ("the name is still here, the code changed") from
+/// [`AnchorStatus::Missing`] ("it is gone").
+pub fn find_symbol_anywhere(source: &str, symbol: &str) -> Option<u32> {
+    source
+        .lines()
+        .enumerate()
+        .find(|(_, line)| contains_symbol(line, symbol))
+        .map(|(idx, _)| (idx + 1) as u32)
+}
+
+fn indent_width(line: &str) -> usize {
+    line.len() - line.trim_start().len()
+}
+
+/// Find the last line (1-based, inclusive) of the block that starts at
+/// `def_line`. Braces first (Rust/TS/Go/Java/C/...), indentation second
+/// (Python/Ruby/YAML), and the definition line alone as the floor.
+fn block_end(lines: &[&str], def_line: u32) -> u32 {
+    let def_idx = (def_line as usize).saturating_sub(1);
+    if def_idx >= lines.len() {
+        return def_line;
+    }
+    let hard_cap = (def_idx + MAX_SPAN_LINES).min(lines.len());
+
+    // Brace matching. Start counting from the first line at/after the
+    // definition that contains an opening brace, to tolerate a wrapped
+    // signature spilling the `{` onto a later line.
+    let brace_start =
+        (def_idx..(def_idx + BRACE_LOOKAHEAD).min(lines.len())).find(|i| lines[*i].contains('{'));
+    if let Some(start) = brace_start {
+        let mut depth: i32 = 0;
+        for (offset, line) in lines[start..hard_cap].iter().enumerate() {
+            depth += line.matches('{').count() as i32;
+            depth -= line.matches('}').count() as i32;
+            if depth <= 0 && line.contains('}') {
+                return (start + offset + 1) as u32;
+            }
+        }
+        // Unbalanced within the cap: fall through to the indentation rule
+        // rather than swallowing the rest of the file.
+    }
+
+    // Indentation rule.
+    let base = indent_width(lines[def_idx]);
+    let mut end = def_idx;
+    for (offset, line) in lines[def_idx + 1..hard_cap].iter().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if indent_width(line) > base {
+            end = def_idx + 1 + offset;
+        } else {
+            break;
+        }
+    }
+    (end + 1) as u32
+}
+
+/// Resolve a draft to a concrete 1-based inclusive line span in `source`.
+/// `None` means "path-only anchor": nothing to hash, so it will degrade to
+/// [`AnchorStatus::Unverifiable`] rather than pretend.
+fn resolve_span(source: &str, draft: &AnchorDraft) -> Option<(u32, u32)> {
+    let lines: Vec<&str> = source.lines().collect();
+    if lines.is_empty() {
+        return None;
+    }
+    let total = lines.len() as u32;
+
+    if let Some(start) = draft.start_line {
+        if start < 1 || start > total {
+            return None;
+        }
+        let end = draft
+            .end_line
+            .unwrap_or(start)
+            .clamp(start, total)
+            .min(start + MAX_SPAN_LINES as u32 - 1);
+        return Some((start, end));
+    }
+
+    let symbol = draft.symbol.as_deref()?;
+    let def_line = find_symbol_definition(source, symbol)?;
+    Some((def_line, block_end(&lines, def_line)))
+}
+
+// ============================================================================
+// CAPTURE
+// ============================================================================
+
+/// Resolve an anchor path against the repository root. Absolute paths are used
+/// as given (a user may legitimately record one).
+fn resolve_path(repo_root: &Path, file_path: &str) -> PathBuf {
+    let candidate = Path::new(file_path);
+    if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        repo_root.join(candidate)
+    }
+}
+
+/// Read a file for anchoring, refusing anything too large or not valid UTF-8.
+fn read_anchor_file(path: &Path) -> Result<String, String> {
+    let meta = std::fs::metadata(path).map_err(|e| format!("cannot stat file: {e}"))?;
+    if !meta.is_file() {
+        return Err("path is not a regular file".to_string());
+    }
+    if meta.len() > MAX_ANCHORED_FILE_BYTES {
+        return Err(format!(
+            "file is {} bytes, above the {} byte anchoring limit",
+            meta.len(),
+            MAX_ANCHORED_FILE_BYTES
+        ));
+    }
+    std::fs::read_to_string(path).map_err(|e| format!("cannot read file as UTF-8 text: {e}"))
+}
+
+/// Turn a draft into a stored anchor by hashing what it points at *today*.
+///
+/// This never fails: an unreadable file, a missing symbol, or a path-only
+/// draft all produce an anchor with `content_hash = None`. Recording an
+/// unverifiable anchor is strictly better than recording nothing, because the
+/// path and symbol are still preserved and the retrieval path can say
+/// truthfully that it could not check them.
+pub fn capture_anchor(node_id: &str, repo_root: &Path, draft: &AnchorDraft) -> CodeAnchor {
+    let now = Utc::now();
+    let mut anchor = CodeAnchor {
+        id: format!("anchor-{}", Uuid::new_v4()),
+        node_id: node_id.to_string(),
+        file_path: draft.file_path.clone(),
+        symbol: draft.symbol.clone(),
+        symbol_kind: draft.symbol_kind.clone(),
+        start_line: draft.start_line,
+        end_line: draft.end_line,
+        span_lines: None,
+        content_hash: None,
+        captured_at: now,
+        last_verified_at: None,
+        last_status: None,
+    };
+
+    let path = resolve_path(repo_root, &draft.file_path);
+    let Ok(source) = read_anchor_file(&path) else {
+        return anchor;
+    };
+    let Some((start, end)) = resolve_span(&source, draft) else {
+        return anchor;
+    };
+
+    let lines: Vec<&str> = source.lines().collect();
+    let slice = lines[(start as usize - 1)..(end as usize).min(lines.len())].join("\n");
+    if let Some((hash, first_rel, last_rel, count)) = hash_span(&slice) {
+        // `hash_span` numbers lines within the slice; translate back to the
+        // file's own coordinates so the recorded position is meaningful.
+        anchor.start_line = Some(start + first_rel - 1);
+        anchor.end_line = Some(start + last_rel - 1);
+        anchor.span_lines = Some(count);
+        anchor.content_hash = Some(hash);
+    }
+    anchor
+}
+
+// ============================================================================
+// VERIFY
+// ============================================================================
+
+fn verdict(
+    anchor: &CodeAnchor,
+    status: AnchorStatus,
+    detail: impl Into<String>,
+    current_line: Option<u32>,
+) -> AnchorVerification {
+    AnchorVerification {
+        anchor_id: anchor.id.clone(),
+        node_id: anchor.node_id.clone(),
+        file_path: anchor.file_path.clone(),
+        symbol: anchor.symbol.clone(),
+        status,
+        detail: detail.into(),
+        recorded_line: anchor.start_line,
+        current_line,
+        checked_at: Utc::now(),
+    }
+}
+
+/// Check one anchor against the working tree as it is now.
+///
+/// The ordering of the checks is the whole contract:
+///
+/// * A missing file is [`Missing`](AnchorStatus::Missing) even for an
+///   unverifiable anchor - "the file you named is gone" is a fact we *can*
+///   establish without a hash.
+/// * A present file with no stored hash is
+///   [`Unverifiable`](AnchorStatus::Unverifiable). This is the legacy path and
+///   it must never say "stale".
+/// * A stored hash that still matches somewhere is fresh, wherever it moved to.
+/// * Only a stored hash that no longer matches anywhere can accuse the memory.
+pub fn verify_anchor(anchor: &CodeAnchor, repo_root: &Path) -> AnchorVerification {
+    let path = resolve_path(repo_root, &anchor.file_path);
+
+    if !path.exists() {
+        return verdict(
+            anchor,
+            AnchorStatus::Missing,
+            format!(
+                "`{}` no longer exists under {}. Whatever this memory says about it cannot be checked against anything.",
+                anchor.file_path,
+                repo_root.display()
+            ),
+            None,
+        );
+    }
+
+    let source = match read_anchor_file(&path) {
+        Ok(text) => text,
+        Err(reason) => {
+            return verdict(
+                anchor,
+                AnchorStatus::Unverifiable,
+                format!("`{}` exists but {reason}.", anchor.file_path),
+                None,
+            );
+        }
+    };
+
+    if !anchor.is_verifiable() {
+        let symbol_note = match anchor.symbol.as_deref() {
+            Some(symbol) => match find_symbol_definition(&source, symbol)
+                .or_else(|| find_symbol_anywhere(&source, symbol))
+            {
+                Some(line) => format!(" `{symbol}` is currently at line {line}."),
+                None => format!(" `{symbol}` is not present in the file today."),
+            },
+            None => String::new(),
+        };
+        return verdict(
+            anchor,
+            AnchorStatus::Unverifiable,
+            format!(
+                "No content hash was recorded for this anchor, so it cannot be verified - it may well be correct.{symbol_note} Re-save this memory with an anchored symbol or line span to make it self-checking."
+            ),
+            None,
+        );
+    }
+
+    let expected = anchor.content_hash.as_deref().expect("is_verifiable");
+    let span_len = anchor.span_lines.expect("is_verifiable") as usize;
+    let normalized = normalize(&source);
+
+    if normalized.len() >= span_len {
+        let texts: Vec<&str> = normalized.iter().map(|(_, t)| *t).collect();
+
+        // Fast path: check the recorded position first. Unchanged files, which
+        // are the overwhelming majority on any single retrieval, cost one hash.
+        if let Some(recorded) = anchor.start_line
+            && let Some(idx) = normalized.iter().position(|(line, _)| *line == recorded)
+            && idx + span_len <= texts.len()
+            && hash_normalized(&texts[idx..idx + span_len]) == expected
+        {
+            return verdict(
+                anchor,
+                AnchorStatus::Verified,
+                format!(
+                    "Anchored content at `{}`{} still matches byte for byte.",
+                    anchor.file_path,
+                    anchor
+                        .symbol
+                        .as_deref()
+                        .map(|s| format!(" ({s})"))
+                        .unwrap_or_default()
+                ),
+                Some(recorded),
+            );
+        }
+
+        // Relocation scan: the same content may simply have moved.
+        let windows = texts.len() - span_len + 1;
+        if windows <= MAX_RELOCATION_WINDOWS {
+            for start in 0..windows {
+                if hash_normalized(&texts[start..start + span_len]) == expected {
+                    let now_at = normalized[start].0;
+                    return verdict(
+                        anchor,
+                        AnchorStatus::Moved,
+                        format!(
+                            "Anchored content is unchanged but moved from line {} to line {now_at} in `{}`. The memory is still accurate; only the coordinate shifted.",
+                            anchor
+                                .start_line
+                                .map(|l| l.to_string())
+                                .unwrap_or_else(|| "?".into()),
+                            anchor.file_path
+                        ),
+                        Some(now_at),
+                    );
+                }
+            }
+        } else {
+            return verdict(
+                anchor,
+                AnchorStatus::Unverifiable,
+                format!(
+                    "`{}` has {} candidate positions, above the {MAX_RELOCATION_WINDOWS} scan limit, so relocation could not be ruled out. Not treating this as stale.",
+                    anchor.file_path, windows
+                ),
+                None,
+            );
+        }
+    }
+
+    // The recorded content is not in this file any more. Is the symbol?
+    if let Some(symbol) = anchor.symbol.as_deref()
+        && let Some(line) = find_symbol_definition(&source, symbol)
+            .or_else(|| find_symbol_anywhere(&source, symbol))
+    {
+        return verdict(
+            anchor,
+            AnchorStatus::Drifted,
+            format!(
+                "`{symbol}` still exists in `{}` (now around line {line}) but its code has changed since this memory was written. Re-read the source before trusting this memory.",
+                anchor.file_path
+            ),
+            Some(line),
+        );
+    }
+
+    verdict(
+        anchor,
+        AnchorStatus::Missing,
+        format!(
+            "The code this memory was anchored to is no longer present in `{}`{}. Treat the memory as historical until it is re-checked.",
+            anchor.file_path,
+            anchor
+                .symbol
+                .as_deref()
+                .map(|s| format!(", and `{s}` is gone too"))
+                .unwrap_or_default()
+        ),
+        None,
+    )
+}
+
+// ============================================================================
+// STORAGE
+// ============================================================================
+
+const ANCHOR_COLUMNS: &str = "id, node_id, file_path, symbol, symbol_kind, start_line, end_line, \
+     span_lines, content_hash, captured_at, last_verified_at, last_status";
+
+fn row_to_anchor(row: &rusqlite::Row<'_>) -> rusqlite::Result<CodeAnchor> {
+    let captured_at: String = row.get(9)?;
+    let last_verified_at: Option<String> = row.get(10)?;
+    let last_status: Option<String> = row.get(11)?;
+    Ok(CodeAnchor {
+        id: row.get(0)?,
+        node_id: row.get(1)?,
+        file_path: row.get(2)?,
+        symbol: row.get(3)?,
+        symbol_kind: row.get(4)?,
+        start_line: row.get::<_, Option<i64>>(5)?.map(|v| v as u32),
+        end_line: row.get::<_, Option<i64>>(6)?.map(|v| v as u32),
+        span_lines: row.get::<_, Option<i64>>(7)?.map(|v| v as u32),
+        content_hash: row.get(8)?,
+        captured_at: DateTime::parse_from_rfc3339(&captured_at)
+            .map(|dt| dt.with_timezone(&Utc))
+            .unwrap_or_else(|_| Utc::now()),
+        last_verified_at: last_verified_at
+            .and_then(|raw| DateTime::parse_from_rfc3339(&raw).ok())
+            .map(|dt| dt.with_timezone(&Utc)),
+        last_status: last_status.as_deref().and_then(AnchorStatus::parse_status),
+    })
+}
+
+impl SqliteMemoryStore {
+    /// Persist source anchors for a memory.
+    ///
+    /// The `node_id` foreign key cascades on delete, so purging a memory takes
+    /// its anchored paths and hashes with it - no orphaned record of what file
+    /// a purged memory pointed at.
+    pub fn record_code_anchors(&self, anchors: &[CodeAnchor]) -> StorageResult<usize> {
+        if anchors.is_empty() {
+            return Ok(0);
+        }
+        let conn = self.writer.lock().unwrap();
+        let mut written = 0;
+        for anchor in anchors {
+            conn.execute(
+                &format!(
+                    "INSERT OR REPLACE INTO code_memory_anchors ({ANCHOR_COLUMNS}) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)"
+                ),
+                params![
+                    anchor.id,
+                    anchor.node_id,
+                    anchor.file_path,
+                    anchor.symbol,
+                    anchor.symbol_kind,
+                    anchor.start_line.map(|v| v as i64),
+                    anchor.end_line.map(|v| v as i64),
+                    anchor.span_lines.map(|v| v as i64),
+                    anchor.content_hash,
+                    anchor.captured_at.to_rfc3339(),
+                    anchor.last_verified_at.map(|dt| dt.to_rfc3339()),
+                    anchor.last_status.map(|s| s.as_str().to_string()),
+                ],
+            )?;
+            written += 1;
+        }
+        Ok(written)
+    }
+
+    /// Load every anchor recorded for one memory.
+    pub fn code_anchors_for_node(&self, node_id: &str) -> StorageResult<Vec<CodeAnchor>> {
+        let conn = self.reader.lock().unwrap();
+        let mut stmt = conn.prepare(&format!(
+            "SELECT {ANCHOR_COLUMNS} FROM code_memory_anchors WHERE node_id = ?1 \
+             ORDER BY file_path, start_line"
+        ))?;
+        let rows = stmt.query_map(params![node_id], row_to_anchor)?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
+    /// Load anchors for a batch of memories, keyed by node id. Memories with no
+    /// anchors are simply absent from the map - that absence is what the
+    /// retrieval path reports as "unverifiable", never as "stale".
+    pub fn code_anchors_for_nodes(
+        &self,
+        node_ids: &[String],
+    ) -> StorageResult<HashMap<String, Vec<CodeAnchor>>> {
+        let mut out: HashMap<String, Vec<CodeAnchor>> = HashMap::new();
+        if node_ids.is_empty() {
+            return Ok(out);
+        }
+        let conn = self.reader.lock().unwrap();
+        let placeholders = vec!["?"; node_ids.len()].join(", ");
+        let mut stmt = conn.prepare(&format!(
+            "SELECT {ANCHOR_COLUMNS} FROM code_memory_anchors \
+             WHERE node_id IN ({placeholders}) ORDER BY file_path, start_line"
+        ))?;
+        let rows = stmt.query_map(rusqlite::params_from_iter(node_ids.iter()), row_to_anchor)?;
+        for anchor in rows {
+            let anchor = anchor?;
+            out.entry(anchor.node_id.clone()).or_default().push(anchor);
+        }
+        Ok(out)
+    }
+
+    /// Cache the latest verdict for an anchor. Purely informational: the
+    /// retrieval path always re-verifies against the live tree, because a
+    /// cached "verified" is exactly the kind of confident lie this feature
+    /// exists to remove.
+    pub fn record_anchor_verification(
+        &self,
+        anchor_id: &str,
+        status: AnchorStatus,
+        checked_at: DateTime<Utc>,
+    ) -> StorageResult<()> {
+        let conn = self.writer.lock().unwrap();
+        conn.execute(
+            "UPDATE code_memory_anchors SET last_verified_at = ?1, last_status = ?2 WHERE id = ?3",
+            params![checked_at.to_rfc3339(), status.as_str(), anchor_id],
+        )?;
+        Ok(())
+    }
+
+    /// Remove every anchor for a memory. Not needed for `purge_node` (the
+    /// foreign key cascades) but useful when a memory is re-anchored.
+    pub fn delete_code_anchors_for_node(&self, node_id: &str) -> StorageResult<usize> {
+        let conn = self.writer.lock().unwrap();
+        Ok(conn.execute(
+            "DELETE FROM code_memory_anchors WHERE node_id = ?1",
+            params![node_id],
+        )?)
+    }
+}
+
+// ============================================================================
+// TESTS
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    const RUST_SOURCE: &str = "\
+use std::fs;
+
+pub fn load_config(path: &str) -> Config {
+    let raw = fs::read_to_string(path).unwrap();
+    parse(&raw)
+}
+
+pub fn other() -> u8 {
+    7
+}
+";
+
+    fn write_file(dir: &Path, name: &str, body: &str) -> PathBuf {
+        let path = dir.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        path
+    }
+
+    fn draft_symbol(file: &str, symbol: &str) -> AnchorDraft {
+        AnchorDraft::new(file).with_symbol(symbol)
+    }
+
+    // --- normalization + hashing ------------------------------------------
+
+    #[test]
+    fn reindenting_and_blank_lines_do_not_change_the_hash() {
+        let a = "fn f() {\n    let x = 1;\n}\n";
+        let b = "\n        fn f() {\n\n                let x = 1;\n        }\n\n";
+        assert_eq!(hash_span(a).unwrap().0, hash_span(b).unwrap().0);
+    }
+
+    #[test]
+    fn changing_a_single_token_changes_the_hash() {
+        let a = "fn f() {\n    let x = 1;\n}\n";
+        let b = "fn f() {\n    let x = 2;\n}\n";
+        assert_ne!(hash_span(a).unwrap().0, hash_span(b).unwrap().0);
+    }
+
+    // --- symbol location ---------------------------------------------------
+
+    #[test]
+    fn definition_line_is_preferred_over_a_call_site() {
+        let src = "load_config(\"a\");\npub fn load_config(p: &str) {}\n";
+        assert_eq!(find_symbol_definition(src, "load_config"), Some(2));
+    }
+
+    #[test]
+    fn call_sites_in_every_common_shape_are_not_definitions() {
+        for call in [
+            "load_config(\"a\");",
+            "    let c = load_config(path);",
+            "    return load_config(path);",
+            "    self.load_config(path)",
+            "    obj.load_config()",
+            "    await load_config(path)",
+        ] {
+            assert!(
+                !line_defines_symbol(call, "load_config"),
+                "must not read as a definition: {call}"
+            );
+        }
+    }
+
+    #[test]
+    fn definitions_in_several_languages_are_recognized() {
+        for def in [
+            "pub fn load_config(p: &str) {",       // Rust
+            "def load_config(path):",              // Python
+            "export function load_config(p) {",    // TS/JS
+            "func load_config(p string) error {",  // Go
+            "  public void load_config(String p)", // Java
+            "int load_config(char *p) {",          // C
+            "const load_config = (p) => {",        // JS binding
+            "  load_config: (p) => {",             // object literal member
+        ] {
+            assert!(
+                line_defines_symbol(def, "load_config"),
+                "must read as a definition: {def}"
+            );
+        }
+    }
+
+    #[test]
+    fn symbol_search_respects_identifier_boundaries() {
+        let src = "fn load_config_v2() {}\n";
+        assert_eq!(find_symbol_anywhere(src, "load_config"), None);
+        assert_eq!(find_symbol_anywhere(src, "load_config_v2"), Some(1));
+    }
+
+    #[test]
+    fn python_style_blocks_end_by_indentation() {
+        let src = "def a():\n    x = 1\n    y = 2\n\ndef b():\n    pass\n";
+        let lines: Vec<&str> = src.lines().collect();
+        let def = find_symbol_definition(src, "a").unwrap();
+        assert_eq!(def, 1);
+        assert_eq!(block_end(&lines, def), 3);
+    }
+
+    #[test]
+    fn brace_blocks_end_at_the_matching_close() {
+        let lines: Vec<&str> = RUST_SOURCE.lines().collect();
+        let def = find_symbol_definition(RUST_SOURCE, "load_config").unwrap();
+        assert_eq!(def, 3);
+        assert_eq!(block_end(&lines, def), 6);
+    }
+
+    // --- draft parsing -----------------------------------------------------
+
+    #[test]
+    fn compact_anchor_forms_parse() {
+        assert_eq!(
+            AnchorDraft::parse("src/state.py#load_config"),
+            AnchorDraft::new("src/state.py").with_symbol("load_config")
+        );
+        assert_eq!(
+            AnchorDraft::parse("src/state.py:552-560"),
+            AnchorDraft::new("src/state.py").with_lines(552, 560)
+        );
+        assert_eq!(
+            AnchorDraft::parse("src/state.py:552"),
+            AnchorDraft::new("src/state.py").with_lines(552, 552)
+        );
+        // A plain path stays a plain path: existing callers are unchanged.
+        assert_eq!(
+            AnchorDraft::parse("src/state.py"),
+            AnchorDraft::new("src/state.py")
+        );
+    }
+
+    // --- the four verdicts -------------------------------------------------
+
+    #[test]
+    fn unchanged_code_verifies() {
+        let dir = tempfile::tempdir().unwrap();
+        write_file(dir.path(), "src/lib.rs", RUST_SOURCE);
+        let anchor = capture_anchor("n1", dir.path(), &draft_symbol("src/lib.rs", "load_config"));
+        assert!(anchor.is_verifiable(), "symbol anchor must capture a hash");
+
+        let v = verify_anchor(&anchor, dir.path());
+        assert_eq!(v.status, AnchorStatus::Verified, "{}", v.detail);
+        assert!(!v.is_stale());
+    }
+
+    /// The exact false alarm a line-number anchor produces: code shifted down,
+    /// nothing about it changed. This must NOT be reported as stale.
+    #[test]
+    fn shifted_but_identical_code_is_moved_not_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        write_file(dir.path(), "src/lib.rs", RUST_SOURCE);
+        let anchor = capture_anchor("n1", dir.path(), &draft_symbol("src/lib.rs", "load_config"));
+        assert_eq!(anchor.start_line, Some(3));
+
+        let shifted = format!("// a new header\n// and another\n\n{RUST_SOURCE}");
+        write_file(dir.path(), "src/lib.rs", &shifted);
+
+        let v = verify_anchor(&anchor, dir.path());
+        assert_eq!(v.status, AnchorStatus::Moved, "{}", v.detail);
+        assert!(!v.is_stale(), "a pure relocation must never read as stale");
+        assert_eq!(v.current_line, Some(6));
+    }
+
+    /// The dangerous case the user found by hand: the symbol still resolves,
+    /// so every symbol-only scheme says "fine", but the body it described is
+    /// gone.
+    #[test]
+    fn same_symbol_with_a_rewritten_body_is_drifted() {
+        let dir = tempfile::tempdir().unwrap();
+        write_file(dir.path(), "src/lib.rs", RUST_SOURCE);
+        let anchor = capture_anchor("n1", dir.path(), &draft_symbol("src/lib.rs", "load_config"));
+
+        let rewritten = RUST_SOURCE.replace(
+            "    let raw = fs::read_to_string(path).unwrap();\n    parse(&raw)",
+            "    Config::from_env()",
+        );
+        assert_ne!(rewritten, RUST_SOURCE);
+        write_file(dir.path(), "src/lib.rs", &rewritten);
+
+        let v = verify_anchor(&anchor, dir.path());
+        assert_eq!(v.status, AnchorStatus::Drifted, "{}", v.detail);
+        assert!(v.is_stale(), "a rewritten body must be visibly stale");
+        assert!(v.detail.contains("load_config"));
+    }
+
+    #[test]
+    fn a_deleted_symbol_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        write_file(dir.path(), "src/lib.rs", RUST_SOURCE);
+        let anchor = capture_anchor("n1", dir.path(), &draft_symbol("src/lib.rs", "load_config"));
+
+        write_file(
+            dir.path(),
+            "src/lib.rs",
+            "pub fn other() -> u8 {\n    7\n}\n",
+        );
+        let v = verify_anchor(&anchor, dir.path());
+        assert_eq!(v.status, AnchorStatus::Missing, "{}", v.detail);
+        assert!(v.is_stale());
+    }
+
+    #[test]
+    fn a_deleted_file_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_file(dir.path(), "src/lib.rs", RUST_SOURCE);
+        let anchor = capture_anchor("n1", dir.path(), &draft_symbol("src/lib.rs", "load_config"));
+        std::fs::remove_file(&path).unwrap();
+
+        let v = verify_anchor(&anchor, dir.path());
+        assert_eq!(v.status, AnchorStatus::Missing);
+        assert!(v.detail.contains("no longer exists"));
+    }
+
+    // --- migration safety: legacy anchors must NEVER read as stale ---------
+
+    /// The single most important guarantee in this module. A memory saved
+    /// before content hashing existed has no hash. Even when the file it names
+    /// has been rewritten beyond recognition, it must degrade to
+    /// "unverifiable" - telling a user their correct memory is wrong would be
+    /// a worse bug than the one being fixed.
+    #[test]
+    fn a_legacy_anchor_without_a_hash_is_unverifiable_never_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        write_file(dir.path(), "src/lib.rs", RUST_SOURCE);
+
+        let legacy = CodeAnchor {
+            id: "anchor-legacy".to_string(),
+            node_id: "n1".to_string(),
+            file_path: "src/lib.rs".to_string(),
+            symbol: Some("load_config".to_string()),
+            symbol_kind: None,
+            start_line: Some(552), // a rotted line number from the old shape
+            end_line: None,
+            span_lines: None,
+            content_hash: None, // the legacy shape: nothing to check against
+            captured_at: Utc::now(),
+            last_verified_at: None,
+            last_status: None,
+        };
+
+        let v = verify_anchor(&legacy, dir.path());
+        assert_eq!(v.status, AnchorStatus::Unverifiable);
+        assert!(
+            !v.is_stale(),
+            "a hashless anchor must never accuse a memory"
+        );
+
+        // ...and it stays unverifiable even after a total rewrite.
+        write_file(
+            dir.path(),
+            "src/lib.rs",
+            "totally different\ncontent here\n",
+        );
+        let v = verify_anchor(&legacy, dir.path());
+        assert_eq!(v.status, AnchorStatus::Unverifiable);
+        assert!(!v.is_stale());
+    }
+
+    /// A path-only anchor (no symbol, no line span) captures no hash, so it is
+    /// unverifiable while the file exists - but a deleted file is still a fact
+    /// we can state.
+    #[test]
+    fn a_path_only_anchor_is_unverifiable_until_the_file_disappears() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_file(dir.path(), "src/lib.rs", RUST_SOURCE);
+        let anchor = capture_anchor("n1", dir.path(), &AnchorDraft::new("src/lib.rs"));
+        assert!(!anchor.is_verifiable());
+        assert_eq!(
+            verify_anchor(&anchor, dir.path()).status,
+            AnchorStatus::Unverifiable
+        );
+
+        std::fs::remove_file(&path).unwrap();
+        assert_eq!(
+            verify_anchor(&anchor, dir.path()).status,
+            AnchorStatus::Missing
+        );
+    }
+
+    #[test]
+    fn an_unresolvable_symbol_captures_no_hash_and_stays_unverifiable() {
+        let dir = tempfile::tempdir().unwrap();
+        write_file(dir.path(), "src/lib.rs", RUST_SOURCE);
+        let anchor = capture_anchor("n1", dir.path(), &draft_symbol("src/lib.rs", "nope"));
+        assert!(anchor.content_hash.is_none());
+        let v = verify_anchor(&anchor, dir.path());
+        assert_eq!(v.status, AnchorStatus::Unverifiable);
+        assert!(!v.is_stale());
+    }
+
+    #[test]
+    fn explicit_line_spans_are_hashed_and_survive_relocation() {
+        let dir = tempfile::tempdir().unwrap();
+        write_file(dir.path(), "src/lib.rs", RUST_SOURCE);
+        let anchor = capture_anchor(
+            "n1",
+            dir.path(),
+            &AnchorDraft::new("src/lib.rs").with_lines(3, 6),
+        );
+        assert!(anchor.is_verifiable());
+        assert_eq!(
+            verify_anchor(&anchor, dir.path()).status,
+            AnchorStatus::Verified
+        );
+
+        write_file(
+            dir.path(),
+            "src/lib.rs",
+            &format!("// header\n{RUST_SOURCE}"),
+        );
+        assert_eq!(
+            verify_anchor(&anchor, dir.path()).status,
+            AnchorStatus::Moved
+        );
+    }
+
+    // --- persistence -------------------------------------------------------
+
+    fn store() -> (SqliteMemoryStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteMemoryStore::new(Some(dir.path().join("t.db"))).unwrap();
+        (store, dir)
+    }
+
+    fn ingest(store: &SqliteMemoryStore, content: &str) -> String {
+        store
+            .ingest(crate::IngestInput {
+                content: content.to_string(),
+                node_type: "pattern".to_string(),
+                source: None,
+                sentiment_score: 0.0,
+                sentiment_magnitude: 0.0,
+                tags: vec!["codebase".to_string()],
+                valid_from: None,
+                valid_until: None,
+                validity_inferred: false,
+                source_envelope: None,
+            })
+            .unwrap()
+            .id
+    }
+
+    #[test]
+    fn anchors_round_trip_through_storage() {
+        let (store, _dir) = store();
+        let repo = tempfile::tempdir().unwrap();
+        write_file(repo.path(), "src/lib.rs", RUST_SOURCE);
+        let node_id = ingest(&store, "load_config reads the file eagerly");
+
+        let anchor = capture_anchor(
+            &node_id,
+            repo.path(),
+            &draft_symbol("src/lib.rs", "load_config"),
+        );
+        assert_eq!(
+            store
+                .record_code_anchors(std::slice::from_ref(&anchor))
+                .unwrap(),
+            1
+        );
+
+        let loaded = store.code_anchors_for_node(&node_id).unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0], anchor);
+
+        let batch = store
+            .code_anchors_for_nodes(std::slice::from_ref(&node_id))
+            .unwrap();
+        assert_eq!(batch.get(&node_id).map(|v| v.len()), Some(1));
+    }
+
+    #[test]
+    fn a_memory_with_no_anchor_row_is_simply_absent() {
+        let (store, _dir) = store();
+        let node_id = ingest(&store, "a legacy code memory with no anchors");
+        assert!(store.code_anchors_for_node(&node_id).unwrap().is_empty());
+        assert!(store.code_anchors_for_nodes(&[node_id]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn verification_status_is_cached_but_not_trusted() {
+        let (store, _dir) = store();
+        let repo = tempfile::tempdir().unwrap();
+        write_file(repo.path(), "src/lib.rs", RUST_SOURCE);
+        let node_id = ingest(&store, "anchored memory");
+        let anchor = capture_anchor(
+            &node_id,
+            repo.path(),
+            &draft_symbol("src/lib.rs", "load_config"),
+        );
+        store
+            .record_code_anchors(std::slice::from_ref(&anchor))
+            .unwrap();
+
+        store
+            .record_anchor_verification(&anchor.id, AnchorStatus::Drifted, Utc::now())
+            .unwrap();
+        let loaded = store.code_anchors_for_node(&node_id).unwrap();
+        assert_eq!(loaded[0].last_status, Some(AnchorStatus::Drifted));
+        assert!(loaded[0].last_verified_at.is_some());
+
+        // The live check still wins over the cached verdict.
+        assert_eq!(
+            verify_anchor(&loaded[0], repo.path()).status,
+            AnchorStatus::Verified
+        );
+    }
+
+    #[test]
+    fn purging_a_memory_takes_its_anchors_with_it() {
+        let (store, _dir) = store();
+        let repo = tempfile::tempdir().unwrap();
+        write_file(repo.path(), "src/lib.rs", RUST_SOURCE);
+        let node_id = ingest(&store, "anchored memory that will be purged");
+        let anchor = capture_anchor(
+            &node_id,
+            repo.path(),
+            &draft_symbol("src/lib.rs", "load_config"),
+        );
+        store.record_code_anchors(&[anchor]).unwrap();
+        assert_eq!(store.code_anchors_for_node(&node_id).unwrap().len(), 1);
+
+        store.purge_node(&node_id, Some("test")).unwrap();
+        assert!(
+            store.code_anchors_for_node(&node_id).unwrap().is_empty(),
+            "purge must not leave the anchored file path behind"
+        );
+    }
+
+    #[test]
+    fn deleting_anchors_for_a_node_is_explicit_and_scoped() {
+        let (store, _dir) = store();
+        let repo = tempfile::tempdir().unwrap();
+        write_file(repo.path(), "src/lib.rs", RUST_SOURCE);
+        let keep = ingest(&store, "keep me");
+        let drop = ingest(&store, "re-anchor me");
+        store
+            .record_code_anchors(&[
+                capture_anchor(
+                    &keep,
+                    repo.path(),
+                    &draft_symbol("src/lib.rs", "load_config"),
+                ),
+                capture_anchor(&drop, repo.path(), &draft_symbol("src/lib.rs", "other")),
+            ])
+            .unwrap();
+
+        assert_eq!(store.delete_code_anchors_for_node(&drop).unwrap(), 1);
+        assert!(store.code_anchors_for_node(&drop).unwrap().is_empty());
+        assert_eq!(store.code_anchors_for_node(&keep).unwrap().len(), 1);
+    }
+}

--- a/crates/vestige-core/src/codebase/mod.rs
+++ b/crates/vestige-core/src/codebase/mod.rs
@@ -68,6 +68,7 @@
 //! # }
 //! ```
 
+pub mod anchor;
 pub mod context;
 pub mod git;
 pub mod patterns;
@@ -76,6 +77,10 @@ pub mod types;
 pub mod watcher;
 
 // Re-export main types
+pub use anchor::{
+    AnchorDraft, AnchorStatus, AnchorVerification, CodeAnchor, MAX_ANCHORED_FILE_BYTES,
+    MAX_SPAN_LINES, capture_anchor, find_symbol_definition, hash_span, verify_anchor,
+};
 pub use context::{ContextCapture, FileContext, Framework, ProjectType, WorkingContext};
 pub use git::{CommitInfo, GitAnalyzer, GitContext, HistoryAnalysis};
 pub use patterns::{PatternDetector, PatternMatch, PatternSuggestion};

--- a/crates/vestige-core/src/storage/migrations.rs
+++ b/crates/vestige-core/src/storage/migrations.rs
@@ -154,6 +154,11 @@ pub const MIGRATIONS: &[Migration] = &[
         description: "FTS5: replace the ascii tokenizer with unicode61 so typographic punctuation and accents stop swallowing adjacent words",
         up: MIGRATION_V30_UP,
     },
+    Migration {
+        version: 31,
+        description: "Self-verifying code memory: content-hashed source anchors so a code memory can be checked against the code it describes instead of being served with false confidence",
+        up: MIGRATION_V31_UP,
+    },
 ];
 
 /// A database migration
@@ -1997,6 +2002,58 @@ END;
 UPDATE schema_version SET version = 30, applied_at = datetime('now');
 "#;
 
+/// V31: Self-verifying code memory anchors.
+///
+/// A code memory used to anchor to source with nothing but a file path printed
+/// into its markdown body. Nothing could tell whether the code it describes
+/// still existed, so a rotted memory was retrieved with exactly the same
+/// confidence as a correct one.
+///
+/// This table stores, per memory, the information needed to *re-check* the
+/// claim later: the path, the optional symbol name, the capture-time line span
+/// (a hint for reporting only, never the identity), and a content hash of the
+/// normalized anchored span. Verification re-hashes the file today and compares.
+///
+/// Migration safety is the whole point of the nullable columns:
+///
+/// * Every existing code memory simply has **no row here**. Absence means
+///   "unverifiable", never "stale" - an old, correct memory must not be
+///   accused of being wrong.
+/// * `content_hash`, `span_lines`, `symbol`, `start_line` and `end_line` are
+///   all nullable. A path-only anchor (no readable span at capture time) is
+///   still recorded, and still degrades to "unverifiable" rather than "stale".
+/// * `node_id` cascades on delete so `purge_node`'s
+///   `DELETE FROM knowledge_nodes` (sqlite.rs) removes the anchored path and
+///   hash with the memory. `PRAGMA foreign_keys = ON` is asserted on both
+///   connections at open time, so the cascade is enforced, not decorative.
+const MIGRATION_V31_UP: &str = r#"
+CREATE TABLE IF NOT EXISTS code_memory_anchors (
+    id                TEXT PRIMARY KEY,
+    node_id           TEXT NOT NULL REFERENCES knowledge_nodes(id) ON DELETE CASCADE,
+    -- Repository-relative path as recorded by the caller.
+    file_path         TEXT NOT NULL,
+    -- Symbol the memory is about. NULL for a path-only anchor.
+    symbol            TEXT,
+    symbol_kind       TEXT,
+    -- Capture-time position. Advisory only: relocation is decided by content
+    -- hash, so a shifted line number never by itself marks a memory stale.
+    start_line        INTEGER,
+    end_line          INTEGER,
+    -- Number of normalized (blank-stripped, trimmed) lines the hash covers.
+    span_lines        INTEGER,
+    -- blake3 of the normalized anchored span. NULL => unverifiable, not stale.
+    content_hash      TEXT,
+    captured_at       TEXT NOT NULL,
+    last_verified_at  TEXT,
+    last_status       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_code_anchors_node ON code_memory_anchors(node_id);
+CREATE INDEX IF NOT EXISTS idx_code_anchors_path ON code_memory_anchors(file_path);
+
+UPDATE schema_version SET version = 31, applied_at = datetime('now');
+"#;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2499,8 +2556,8 @@ mod tests {
 
         let applied = apply_migrations(&conn).expect("V20+ apply on a V19 database");
         assert_eq!(
-            applied, 11,
-            "V20 through V30 should apply on a V19 database"
+            applied, 12,
+            "V20 through V31 should apply on a V19 database"
         );
         assert_eq!(
             get_current_version(&conn).expect("version"),
@@ -2513,16 +2570,16 @@ mod tests {
         );
     }
 
-    /// Fresh database: all migrations apply cleanly through V30 and the cursor
+    /// Fresh database: all migrations apply cleanly through V31 and the cursor
     /// table exists and is empty (nothing to clear, no error).
     #[test]
     fn v20_applies_cleanly_on_a_fresh_database() {
         let conn = rusqlite::Connection::open_in_memory().expect("open in-memory");
-        apply_migrations(&conn).expect("fresh migrations succeed through V30");
+        apply_migrations(&conn).expect("fresh migrations succeed through V31");
         assert_eq!(
             get_current_version(&conn).expect("version"),
-            30,
-            "latest migration must be V30"
+            31,
+            "latest migration must be V31"
         );
         assert_eq!(cursor_row_count(&conn), 0);
     }
@@ -2573,11 +2630,11 @@ mod tests {
         )
         .expect("seed legacy vector");
 
-        apply_migrations(&conn).expect("apply V28 through V30");
+        apply_migrations(&conn).expect("apply V28 through V31");
         assert_eq!(
             get_current_version(&conn).expect("version"),
-            30,
-            "V28 profile migration is followed by the V29 scope index and the V30 FTS rebuild"
+            31,
+            "V28 profile migration is followed by the V29 scope index, the V30 FTS rebuild, and the V31 code anchors"
         );
         let copied: i64 = conn
             .query_row(
@@ -2777,7 +2834,7 @@ mod tests {
         )
         .expect("mark V25 fixture current");
 
-        assert_eq!(apply_migrations(&conn).expect("apply V26 through V30"), 5);
+        assert_eq!(apply_migrations(&conn).expect("apply V26 through V31"), 6);
         let columns: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM pragma_table_info('receipt_envelopes')

--- a/crates/vestige-core/src/storage/sqlite.rs
+++ b/crates/vestige-core/src/storage/sqlite.rs
@@ -4805,6 +4805,7 @@ impl SqliteMemoryStore {
             )
             .optional()?;
 
+        #[cfg(feature = "embeddings")]
         let active_embedding_model = active_profile.as_ref().and_then(|active| {
             reader
                 .query_row(
@@ -4815,7 +4816,7 @@ impl SqliteMemoryStore {
                 .ok()
         });
         #[cfg(not(feature = "embeddings"))]
-        let active_embedding_model = None;
+        let active_embedding_model: Option<String> = None;
 
         #[cfg(feature = "embeddings")]
         let (nodes_with_active_embeddings, nodes_with_mismatched_embeddings) = {
@@ -6526,8 +6527,6 @@ impl SqliteMemoryStore {
         }
     }
 
-    /// Semantic search returning scores
-    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
     /// Bring the in-process vector index up to date with vectors written by OTHER
     /// processes since this one last looked.
     ///
@@ -6636,6 +6635,8 @@ impl SqliteMemoryStore {
         added
     }
 
+    /// Semantic search returning scores
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
     fn semantic_search_raw(&self, query: &str, limit: i32) -> Result<Vec<(String, f32)>> {
         if !self.vector_search_available() {
             return Ok(vec![]);

--- a/crates/vestige-core/src/storage/sqlite.rs
+++ b/crates/vestige-core/src/storage/sqlite.rs
@@ -1014,8 +1014,10 @@ impl SqliteMemoryStore {
             let ok = match cascade_ok.get(&table) {
                 Some(v) => *v,
                 None => {
-                    let mut stmt = tx.prepare(&format!("PRAGMA foreign_key_list(\"{}\")",
-                        table.replace('"', "\"\"")))?;
+                    let mut stmt = tx.prepare(&format!(
+                        "PRAGMA foreign_key_list(\"{}\")",
+                        table.replace('"', "\"\"")
+                    ))?;
                     let rows = stmt.query_map([], |row| {
                         Ok((row.get::<_, String>(2)?, row.get::<_, String>(6)?))
                     })?;
@@ -1037,7 +1039,10 @@ impl SqliteMemoryStore {
                 continue;
             }
             let n = tx.execute(
-                &format!("DELETE FROM \"{}\" WHERE rowid = ?1", table.replace('"', "\"\"")),
+                &format!(
+                    "DELETE FROM \"{}\" WHERE rowid = ?1",
+                    table.replace('"', "\"\"")
+                ),
                 params![rowid],
             )?;
             repaired += n as u64;
@@ -19198,7 +19203,9 @@ mod tests {
             })
             .unwrap();
 
-        let results = storage.concrete_search_filtered(needle, 10, None, None).unwrap();
+        let results = storage
+            .concrete_search_filtered(needle, 10, None, None)
+            .unwrap();
         assert!(!results.is_empty(), "exact lookup must return something");
         assert_eq!(
             results[0].node.id, target.id,
@@ -21118,7 +21125,17 @@ mod tests {
         assert!(!node.is_currently_valid());
 
         // Reverse order on a fresh store: the newer dated claim arriving
-        // second keeps the normal gate behavior (reinforce, no auto-close).
+        // second must NOT auto-close anything. That is this half's subject.
+        //
+        // It previously also asserted `reinforce`, which encoded a defect. The
+        // pair here ("version is 4.2" against "version is 5.0") is a mutually
+        // exclusive VALUE conflict, the same shape as PostgreSQL 14 -> 16, and
+        // the write-path detector could not see it: short numeric tokens were
+        // dropped by the substantive-word length filter, so the two texts
+        // looked identical and the gate reinforced on similarity alone. The
+        // effect was that telling Vestige "the version is now 5.0" discarded
+        // that update and made it believe 4.2 MORE strongly. The gate now
+        // keeps both claims. See advanced::contradiction.
         let dir = tempdir().unwrap();
         let storage = storage_with_marker_gate_runtime(&dir);
         let target = storage
@@ -21135,14 +21152,27 @@ mod tests {
                 ..Default::default()
             })
             .unwrap();
-        assert_eq!(result.decision, "reinforce");
-        assert_eq!(result.node.id, target.id);
-        assert!(result.auto_closed_until.is_none());
-        let node = storage.get_node(&target.id).unwrap().unwrap();
         assert_eq!(
-            node.valid_from.map(|value| value.to_rfc3339()),
-            Some(newer_from.to_rfc3339())
+            result.decision, "create",
+            "a version change is a value conflict, not a reinforcement"
         );
+        assert_ne!(
+            result.node.id, target.id,
+            "the superseded 4.2 claim must not be overwritten in place"
+        );
+        assert!(
+            result.auto_closed_until.is_none(),
+            "a newer dated claim arriving second closes nothing"
+        );
+        assert_eq!(
+            result.node.valid_from.map(|value| value.to_rfc3339()),
+            Some(newer_from.to_rfc3339()),
+            "the new node carries its own validity"
+        );
+        // The older claim survives intact, still open, still retrievable.
+        let previous = storage.get_node(&target.id).unwrap().unwrap();
+        assert!(previous.valid_until.is_none());
+        assert!(previous.content.contains("4.2"));
     }
 
     #[test]

--- a/crates/vestige-core/src/storage/sqlite.rs
+++ b/crates/vestige-core/src/storage/sqlite.rs
@@ -1037,17 +1037,99 @@ impl SqliteMemoryStore {
         Ok(repaired)
     }
 
+    /// Run `PRAGMA quick_check` and return its rows.
+    fn quick_check_rows(conn: &Connection) -> Result<Vec<String>> {
+        let mut out = Vec::new();
+        let mut stmt = conn.prepare("PRAGMA quick_check")?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    /// Names of every FTS5 virtual table in the schema.
+    fn fts5_table_names(conn: &Connection) -> Result<Vec<String>> {
+        let mut stmt = conn.prepare(
+            "SELECT name FROM sqlite_master \
+             WHERE type = 'table' AND sql LIKE '%USING fts5%'",
+        )?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    /// Is every failing quick_check row attributable to an FTS5 index we can
+    /// rebuild? A single row we cannot attribute means real damage, and the
+    /// caller must fail rather than paper over it.
+    fn quick_check_failure_is_only_fts5(rows: &[String], fts_tables: &[String]) -> bool {
+        if fts_tables.is_empty() {
+            return false;
+        }
+        rows.iter().filter(|r| r.as_str() != "ok").all(|r| {
+            let lower = r.to_lowercase();
+            lower.contains("fts5") && fts_tables.iter().any(|t| lower.contains(&t.to_lowercase()))
+        })
+    }
+
     fn run_integrity_checks(conn: &Connection, phase: &str) -> Result<SqliteIntegrityStatus> {
-        let mut quick_rows = Vec::new();
-        {
-            let mut stmt = conn.prepare("PRAGMA quick_check")?;
-            let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
-            for row in rows {
-                quick_rows.push(row?);
+        let mut quick_rows = Self::quick_check_rows(conn)?;
+
+        // An FTS5 external-content index is DERIVED STATE. `knowledge_fts` is
+        // declared `content='knowledge_nodes'`, so every token in it is
+        // reconstructible from a table quick_check just verified. Refusing to
+        // open the whole store because a rebuildable index is damaged strands
+        // the user's memories behind an index we can regenerate in seconds --
+        // and that is exactly what happened in the field: a store with 2,926
+        // intact memories became unopenable over one corrupt fts5 blob.
+        //
+        // So: rebuild and re-check. Only if the rebuild fails, or the re-check
+        // still fails, is this real corruption worth refusing over. This
+        // deliberately mirrors the CASCADE-orphan repair below -- repair derived
+        // state, fail loudly on genuine damage.
+        //
+        // Writer phases only. The runtime reader must never attempt a write.
+        let repairable_phase = phase == "pre-migration" || phase == "post-migration";
+        let quick_ok = |rows: &[String]| {
+            rows.len() == 1 && rows.first().map(String::as_str) == Some("ok")
+        };
+        if !quick_ok(&quick_rows) && repairable_phase {
+            let fts_tables = Self::fts5_table_names(conn)?;
+            if Self::quick_check_failure_is_only_fts5(&quick_rows, &fts_tables) {
+                let detail = quick_rows.join("; ");
+                let mut rebuilt = Vec::new();
+                for table in &fts_tables {
+                    // Identifier is read back from sqlite_master, not user input.
+                    let quoted = table.replace('"', "\"\"");
+                    match conn.execute_batch(&format!(
+                        "INSERT INTO \"{quoted}\"(\"{quoted}\") VALUES('rebuild');"
+                    )) {
+                        Ok(()) => rebuilt.push(table.clone()),
+                        Err(error) => {
+                            return Err(StorageError::Init(format!(
+                                "SQLite {phase} quick_check failed ({detail}) and rebuilding \
+                                 FTS index '{table}' also failed: {error}"
+                            )));
+                        }
+                    }
+                }
+                quick_rows = Self::quick_check_rows(conn)?;
+                if quick_ok(&quick_rows) {
+                    tracing::warn!(
+                        phase,
+                        rebuilt = ?rebuilt,
+                        detail,
+                        "rebuilt corrupt FTS index from its content table; store opened normally"
+                    );
+                }
             }
         }
+
         let quick_check = quick_rows.join("; ");
-        if quick_rows.len() != 1 || quick_rows.first().map(String::as_str) != Some("ok") {
+        if !quick_ok(&quick_rows) {
             return Err(StorageError::Init(format!(
                 "SQLite {phase} quick_check failed: {quick_check}"
             )));
@@ -18903,6 +18985,59 @@ mod tests {
     /// at 3.0, and both fed the same combined_score: measured on a 202-document
     /// corpus, a note citing a UUID three times scored 27.5 against the exact
     /// match's 3.0. That inverted the documented exact-lookup guarantee.
+    /// A corrupt FTS index must NOT strand the user's memories. `knowledge_fts`
+    /// is declared `content='knowledge_nodes'`, so it is derived state and is
+    /// always reconstructible. This reproduces the field failure: a store with
+    /// intact memories became unopenable because one fts5 blob was damaged.
+    #[test]
+    fn corrupt_fts_index_is_rebuilt_instead_of_bricking_the_store() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("vestige.db");
+
+        // Seed a store and close it cleanly.
+        {
+            let storage = Storage::new(Some(path.clone())).expect("open");
+            for i in 0..5 {
+                storage
+                    .ingest(IngestInput {
+                        content: format!("memory number {i} about deployment"),
+                        node_type: "fact".to_string(),
+                        ..Default::default()
+                    })
+                    .expect("ingest");
+            }
+        }
+
+        // Corrupt the FTS index the way an interrupted rebuild does.
+        {
+            let conn = Connection::open(&path).expect("raw open");
+            conn.execute_batch(
+                "UPDATE knowledge_fts_data SET block = randomblob(200) \
+                 WHERE id = (SELECT id FROM knowledge_fts_data WHERE id > 1 LIMIT 1);",
+            )
+            .expect("corrupt");
+            let corrupt = conn
+                .execute_batch("INSERT INTO knowledge_fts(knowledge_fts) VALUES('integrity-check');")
+                .is_err();
+            assert!(corrupt, "the fixture must actually corrupt the index");
+        }
+
+        // Reopening must succeed by rebuilding, not fail.
+        let storage = Storage::new(Some(path.clone()))
+            .expect("a corrupt DERIVED index must not prevent opening the store");
+        let all = storage.get_all_nodes(100, 0).expect("list nodes");
+        assert_eq!(all.len(), 5, "every memory must survive the rebuild");
+
+        // And the rebuilt index must actually be usable again.
+        let hits = storage
+            .concrete_search_filtered("deployment", 10, None, None)
+            .expect("keyword search after rebuild");
+        assert!(
+            !hits.is_empty(),
+            "the rebuilt index must find the seeded memories"
+        );
+    }
+
     #[test]
     fn test_concrete_search_exact_match_beats_a_doc_that_only_cites_it() {
         let storage = create_test_storage();

--- a/crates/vestige-core/src/storage/sqlite.rs
+++ b/crates/vestige-core/src/storage/sqlite.rs
@@ -680,6 +680,15 @@ pub struct SqliteMemoryStore {
     attached_profile_runtime: RwLock<Option<AttachedProfileRuntime>>,
     /// Cached model signature. `None` until the first embedding is written.
     registered_model: std::sync::RwLock<Option<crate::storage::memory_store::ModelSignature>>,
+    /// Last `PRAGMA data_version` observed on the reader connection.
+    ///
+    /// SQLite increments this on a connection whenever ANOTHER connection commits
+    /// to the database. It is the cheapest possible cross-process change signal --
+    /// no table scan, no file stat -- and it is what lets a long-lived process
+    /// notice that a peer has written memories it has never seen. See
+    /// `refresh_vector_index_if_stale`.
+    #[cfg(feature = "vector-search")]
+    last_seen_data_version: Mutex<i64>,
 }
 
 #[cfg(all(feature = "embeddings", feature = "vector-search"))]
@@ -1093,9 +1102,8 @@ impl SqliteMemoryStore {
         //
         // Writer phases only. The runtime reader must never attempt a write.
         let repairable_phase = phase == "pre-migration" || phase == "post-migration";
-        let quick_ok = |rows: &[String]| {
-            rows.len() == 1 && rows.first().map(String::as_str) == Some("ok")
-        };
+        let quick_ok =
+            |rows: &[String]| rows.len() == 1 && rows.first().map(String::as_str) == Some("ok");
         if !quick_ok(&quick_rows) && repairable_phase {
             let fts_tables = Self::fts5_table_names(conn)?;
             if Self::quick_check_failure_is_only_fts5(&quick_rows, &fts_tables) {
@@ -1492,6 +1500,8 @@ impl SqliteMemoryStore {
             embedding_service,
             #[cfg(feature = "vector-search")]
             vector_index,
+            #[cfg(feature = "vector-search")]
+            last_seen_data_version: Mutex::new(-1),
             #[cfg(all(feature = "embeddings", feature = "vector-search"))]
             query_cache,
             #[cfg(all(feature = "embeddings", feature = "vector-search"))]
@@ -4340,7 +4350,6 @@ impl SqliteMemoryStore {
     /// Significantly reduces retrieval strength so better alternatives surface
     /// Does NOT delete - the memory stays for reference but ranks lower
     pub fn demote_memory(&self, id: &str) -> Result<KnowledgeNode> {
-
         // Strong penalty: -0.3 retrieval, -0.15 retention, halve stability
         {
             let writer = self
@@ -6514,6 +6523,114 @@ impl SqliteMemoryStore {
 
     /// Semantic search returning scores
     #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    /// Bring the in-process vector index up to date with vectors written by OTHER
+    /// processes since this one last looked.
+    ///
+    /// THE BUG THIS FIXES (#181). The HNSW index is process-local: it is built once
+    /// at startup from `embedding_profile_vectors` and thereafter only ever appended
+    /// to by THIS process's own ingests. A second MCP server writing to the same
+    /// SQLite file is therefore invisible to it. In a normal setup -- a desktop
+    /// client, an editor integration, a CLI and a dashboard all pointed at one store
+    /// -- every long-lived process is semantically blind to everything its peers have
+    /// written since it booted. The consequences are silent: the prediction-error
+    /// gate sees no similar candidate and creates a duplicate instead of reinforcing,
+    /// and recall returns an incomplete answer with no indication anything is missing.
+    /// The FTS5 leg reads SQLite directly and is unaffected, which is exactly why the
+    /// failure is partial and hard to notice.
+    ///
+    /// THE SIGNAL. `PRAGMA data_version` is incremented on a connection whenever a
+    /// DIFFERENT connection commits. Reading it is a single pragma with no table
+    /// access, so this check is affordable on every query, and when nothing has
+    /// changed it costs one integer comparison.
+    ///
+    /// LOCK DISCIPLINE. This deliberately acquires the reader lock and the index lock
+    /// SEQUENTIALLY and never holds both at once: read the version, drop; read the
+    /// missing rows, drop; then take the index and add. `semantic_search_raw` holds
+    /// only the index lock, so no ordering cycle exists and this cannot deadlock
+    /// against it.
+    ///
+    /// FAILS OPEN. A refresh problem must degrade to a possibly-stale index, never
+    /// break the query -- returning an error here would turn a peer's write into an
+    /// outage. Returns the number of vectors added.
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    fn refresh_vector_index_if_stale(&self) -> usize {
+        let Some(index_mutex) = self.vector_index.as_ref() else {
+            return 0;
+        };
+
+        // --- reader lock: has anyone else committed? ---
+        let current_version: i64 = {
+            let Ok(reader) = self.reader.lock() else {
+                return 0;
+            };
+            match reader.query_row("PRAGMA data_version", [], |row| row.get(0)) {
+                Ok(v) => v,
+                Err(_) => return 0,
+            }
+        };
+        {
+            let Ok(mut seen) = self.last_seen_data_version.lock() else {
+                return 0;
+            };
+            if *seen == current_version {
+                return 0; // nothing has changed since we last looked
+            }
+            *seen = current_version;
+        }
+
+        let Ok(Some(active)) = self.active_embedding_profile() else {
+            return 0;
+        };
+
+        // --- reader lock: which vectors exist for the active profile? ---
+        let rows: Vec<(String, Vec<u8>)> = {
+            let Ok(reader) = self.reader.lock() else {
+                return 0;
+            };
+            let Ok(mut stmt) = reader.prepare(
+                "SELECT node_id, embedding FROM embedding_profile_vectors WHERE profile_id = ?1",
+            ) else {
+                return 0;
+            };
+            let Ok(mapped) = stmt.query_map(params![active.profile_id.as_str()], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?))
+            }) else {
+                return 0;
+            };
+            mapped.filter_map(|r| r.ok()).collect()
+        };
+
+        // --- index lock: add only what we do not already have ---
+        let Ok(mut index) = index_mutex.lock() else {
+            return 0;
+        };
+        let mut added = 0usize;
+        for (node_id, blob) in rows {
+            if index.contains(&node_id) {
+                continue;
+            }
+            // Same decoder the startup index builder uses, so a vector added here
+            // is byte-identical to one added by a full rebuild.
+            let Some(embedding) = Embedding::from_bytes(&blob) else {
+                continue; // unreadable vector: skip it, never fail the query
+            };
+            if embedding.dimensions != index.dimensions() {
+                continue; // wrong profile/dimension: not ours to add
+            }
+            if index.add(&node_id, &embedding.vector).is_ok() {
+                added += 1;
+            }
+        }
+        if added > 0 {
+            tracing::debug!(
+                added,
+                data_version = current_version,
+                "refreshed vector index with memories written by another process"
+            );
+        }
+        added
+    }
+
     fn semantic_search_raw(&self, query: &str, limit: i32) -> Result<Vec<(String, f32)>> {
         if !self.vector_search_available() {
             return Ok(vec![]);
@@ -6546,6 +6663,12 @@ impl SqliteMemoryStore {
             }
             _ => self.get_query_embedding(query)?,
         };
+
+        // Pick up anything a peer process wrote since we last searched (#181).
+        // Cheap when nothing changed: one PRAGMA and an integer comparison. Runs
+        // BEFORE the index lock is taken, and takes its own locks sequentially,
+        // so it cannot deadlock against the search below.
+        self.refresh_vector_index_if_stale();
 
         let index = self.vector_index.as_ref().unwrap();
         let index = index
@@ -19017,7 +19140,9 @@ mod tests {
             )
             .expect("corrupt");
             let corrupt = conn
-                .execute_batch("INSERT INTO knowledge_fts(knowledge_fts) VALUES('integrity-check');")
+                .execute_batch(
+                    "INSERT INTO knowledge_fts(knowledge_fts) VALUES('integrity-check');",
+                )
                 .is_err();
             assert!(corrupt, "the fixture must actually corrupt the index");
         }

--- a/crates/vestige-mcp/Cargo.toml
+++ b/crates/vestige-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vestige-mcp"
-version = "2.4.1"
+version = "2.5.0"
 edition = "2024"
 description = "Cognitive memory MCP server for AI agents - FSRS-6, spreading activation, synaptic tagging, 3D dashboard, and 130 years of memory research"
 authors = ["samvallad33"]
@@ -62,7 +62,7 @@ path = "src/bin/cli.rs"
 # Only `bundled-sqlite` is always on. `embeddings` and `vector-search` are
 # toggled via vestige-mcp's own feature flags below so `--no-default-features`
 # actually works (previously hardcoded here, which silently defeated the flag).
-vestige-core = { version = "2.4.1", path = "../vestige-core", default-features = false, features = ["bundled-sqlite"] }
+vestige-core = { version = "2.5.0", path = "../vestige-core", default-features = false, features = ["bundled-sqlite"] }
 
 # ============================================================================
 # MCP Server Dependencies

--- a/crates/vestige-mcp/Cargo.toml
+++ b/crates/vestige-mcp/Cargo.toml
@@ -104,7 +104,7 @@ clap = { version = "4", features = ["derive"] }
 colored = "3"
 
 # SQLite (for backup WAL checkpoint)
-rusqlite = { version = "0.38", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 
 # Dashboard (v2.0) - HTTP server + WebSocket + embedded SvelteKit
 axum = { version = "0.8", default-features = false, features = ["json", "query", "tokio", "http1", "ws"] }

--- a/crates/vestige-mcp/src/server.rs
+++ b/crates/vestige-mcp/src/server.rs
@@ -168,10 +168,19 @@ impl McpServer {
             return None;
         }
 
-        // Check initialization for non-initialize requests
+        // Check initialization for non-initialize requests.
+        //
+        // `server/discover` is deliberately exempt. Its entire purpose is to let
+        // a client learn what this server speaks BEFORE committing to a protocol
+        // revision, and MCP 2026-07-28 -- which removes the handshake altogether
+        // -- explicitly sanctions using it as a backward-compatibility probe on
+        // stdio. Gating it behind the very handshake it exists to precede makes
+        // it useless: a modern client probing this server would get
+        // "Server not initialized" and have to guess.
         if !self.initialized
             && request.method != "initialize"
             && request.method != "notifications/initialized"
+            && request.method != "server/discover"
         {
             warn!(
                 "Rejecting request '{}': server not initialized",
@@ -192,6 +201,7 @@ impl McpServer {
             "tools/call" => self.handle_tools_call(request.params).await,
             "resources/list" => self.handle_resources_list().await,
             "resources/read" => self.handle_resources_read(request.params).await,
+            "server/discover" => self.handle_server_discover(),
             "ping" => Ok(serde_json::json!({})),
             method => {
                 warn!("Unknown method: {}", method);
@@ -203,6 +213,39 @@ impl McpServer {
             Ok(result) => JsonRpcResponse::success(request.id, result),
             Err(error) => JsonRpcResponse::error(request.id, error),
         })
+    }
+
+    /// `server/discover` — advertise supported protocol versions, capabilities and
+    /// identity WITHOUT a handshake.
+    ///
+    /// MCP 2026-07-28 makes this mandatory: it removes the
+    /// `initialize`/`notifications/initialized` handshake entirely and makes the
+    /// protocol stateless, so a client needs some way to learn what a server
+    /// speaks before it commits to a revision. On stdio the spec explicitly
+    /// allows using this as a backward-compatibility probe, which is exactly how
+    /// a 2026-era client will meet this 2025-11-25 server.
+    ///
+    /// Answering it truthfully costs nothing and is strictly better than the
+    /// alternative, which is a modern client getting `method_not_found` and
+    /// having to guess. It deliberately does NOT claim 2026-07-28 support: the
+    /// stateless core, `resultType`, and MRTR are not implemented yet, and
+    /// advertising a revision we do not serve would be a false claim that fails
+    /// conformance for real.
+    ///
+    /// Unlike `initialize`, this neither takes params nor mutates session state,
+    /// so it is safe to call at any point, including before initialization.
+    fn handle_server_discover(&self) -> Result<serde_json::Value, JsonRpcError> {
+        Ok(serde_json::json!({
+            "protocolVersions": supported_protocol_versions(),
+            "serverInfo": {
+                "name": "vestige",
+                "version": env!("CARGO_PKG_VERSION"),
+            },
+            "capabilities": {
+                "tools": { "listChanged": false },
+                "resources": { "listChanged": false },
+            },
+        }))
     }
 
     /// Handle initialize request
@@ -471,8 +514,35 @@ impl McpServer {
             }
         }
 
-        let result = ListToolsResult { tools };
-        serde_json::to_value(result).map_err(|e| JsonRpcError::internal_error(&e.to_string()))
+        // Deterministic order. MCP 2026-07-28 says servers SHOULD return tools
+        // from tools/list in a stable order so clients can cache the list and so
+        // the bytes land identically in an LLM prompt cache. The vec above is
+        // hand-ordered by theme, which is good for a human reading the source and
+        // useless as a cache key the moment anyone reorders it.
+        tools.sort_by(|a, b| a.name.cmp(&b.name));
+
+        let mut result = serde_json::to_value(ListToolsResult { tools })
+            .map_err(|e| JsonRpcError::internal_error(&e.to_string()))?;
+
+        // Freshness hints (MCP 2026-07-28 `CacheableResult`). Measured on a real
+        // install: this response is 28,506 bytes and was served 1,161 times from
+        // one log -- roughly 7,000 tokens of tool schema pushed into model context
+        // on every single session start, re-sent forever, with nothing telling the
+        // client it could have kept the previous copy.
+        //
+        // The advertised surface only changes when the binary changes, so an hour
+        // is conservative rather than aggressive. `private` because the list can
+        // vary with per-install configuration; a shared intermediary must not
+        // serve one install's tool list to another.
+        //
+        // Emitting these at 2025-11-25 is forward-compatible: unknown result
+        // fields are ignored by older clients, and the fields become required at
+        // 2026-07-28.
+        if let Some(object) = result.as_object_mut() {
+            object.insert("ttlMs".to_string(), serde_json::json!(3_600_000u64));
+            object.insert("cacheScope".to_string(), serde_json::json!("private"));
+        }
+        Ok(result)
     }
 
     /// Handle tools/call request

--- a/crates/vestige-mcp/src/tools/codebase_unified.rs
+++ b/crates/vestige-mcp/src/tools/codebase_unified.rs
@@ -5,10 +5,14 @@
 
 use serde::Deserialize;
 use serde_json::Value;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::cognitive::CognitiveEngine;
+use vestige_core::codebase::{
+    AnchorDraft, AnchorStatus, AnchorVerification, CodeAnchor, capture_anchor, verify_anchor,
+};
 use vestige_core::{IngestInput, OutputConfig, Storage};
 
 use super::search_unified::apply_output_masks;
@@ -20,8 +24,8 @@ pub fn schema() -> Value {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["remember_pattern", "remember_decision", "get_context"],
-                "description": "Action to perform: 'remember_pattern' stores a code pattern, 'remember_decision' stores an architectural decision, 'get_context' retrieves patterns and decisions for a codebase"
+                "enum": ["remember_pattern", "remember_decision", "get_context", "verify"],
+                "description": "Action to perform: 'remember_pattern' stores a code pattern, 'remember_decision' stores an architectural decision, 'get_context' retrieves patterns and decisions (each annotated with whether the code it describes still matches), 'verify' re-checks every anchored code memory against the working tree and reports which ones have gone stale"
             },
             // remember_pattern fields
             "name": {
@@ -50,7 +54,31 @@ pub fn schema() -> Value {
             "files": {
                 "type": "array",
                 "items": { "type": "string" },
-                "description": "Files where this pattern is used or affected by this decision"
+                "description": "Files where this pattern is used or affected by this decision. Accepts a plain path ('src/state.py'), a path plus symbol ('src/state.py#load_config'), or a path plus line span ('src/state.py:552-580'). Anything more specific than a plain path is content-hashed at save time so the memory can later tell you itself whether the code it describes has changed."
+            },
+            "anchors": {
+                "type": "array",
+                "description": "Structured form of 'files', for callers that already know the symbol. Each anchor is content-hashed at save time so staleness becomes detectable instead of invisible.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "path": { "type": "string", "description": "Repository-relative path to the anchored file" },
+                        "symbol": { "type": "string", "description": "Function/type/class this memory is about. Strongly preferred over a line number: line numbers rot within a week." },
+                        "symbolKind": { "type": "string", "description": "Optional display kind, e.g. 'fn', 'class'" },
+                        "startLine": { "type": "integer", "description": "1-based start line, when the exact span is known" },
+                        "endLine": { "type": "integer", "description": "1-based inclusive end line" }
+                    },
+                    "required": ["path"]
+                }
+            },
+            "repoPath": {
+                "type": "string",
+                "description": "Repository root used to resolve anchor paths (default: the server's working directory)"
+            },
+            "verify": {
+                "type": "boolean",
+                "description": "Check returned code memories against the current source and flag the ones that no longer match (default: true)",
+                "default": true
             },
             "codebase": {
                 "type": "string",
@@ -80,9 +108,23 @@ struct CodebaseArgs {
     alternatives: Option<Vec<String>>,
     // Shared fields
     files: Option<Vec<String>>,
+    anchors: Option<Vec<AnchorArg>>,
+    repo_path: Option<String>,
     codebase: Option<String>,
     // Context fields
     limit: Option<i32>,
+    verify: Option<bool>,
+}
+
+/// Structured anchor as it arrives over MCP.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AnchorArg {
+    path: String,
+    symbol: Option<String>,
+    symbol_kind: Option<String>,
+    start_line: Option<u32>,
+    end_line: Option<u32>,
 }
 
 /// Execute the unified codebase tool
@@ -101,8 +143,9 @@ pub async fn execute(
         "remember_pattern" => execute_remember_pattern(storage, cognitive, &args).await,
         "remember_decision" => execute_remember_decision(storage, cognitive, &args).await,
         "get_context" => execute_get_context(storage, cognitive, output_config, &args).await,
+        "verify" => execute_verify(storage, &args).await,
         _ => Err(format!(
-            "Invalid action '{}'. Must be one of: remember_pattern, remember_decision, get_context",
+            "Invalid action '{}'. Must be one of: remember_pattern, remember_decision, get_context, verify",
             args.action
         )),
     }
@@ -179,11 +222,16 @@ async fn execute_remember_pattern(
         );
     }
 
+    // Anchor the memory to the code it describes so it can later be checked
+    // instead of being served with unearned confidence.
+    let anchors = capture_and_record(storage, &node_id, args);
+
     Ok(serde_json::json!({
         "action": "remember_pattern",
         "success": true,
         "nodeId": node_id,
         "patternName": name,
+        "anchors": anchors,
         "message": format!("Pattern '{}' remembered successfully", name),
     }))
 }
@@ -277,12 +325,261 @@ async fn execute_remember_decision(
         );
     }
 
+    let anchors = capture_and_record(storage, &node_id, args);
+
     Ok(serde_json::json!({
         "action": "remember_decision",
         "success": true,
         "nodeId": node_id,
+        "anchors": anchors,
         "message": "Architectural decision remembered successfully",
     }))
+}
+
+// ============================================================================
+// SOURCE ANCHORING
+// ============================================================================
+//
+// A code memory used to anchor to source by printing the caller's `files`
+// array into its markdown body. Nothing about that shape could answer the only
+// question that matters when the memory is served back months later: does the
+// code it describes still exist, and does it still say the same thing?
+//
+// Because nothing could answer it, a memory that had rotted came back with
+// exactly the same confidence as one that was still true. The fix is not to
+// delete rotted memories - the user values that memories are preserved - it is
+// to make rot *visible* at retrieval time.
+
+/// Resolve the repository root used to interpret anchor paths.
+fn resolve_repo_root(args: &CodebaseArgs) -> Option<PathBuf> {
+    match args.repo_path.as_deref() {
+        Some(raw) if !raw.trim().is_empty() => Some(PathBuf::from(raw.trim())),
+        _ => std::env::current_dir().ok(),
+    }
+}
+
+/// Collect anchor drafts from both input shapes: the structured `anchors`
+/// array and the existing `files` array (which now also understands the
+/// compact `path#symbol` and `path:start-end` forms).
+fn collect_drafts(args: &CodebaseArgs) -> Vec<AnchorDraft> {
+    let mut drafts: Vec<AnchorDraft> = Vec::new();
+
+    if let Some(anchors) = args.anchors.as_ref() {
+        for a in anchors {
+            if a.path.trim().is_empty() {
+                continue;
+            }
+            drafts.push(AnchorDraft {
+                file_path: a.path.trim().to_string(),
+                symbol: a.symbol.clone().filter(|s| !s.trim().is_empty()),
+                symbol_kind: a.symbol_kind.clone(),
+                start_line: a.start_line,
+                end_line: a.end_line,
+            });
+        }
+    }
+
+    if let Some(files) = args.files.as_ref() {
+        for f in files {
+            if f.trim().is_empty() {
+                continue;
+            }
+            drafts.push(AnchorDraft::parse(f));
+        }
+    }
+
+    drafts.dedup_by(|a, b| {
+        a.file_path == b.file_path && a.symbol == b.symbol && a.start_line == b.start_line
+    });
+    drafts
+}
+
+/// Capture and persist anchors for a freshly stored memory, and describe what
+/// was captured. Never fails the write: an anchor that could not be hashed is
+/// still recorded (and reported) as unverifiable, which is strictly more
+/// honest than recording nothing.
+fn capture_and_record(storage: &Arc<Storage>, node_id: &str, args: &CodebaseArgs) -> Value {
+    let drafts = collect_drafts(args);
+    if drafts.is_empty() {
+        return serde_json::json!({
+            "count": 0,
+            "verifiable": 0,
+            "items": [],
+            "note": "No files were anchored, so this memory cannot self-check. Pass `files: [\"src/x.rs#my_symbol\"]` or `anchors` to make it verifiable.",
+        });
+    }
+
+    let Some(repo_root) = resolve_repo_root(args) else {
+        return serde_json::json!({
+            "count": 0,
+            "verifiable": 0,
+            "items": [],
+            "note": "Could not determine a repository root, so no anchors were captured. Pass `repoPath` to enable staleness detection.",
+        });
+    };
+
+    let anchors: Vec<CodeAnchor> = drafts
+        .iter()
+        .map(|d| capture_anchor(node_id, &repo_root, d))
+        .collect();
+
+    let items: Vec<Value> = anchors
+        .iter()
+        .map(|a| {
+            serde_json::json!({
+                "path": a.file_path,
+                "symbol": a.symbol,
+                "startLine": a.start_line,
+                "endLine": a.end_line,
+                "verifiable": a.is_verifiable(),
+                "reason": if a.is_verifiable() {
+                    Value::Null
+                } else if a.symbol.is_some() {
+                    Value::String("the symbol could not be located in that file, so no content hash was stored".into())
+                } else {
+                    Value::String("path-only anchor: no symbol or line span, so only file existence can be checked later".into())
+                },
+            })
+        })
+        .collect();
+
+    let verifiable = anchors.iter().filter(|a| a.is_verifiable()).count();
+    let recorded = storage.record_code_anchors(&anchors);
+
+    serde_json::json!({
+        "count": anchors.len(),
+        "verifiable": verifiable,
+        "items": items,
+        "recorded": recorded.as_ref().map(|n| *n as i64).unwrap_or(0),
+        "error": recorded.err().map(|e| e.to_string()),
+    })
+}
+
+/// One anchor verdict, rendered for the tool response.
+fn verification_json(v: &AnchorVerification) -> Value {
+    serde_json::json!({
+        "path": v.file_path,
+        "symbol": v.symbol,
+        "status": v.status.as_str(),
+        "detail": v.detail,
+        "recordedLine": v.recorded_line,
+        "currentLine": v.current_line,
+    })
+}
+
+/// Roll several anchor verdicts for one memory into a single status.
+///
+/// Staleness wins over freshness: if any anchor of a memory no longer matches,
+/// the memory is flagged. A memory whose anchors are all unverifiable is
+/// "unverifiable", never "stale" - this is the legacy path, and accusing a
+/// correct memory of being wrong would be worse than the bug being fixed.
+fn worst_status(verifications: &[AnchorVerification]) -> AnchorStatus {
+    if verifications
+        .iter()
+        .any(|v| v.status == AnchorStatus::Missing)
+    {
+        AnchorStatus::Missing
+    } else if verifications
+        .iter()
+        .any(|v| v.status == AnchorStatus::Drifted)
+    {
+        AnchorStatus::Drifted
+    } else if verifications.iter().any(|v| v.status.is_fresh()) {
+        // Some anchor positively matched and none contradicted it.
+        if verifications
+            .iter()
+            .any(|v| v.status == AnchorStatus::Moved)
+        {
+            AnchorStatus::Moved
+        } else {
+            AnchorStatus::Verified
+        }
+    } else {
+        AnchorStatus::Unverifiable
+    }
+}
+
+/// Verify every anchor belonging to `node_ids` and return, per node, the rolled
+/// up status plus the individual verdicts.
+fn verify_nodes(
+    storage: &Arc<Storage>,
+    repo_root: &std::path::Path,
+    node_ids: &[String],
+) -> std::collections::HashMap<String, (AnchorStatus, Vec<AnchorVerification>)> {
+    let mut out = std::collections::HashMap::new();
+    let Ok(by_node) = storage.code_anchors_for_nodes(node_ids) else {
+        return out;
+    };
+    for (node_id, anchors) in by_node {
+        let verdicts: Vec<AnchorVerification> = anchors
+            .iter()
+            .map(|a| verify_anchor(a, repo_root))
+            .collect();
+        // Cache the verdict for reporting. The retrieval path always
+        // re-verifies against the live tree, so this is never load-bearing.
+        for (anchor, verdict) in anchors.iter().zip(verdicts.iter()) {
+            let _ =
+                storage.record_anchor_verification(&anchor.id, verdict.status, verdict.checked_at);
+        }
+        out.insert(node_id, (worst_status(&verdicts), verdicts));
+    }
+    out
+}
+
+/// Annotate already-formatted memory items with their verification verdict.
+/// Returns the ids of the memories that are visibly stale.
+fn annotate_items(
+    items: &mut [Value],
+    verified: &std::collections::HashMap<String, (AnchorStatus, Vec<AnchorVerification>)>,
+) -> Vec<String> {
+    let mut stale_ids = Vec::new();
+    for item in items.iter_mut() {
+        let Some(id) = item.get("id").and_then(|v| v.as_str()).map(str::to_string) else {
+            continue;
+        };
+        let Some(obj) = item.as_object_mut() else {
+            continue;
+        };
+
+        match verified.get(&id) {
+            Some((status, verdicts)) => {
+                obj.insert(
+                    "anchorStatus".to_string(),
+                    Value::String(status.as_str().to_string()),
+                );
+                obj.insert(
+                    "anchors".to_string(),
+                    Value::Array(verdicts.iter().map(verification_json).collect()),
+                );
+                if status.is_stale() {
+                    stale_ids.push(id);
+                    let reason = verdicts
+                        .iter()
+                        .filter(|v| v.is_stale())
+                        .map(|v| v.detail.clone())
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    obj.insert("stale".to_string(), Value::Bool(true));
+                    obj.insert("staleReason".to_string(), Value::String(reason));
+                }
+            }
+            None => {
+                // No anchor row at all: every memory written before anchoring
+                // existed lands here. Unverifiable, explicitly not stale.
+                obj.insert(
+                    "anchorStatus".to_string(),
+                    Value::String("unanchored".to_string()),
+                );
+                obj.insert(
+                    "anchorNote".to_string(),
+                    Value::String(
+                        "This memory has no source anchor, so Vestige cannot check it against the code. It may be perfectly correct - it just cannot prove it.".to_string(),
+                    ),
+                );
+            }
+        }
+    }
+    stale_ids
 }
 
 /// Get codebase context (patterns and decisions)
@@ -360,10 +657,76 @@ async fn execute_get_context(
         }
     }
 
+    // ====================================================================
+    // STALENESS: a code memory that no longer matches its source must be
+    // VISIBLY wrong here, not silently wrong. Nothing is deleted or rewritten
+    // - the memory is returned exactly as the user saved it, with the verdict
+    // attached so it cannot be read without being seen.
+    // ====================================================================
+    let verify_enabled = args.verify.unwrap_or(true);
+    let repo_root = if verify_enabled {
+        resolve_repo_root(args)
+    } else {
+        None
+    };
+
+    let mut verification = serde_json::json!({
+        "enabled": false,
+        "reason": if !verify_enabled {
+            "verification disabled by the caller (verify=false)"
+        } else {
+            "no repository root could be resolved; pass repoPath to enable staleness detection"
+        },
+    });
+    let mut stale_ids: Vec<String> = Vec::new();
+
+    if let Some(root) = repo_root.as_deref() {
+        let node_ids: Vec<String> = patterns
+            .iter()
+            .chain(decisions.iter())
+            .map(|n| n.id.clone())
+            .collect();
+        let verified = verify_nodes(storage, root, &node_ids);
+
+        stale_ids.extend(annotate_items(&mut formatted_patterns, &verified));
+        stale_ids.extend(annotate_items(&mut formatted_decisions, &verified));
+
+        let all: Vec<&AnchorStatus> = verified.values().map(|(s, _)| s).collect();
+        let fresh = all.iter().filter(|s| s.is_fresh()).count();
+        let stale = all.iter().filter(|s| s.is_stale()).count();
+        let unverifiable = node_ids.len() - fresh - stale;
+
+        verification = serde_json::json!({
+            "enabled": true,
+            "repoPath": root.display().to_string(),
+            "checked": node_ids.len(),
+            "fresh": fresh,
+            "stale": stale,
+            "unverifiable": unverifiable,
+            "warning": if stale > 0 {
+                Value::String(format!(
+                    "{stale} of {} returned code memories no longer match the code they describe (`stale: true`, see `staleReason`). They are preserved, not deleted - re-read the source before acting on them.",
+                    node_ids.len()
+                ))
+            } else {
+                Value::Null
+            },
+            "note": if unverifiable > 0 {
+                Value::String(format!(
+                    "{unverifiable} memory/memories have no verifiable anchor. That means Vestige cannot check them, NOT that they are wrong. Re-save them with `files: [\"path#symbol\"]` to make them self-checking."
+                ))
+            } else {
+                Value::Null
+            },
+        });
+    }
+
     Ok(serde_json::json!({
         "action": "get_context",
         "codebase": args.codebase,
         "profile": output_config.profile.as_str(),
+        "verification": verification,
+        "staleMemories": stale_ids,
         "patterns": {
             "count": formatted_patterns.len(),
             "items": formatted_patterns,
@@ -373,6 +736,71 @@ async fn execute_get_context(
             "items": formatted_decisions,
         },
         "crossProjectInsights": universal_patterns,
+    }))
+}
+
+/// Re-check every anchored code memory against the working tree.
+///
+/// The user found their one dangerous code memory "by looking". This action is
+/// that same audit, done mechanically: it reports which memories still match
+/// their source, which have drifted, and which cannot be checked at all -
+/// without changing or removing any of them.
+async fn execute_verify(storage: &Arc<Storage>, args: &CodebaseArgs) -> Result<Value, String> {
+    let repo_root = resolve_repo_root(args).ok_or(
+        "Could not resolve a repository root. Pass `repoPath` pointing at the checkout to verify against.",
+    )?;
+
+    let tag_filter = args.codebase.as_ref().map(|cb| format!("codebase:{}", cb));
+    let limit = args.limit.unwrap_or(200).clamp(1, 1000);
+
+    let mut nodes = storage
+        .get_nodes_by_type_and_tag("pattern", tag_filter.as_deref(), limit)
+        .unwrap_or_default();
+    nodes.extend(
+        storage
+            .get_nodes_by_type_and_tag("decision", tag_filter.as_deref(), limit)
+            .unwrap_or_default(),
+    );
+
+    let node_ids: Vec<String> = nodes.iter().map(|n| n.id.clone()).collect();
+    let verified = verify_nodes(storage, &repo_root, &node_ids);
+
+    let mut stale = Vec::new();
+    let mut fresh = 0usize;
+    let mut unanchored = Vec::new();
+
+    for node in &nodes {
+        match verified.get(&node.id) {
+            Some((status, verdicts)) if status.is_stale() => stale.push(serde_json::json!({
+                "id": node.id,
+                "status": status.as_str(),
+                "content": node.content,
+                "anchors": verdicts.iter().map(verification_json).collect::<Vec<_>>(),
+            })),
+            Some((status, _)) if status.is_fresh() => fresh += 1,
+            _ => unanchored.push(node.id.clone()),
+        }
+    }
+
+    Ok(serde_json::json!({
+        "action": "verify",
+        "codebase": args.codebase,
+        "repoPath": repo_root.display().to_string(),
+        "checked": nodes.len(),
+        "fresh": fresh,
+        "stale": stale.len(),
+        "unverifiable": unanchored.len(),
+        "staleMemories": stale,
+        "unverifiableMemories": unanchored,
+        "message": if stale.is_empty() {
+            format!("{fresh} of {} code memories still match their source. Nothing was modified or deleted.", nodes.len())
+        } else {
+            format!(
+                "{} of {} code memories no longer match the code they describe. They are listed in full and left untouched - review them, do not assume they are correct.",
+                stale.len(),
+                nodes.len()
+            )
+        },
     }))
 }
 
@@ -665,6 +1093,320 @@ mod tests {
         let value = result.unwrap();
         assert_eq!(value["action"], "get_context");
         assert!(value["codebase"].is_null());
+    }
+
+    // =====================================================================
+    // STALENESS DETECTION
+    //
+    // The production report: "4 code memories in 6 months, 1 of them actively
+    // dangerous, found by looking." These tests are that audit, mechanized.
+    // Each one asserts a property the pre-change code could not express,
+    // because a code memory anchored to nothing but a path printed into
+    // markdown has no way to be checked at all.
+    // =====================================================================
+
+    const SOURCE: &str = "\
+use std::fs;
+
+pub fn load_config(path: &str) -> Config {
+    let raw = fs::read_to_string(path).unwrap();
+    parse(&raw)
+}
+";
+
+    fn repo_with_source(body: &str) -> tempfile::TempDir {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/state.rs"), body).unwrap();
+        dir
+    }
+
+    fn rewrite_source(repo: &tempfile::TempDir, body: &str) {
+        std::fs::write(repo.path().join("src/state.rs"), body).unwrap();
+    }
+
+    async fn save_anchored(
+        storage: &Arc<Storage>,
+        cog: &Arc<Mutex<CognitiveEngine>>,
+        repo: &tempfile::TempDir,
+        name: &str,
+    ) -> Value {
+        let args = serde_json::json!({
+            "action": "remember_pattern",
+            "name": name,
+            "description": "load_config reads the whole file eagerly; do not call it in a loop",
+            "files": ["src/state.rs#load_config"],
+            "repoPath": repo.path().to_str().unwrap(),
+            "codebase": "anchored"
+        });
+        execute(storage, cog, &OutputConfig::default(), Some(args))
+            .await
+            .unwrap()
+    }
+
+    async fn get_context(
+        storage: &Arc<Storage>,
+        cog: &Arc<Mutex<CognitiveEngine>>,
+        repo: &tempfile::TempDir,
+    ) -> Value {
+        let args = serde_json::json!({
+            "action": "get_context",
+            "codebase": "anchored",
+            "repoPath": repo.path().to_str().unwrap()
+        });
+        execute(storage, cog, &OutputConfig::default(), Some(args))
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn saving_with_a_symbol_anchor_records_a_verifiable_hash() {
+        let (storage, _dir) = test_storage().await;
+        let cog = test_cognitive();
+        let repo = repo_with_source(SOURCE);
+
+        let saved = save_anchored(&storage, &cog, &repo, "Eager config read").await;
+        assert_eq!(saved["anchors"]["count"], 1);
+        assert_eq!(
+            saved["anchors"]["verifiable"], 1,
+            "a `path#symbol` anchor must be content-hashed at save time"
+        );
+        assert_eq!(saved["anchors"]["recorded"], 1);
+        assert_eq!(saved["anchors"]["items"][0]["symbol"], "load_config");
+    }
+
+    /// The actively dangerous case. The symbol still resolves, so every
+    /// symbol-only or path-only scheme reports "fine", but the behavior the
+    /// memory describes is gone. It must come back flagged.
+    #[tokio::test]
+    async fn a_code_memory_whose_source_changed_is_visibly_stale_on_retrieval() {
+        let (storage, _dir) = test_storage().await;
+        let cog = test_cognitive();
+        let repo = repo_with_source(SOURCE);
+        save_anchored(&storage, &cog, &repo, "Eager config read").await;
+
+        // Same symbol, completely different body: the memory is now wrong.
+        rewrite_source(
+            &repo,
+            "pub fn load_config(path: &str) -> Config {\n    Config::from_env()\n}\n",
+        );
+
+        let ctx = get_context(&storage, &cog, &repo).await;
+        let item = &ctx["patterns"]["items"][0];
+
+        assert_eq!(item["anchorStatus"], "drifted", "response: {ctx}");
+        assert_eq!(item["stale"], true, "a rotted memory must be flagged stale");
+        assert!(
+            item["staleReason"]
+                .as_str()
+                .unwrap()
+                .contains("load_config"),
+            "the reason must name what changed"
+        );
+        assert_eq!(ctx["verification"]["stale"], 1);
+        assert!(ctx["verification"]["warning"].is_string());
+        assert_eq!(ctx["staleMemories"].as_array().unwrap().len(), 1);
+
+        // Preserved, not deleted or rewritten.
+        assert_eq!(ctx["patterns"]["count"], 1);
+        assert!(
+            item["content"]
+                .as_str()
+                .unwrap()
+                .contains("do not call it in a loop"),
+            "the memory itself must be returned untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_deleted_source_file_makes_the_memory_visibly_stale() {
+        let (storage, _dir) = test_storage().await;
+        let cog = test_cognitive();
+        let repo = repo_with_source(SOURCE);
+        save_anchored(&storage, &cog, &repo, "Eager config read").await;
+
+        std::fs::remove_file(repo.path().join("src/state.rs")).unwrap();
+
+        let ctx = get_context(&storage, &cog, &repo).await;
+        let item = &ctx["patterns"]["items"][0];
+        assert_eq!(item["anchorStatus"], "missing", "response: {ctx}");
+        assert_eq!(item["stale"], true);
+    }
+
+    /// The false alarm a line-number anchor produces on every insertion above
+    /// it. `state.py:552` is wrong within a week; the content hash is not.
+    #[tokio::test]
+    async fn code_that_only_moved_is_not_reported_as_stale() {
+        let (storage, _dir) = test_storage().await;
+        let cog = test_cognitive();
+        let repo = repo_with_source(SOURCE);
+        save_anchored(&storage, &cog, &repo, "Eager config read").await;
+
+        rewrite_source(&repo, &format!("// new header\n// more header\n\n{SOURCE}"));
+
+        let ctx = get_context(&storage, &cog, &repo).await;
+        let item = &ctx["patterns"]["items"][0];
+        assert_eq!(item["anchorStatus"], "moved", "response: {ctx}");
+        assert!(
+            item.get("stale").is_none(),
+            "a pure relocation must never be flagged stale"
+        );
+        assert_eq!(ctx["verification"]["stale"], 0);
+        assert_eq!(ctx["verification"]["fresh"], 1);
+        assert!(
+            item["anchors"][0]["currentLine"].as_u64().unwrap()
+                > item["anchors"][0]["recordedLine"].as_u64().unwrap(),
+            "the new location should be reported"
+        );
+    }
+
+    #[tokio::test]
+    async fn unchanged_code_is_reported_fresh() {
+        let (storage, _dir) = test_storage().await;
+        let cog = test_cognitive();
+        let repo = repo_with_source(SOURCE);
+        save_anchored(&storage, &cog, &repo, "Eager config read").await;
+
+        let ctx = get_context(&storage, &cog, &repo).await;
+        assert_eq!(ctx["patterns"]["items"][0]["anchorStatus"], "verified");
+        assert_eq!(ctx["verification"]["fresh"], 1);
+        assert_eq!(ctx["verification"]["stale"], 0);
+    }
+
+    /// MIGRATION SAFETY. Every code memory that already exists was written
+    /// without anchors. Those must degrade to "unverifiable" - telling a user
+    /// their correct memory is wrong is worse than the bug being fixed.
+    #[tokio::test]
+    async fn a_pre_existing_unanchored_memory_is_unverifiable_never_stale() {
+        let (storage, _dir) = test_storage().await;
+        let cog = test_cognitive();
+        let repo = repo_with_source(SOURCE);
+
+        // Exactly the old shape: files printed into markdown, no anchors.
+        let args = serde_json::json!({
+            "action": "remember_pattern",
+            "name": "Legacy memory",
+            "description": "Something true about state.rs",
+            "codebase": "anchored"
+        });
+        execute(&storage, &cog, &OutputConfig::default(), Some(args))
+            .await
+            .unwrap();
+
+        // Rewrite the world underneath it.
+        rewrite_source(&repo, "nothing like the original at all\n");
+
+        let ctx = get_context(&storage, &cog, &repo).await;
+        let item = &ctx["patterns"]["items"][0];
+        assert_eq!(item["anchorStatus"], "unanchored", "response: {ctx}");
+        assert!(
+            item.get("stale").is_none(),
+            "an unanchored memory must never be accused of being stale"
+        );
+        assert!(item["anchorNote"].as_str().unwrap().contains("cannot"));
+        assert_eq!(ctx["verification"]["stale"], 0);
+        assert_eq!(ctx["verification"]["unverifiable"], 1);
+        assert!(ctx["staleMemories"].as_array().unwrap().is_empty());
+    }
+
+    /// A path-only anchor cannot be content-checked while the file exists, and
+    /// must say so rather than claim verification it did not perform.
+    #[tokio::test]
+    async fn a_path_only_anchor_reports_itself_unverifiable() {
+        let (storage, _dir) = test_storage().await;
+        let cog = test_cognitive();
+        let repo = repo_with_source(SOURCE);
+
+        let args = serde_json::json!({
+            "action": "remember_decision",
+            "decision": "Config loading lives in state.rs",
+            "rationale": "Keeps IO in one place",
+            "files": ["src/state.rs"],
+            "repoPath": repo.path().to_str().unwrap(),
+            "codebase": "anchored"
+        });
+        let saved = execute(&storage, &cog, &OutputConfig::default(), Some(args))
+            .await
+            .unwrap();
+        assert_eq!(saved["anchors"]["count"], 1);
+        assert_eq!(saved["anchors"]["verifiable"], 0);
+        assert!(
+            saved["anchors"]["items"][0]["reason"]
+                .as_str()
+                .unwrap()
+                .contains("path-only")
+        );
+
+        let ctx = get_context(&storage, &cog, &repo).await;
+        let item = &ctx["decisions"]["items"][0];
+        assert_eq!(item["anchorStatus"], "unverifiable");
+        assert!(item.get("stale").is_none());
+    }
+
+    #[tokio::test]
+    async fn verify_action_audits_every_anchored_memory_without_changing_them() {
+        let (storage, _dir) = test_storage().await;
+        let cog = test_cognitive();
+        let repo = repo_with_source(SOURCE);
+        save_anchored(&storage, &cog, &repo, "Eager config read").await;
+
+        rewrite_source(
+            &repo,
+            "pub fn load_config(path: &str) -> Config {\n    Config::from_env()\n}\n",
+        );
+
+        let args = serde_json::json!({
+            "action": "verify",
+            "codebase": "anchored",
+            "repoPath": repo.path().to_str().unwrap()
+        });
+        let report = execute(&storage, &cog, &OutputConfig::default(), Some(args))
+            .await
+            .unwrap();
+
+        assert_eq!(report["action"], "verify");
+        assert_eq!(report["stale"], 1, "report: {report}");
+        assert_eq!(report["fresh"], 0);
+        assert_eq!(report["staleMemories"][0]["status"], "drifted");
+        assert!(
+            report["message"]
+                .as_str()
+                .unwrap()
+                .contains("left untouched")
+        );
+
+        // The memory itself survives the audit.
+        let ctx = get_context(&storage, &cog, &repo).await;
+        assert_eq!(ctx["patterns"]["count"], 1);
+    }
+
+    #[tokio::test]
+    async fn verification_can_be_turned_off() {
+        let (storage, _dir) = test_storage().await;
+        let cog = test_cognitive();
+        let repo = repo_with_source(SOURCE);
+        save_anchored(&storage, &cog, &repo, "Eager config read").await;
+
+        let args = serde_json::json!({
+            "action": "get_context",
+            "codebase": "anchored",
+            "repoPath": repo.path().to_str().unwrap(),
+            "verify": false
+        });
+        let ctx = execute(&storage, &cog, &OutputConfig::default(), Some(args))
+            .await
+            .unwrap();
+        assert_eq!(ctx["verification"]["enabled"], false);
+        assert!(ctx["patterns"]["items"][0].get("anchorStatus").is_none());
+    }
+
+    #[tokio::test]
+    async fn schema_advertises_the_verify_action_and_anchor_inputs() {
+        let schema = schema();
+        let actions = schema["properties"]["action"]["enum"].as_array().unwrap();
+        assert!(actions.contains(&serde_json::json!("verify")));
+        assert!(schema["properties"]["anchors"].is_object());
+        assert!(schema["properties"]["repoPath"].is_object());
     }
 
     /// Phase 2: the `lean` profile masks the `createdAt` timestamp from

--- a/crates/vestige-mcp/src/tools/cross_reference.rs
+++ b/crates/vestige-mcp/src/tools/cross_reference.rs
@@ -383,6 +383,35 @@ const NEGATION_PAIRS: &[(&str, &str)] = &[
     ("disabled", "enabled"),
 ];
 
+/// Directional antonym pairs, used ONLY with the strict both-sides test below.
+///
+/// These are deliberately NOT in NEGATION_PAIRS. That list is scanned for the
+/// asymmetric PRESENCE of its first element, which is safe for explicit negations
+/// ("never", "don't") but would over-fire badly on ordinary evaluative words:
+/// plenty of innocent memories say something "hurts" or is "slower" without
+/// contradicting anything.
+///
+/// Requiring one memory to contain one side and the other memory to contain the
+/// other side is a far stricter test, and it catches the class the negation scan
+/// structurally cannot: two memories asserting OPPOSITE DIRECTIONS about the same
+/// subject, with no negation word in either. That is the shape of the failure
+/// this system exists to prevent -- "prompt diversity HURTS accuracy" against
+/// "prompt diversity IMPROVES accuracy" contains no negation at all.
+const ANTONYM_PAIRS: &[(&str, &str)] = &[
+    ("hurts", "improves"),
+    ("hurt", "improved"),
+    ("degrades", "enhances"),
+    ("decreases", "increases"),
+    ("reduces", "raises"),
+    ("worse", "better"),
+    ("slower", "faster"),
+    ("fails", "succeeds"),
+    ("breaks", "fixes"),
+    ("unsafe", "safe"),
+    ("unstable", "stable"),
+    ("unsupported", "supported"),
+];
+
 const CORRECTION_SIGNALS: &[&str] = &[
     "actually",
     "correction",
@@ -433,6 +462,83 @@ pub(crate) fn appears_contradictory(a: &str, b: &str) -> bool {
             return true;
         }
     }
+
+    // Opposite-direction claims with NO negation word in either memory.
+    //
+    // The scan above keys off the asymmetric presence of an explicit negation,
+    // so it cannot see "X hurts accuracy" against "X improves accuracy" -- there
+    // is nothing negated in either. That is precisely the shape of the real-world
+    // failure this guard exists for: an authoritative finding and a fresh claim
+    // asserting opposite directions about the same subject.
+    //
+    // Both sides are required to be present, in opposite memories. That is much
+    // stricter than the asymmetric-presence test and is why these words can be
+    // checked at all: on their own, "hurts" or "slower" appear in plenty of
+    // memories that contradict nothing. Combined with the >= 4 shared substantive
+    // words gate above, this means "same subject, opposite direction".
+    for (neg, opp) in ANTONYM_PAIRS {
+        let a_neg = a_lower.contains(neg);
+        let b_neg = b_lower.contains(neg);
+        let a_opp = a_lower.contains(opp);
+        let b_opp = b_lower.contains(opp);
+        if (a_neg && b_opp && !b_neg && !a_opp) || (b_neg && a_opp && !a_neg && !b_opp) {
+            return true;
+        }
+    }
+    // Mutually exclusive VALUES for the same attribute.
+    //
+    // This is the most common real-world contradiction and neither test above can
+    // see it: "Priya holds a Bachelor degree in computer science from Leeds"
+    // against "Priya holds a Master of Science degree in computer science from
+    // Leeds" contains no negation and no antonym, yet both cannot be true. It is
+    // also the shape MemConflict is built to measure, where every published system
+    // scores poorly.
+    //
+    // The distinguishing signal is DIVERGENCE versus ELABORATION. If the two
+    // memories overlap heavily but NEITHER's substantive vocabulary is a subset of
+    // the other's, they are asserting different things in the same slot. If one IS
+    // a subset of the other, it is an elaboration ("works in Leeds" versus "works
+    // in Leeds and London") and must not be flagged.
+    //
+    // Requires a high overlap floor so this only fires on memories that are
+    // demonstrably about the same subject, and requires each side to contribute at
+    // least one distinctive term so trivial rewordings do not qualify.
+    {
+        // Strip surrounding punctuation before comparing. Without this, "X" and
+        // "X," are distinct tokens, so a strict elaboration (A plus two extra
+        // words) looks like mutual divergence and gets flagged as a conflict.
+        // Caught by antonym_detection_does_not_fire_on_agreement_or_unrelated_text.
+        let norm = |set: &std::collections::HashSet<&str>| -> std::collections::HashSet<String> {
+            set.iter()
+                .map(|w| {
+                    w.trim_matches(|c: char| !c.is_alphanumeric())
+                        .to_string()
+                })
+                .filter(|w| w.len() > 3)
+                .collect()
+        };
+        let a_words = norm(&a_words);
+        let b_words = norm(&b_words);
+        let shared = a_words.intersection(&b_words).count();
+        let union = a_words.union(&b_words).count();
+        let overlap = if union == 0 {
+            0.0
+        } else {
+            shared as f32 / union as f32
+        };
+        let a_only = a_words.difference(&b_words).count();
+        let b_only = b_words.difference(&a_words).count();
+        // Both sides distinctive => divergence, not elaboration.
+        let diverges = a_only > 0 && b_only > 0;
+        // Keep the divergence small relative to the shared core: two memories that
+        // merely touch the same topic will diverge in many terms, whereas a
+        // same-attribute conflict differs in only a few.
+        let small_divergence = (a_only + b_only) <= shared;
+        if overlap >= 0.6 && diverges && small_divergence {
+            return true;
+        }
+    }
+
     // Correction signal: require ≥6 shared substantive words so we know the
     // two memories are on the SAME subject, and require the signal to appear
     // in exactly one of them (asymmetric — the memory with the correction
@@ -1208,6 +1314,82 @@ fn preview_text(value: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{query_coverage, topic_overlap};
+
+    /// The AIMO3 shape: two memories asserting OPPOSITE DIRECTIONS about the same
+    /// subject, with no negation word in either. The negation scan structurally
+    /// cannot see this, and it is the exact case where acting on the wrong side
+    /// suppresses the memory that would have corrected it.
+    #[test]
+    fn opposite_direction_claims_are_contradictions_without_any_negation() {
+        let hurts = "Prompt diversity monotonically hurts AIMO3 accuracy at temperature \
+                     0.6 and above on GPT-OSS-120B during the competition run";
+        let improves = "Prompt diversity monotonically improves AIMO3 accuracy at temperature \
+                        0.6 and above on GPT-OSS-120B during the competition run";
+        assert!(
+            super::appears_contradictory(hurts, improves),
+            "opposite-direction claims about the same subject must be contradictory"
+        );
+
+        // Neither memory contains a negation word, which is why the older
+        // negation-asymmetry scan missed this entirely.
+        for text in [hurts, improves] {
+            let t = text.to_lowercase();
+            assert!(!t.contains("never") && !t.contains("don't") && !t.contains("avoid"));
+        }
+    }
+
+    /// Mutually exclusive values for the same attribute -- the shape MemConflict
+    /// measures and the one both other detection paths structurally miss. Verified
+    /// against the live server: both memories were retrievable via lookup while
+    /// recall(mode="contradictions") returned ZERO pairs.
+    #[test]
+    fn same_attribute_different_value_is_a_contradiction() {
+        let bachelor = "Priya holds a Bachelor degree in computer science from Leeds University";
+        let master = "Priya holds a Master degree in computer science from Leeds University";
+        assert!(
+            super::appears_contradictory(bachelor, master),
+            "two incompatible values for the same attribute must be contradictory"
+        );
+
+        // No negation and no antonym in either -- this is why the other two paths
+        // cannot see it.
+        for t in [bachelor, master] {
+            let l = t.to_lowercase();
+            assert!(!l.contains("never") && !l.contains("not ") && !l.contains("hurts"));
+        }
+    }
+
+    /// Elaboration is not contradiction. A memory that ADDS detail to another must
+    /// never be flagged, or every refinement becomes a conflict.
+    #[test]
+    fn elaboration_is_not_flagged_as_contradiction() {
+        let base = "Priya works in the Leeds office on the payments platform team";
+        let more = "Priya works in the Leeds office on the payments platform team and mentors interns";
+        assert!(
+            !super::appears_contradictory(base, more),
+            "a superset elaboration must not be a contradiction"
+        );
+    }
+
+    /// The antonym test must not fire on agreement, or on two memories that merely
+    /// share a domain. Both sides must be present in OPPOSITE memories.
+    #[test]
+    fn antonym_detection_does_not_fire_on_agreement_or_unrelated_text() {
+        let a = "Prompt diversity monotonically hurts AIMO3 accuracy at temperature \
+                 0.6 and above on GPT-OSS-120B";
+        let same = "Prompt diversity monotonically hurts AIMO3 accuracy at temperature \
+                    0.6 and above on GPT-OSS-120B, confirmed twice";
+        assert!(
+            !super::appears_contradictory(a, same),
+            "two memories agreeing must not be flagged as contradictory"
+        );
+
+        let unrelated = "The dashboard accent colour improves legibility in dark mode";
+        assert!(
+            !super::appears_contradictory(a, unrelated),
+            "different subjects must not be flagged merely because antonyms appear"
+        );
+    }
 
     /// STAGE 5b's claim-vs-memory conflict gate was built on symmetric Jaccard,
     /// which divides by the UNION. A short claim can therefore never clear a 0.4

--- a/crates/vestige-mcp/src/tools/cross_reference.rs
+++ b/crates/vestige-mcp/src/tools/cross_reference.rs
@@ -371,190 +371,26 @@ fn generate_reasoning_chain(
 // (or vice versa). Previously we had wildcard entries like ("not ", "") that
 // fired on any asymmetric presence of "not " — matched millions of innocent
 // sentences ("FSRS-6 is not yet..." vs anything without the word "not").
-const NEGATION_PAIRS: &[(&str, &str)] = &[
-    ("don't", "do"),
-    ("never", "always"),
-    ("avoid", "use"),
-    ("wrong", "right"),
-    ("incorrect", "correct"),
-    ("deprecated", "recommended"),
-    ("outdated", "current"),
-    ("removed", "added"),
-    ("disabled", "enabled"),
-];
-
-/// Directional antonym pairs, used ONLY with the strict both-sides test below.
+/// Do two memories appear to assert incompatible things?
 ///
-/// These are deliberately NOT in NEGATION_PAIRS. That list is scanned for the
-/// asymmetric PRESENCE of its first element, which is safe for explicit negations
-/// ("never", "don't") but would over-fire badly on ordinary evaluative words:
-/// plenty of innocent memories say something "hurts" or is "slower" without
-/// contradicting anything.
+/// Thin wrapper over the shared detector in `vestige_core::advanced::contradiction`,
+/// which the WRITE path (`PredictionErrorGate::detect_contradiction`) now uses
+/// as well. These were two separate implementations of the same concept and
+/// they drifted: this side grew negation symmetry, antonym pairs and a
+/// divergence test while the write side kept a single directional negation
+/// scan. Retrieval-side contradiction protection can only protect a memory
+/// that survived ingestion, so the weaker copy guarding the door decided the
+/// outcome. One implementation now, with the only real difference between the
+/// call sites named by `SubjectIdentity`.
 ///
-/// Requiring one memory to contain one side and the other memory to contain the
-/// other side is a far stricter test, and it catches the class the negation scan
-/// structurally cannot: two memories asserting OPPOSITE DIRECTIONS about the same
-/// subject, with no negation word in either. That is the shape of the failure
-/// this system exists to prevent -- "prompt diversity HURTS accuracy" against
-/// "prompt diversity IMPROVES accuracy" contains no negation at all.
-const ANTONYM_PAIRS: &[(&str, &str)] = &[
-    ("hurts", "improves"),
-    ("hurt", "improved"),
-    ("degrades", "enhances"),
-    ("decreases", "increases"),
-    ("reduces", "raises"),
-    ("worse", "better"),
-    ("slower", "faster"),
-    ("fails", "succeeds"),
-    ("breaks", "fixes"),
-    ("unsafe", "safe"),
-    ("unstable", "stable"),
-    ("unsupported", "supported"),
-];
-
-const CORRECTION_SIGNALS: &[&str] = &[
-    "actually",
-    "correction",
-    "update:",
-    "updated:",
-    "fixed",
-    "was wrong",
-    "changed to",
-    "now uses",
-    "replaced by",
-    "superseded",
-    "no longer",
-    "instead of",
-    "switched to",
-    "migrated to",
-];
-
+/// Retrieval infers subject identity from the text alone, because a candidate
+/// pair here is drawn from thousands of unrelated memories.
 pub(crate) fn appears_contradictory(a: &str, b: &str) -> bool {
-    let a_lower = a.to_lowercase();
-    let b_lower = b.to_lowercase();
-
-    let a_words: std::collections::HashSet<&str> =
-        a_lower.split_whitespace().filter(|w| w.len() > 3).collect();
-    let b_words: std::collections::HashSet<&str> =
-        b_lower.split_whitespace().filter(|w| w.len() > 3).collect();
-    let shared_words = a_words.intersection(&b_words).count();
-
-    // Require ≥4 substantive shared words — two memories must be about the
-    // same thing, not merely brushing the same domain. Previous floor of 2
-    // flagged "FSRS-6 upgrade research sources" and "ARC-AGI-3 FSRS-6 v11
-    // fixes" as contradictions of "Vestige uses FSRS-6 with 21 parameters"
-    // because they all mention "FSRS-6" — different applications, same word.
-    if shared_words < 4 {
-        return false;
-    }
-
-    // Negation: one memory carries a negative stance ("don't", "never",
-    // "avoid", etc.) and the other doesn't. Combined with the shared_words
-    // ≥ 4 gate above, this means "same subject, opposite position." The
-    // wildcard `("not ", "")` and `("no longer", "")` entries were dropped
-    // from NEGATION_PAIRS specifically because "not" / "no longer" are too
-    // common in natural prose to indicate a stance flip without other
-    // signals.
-    for (neg, _opp) in NEGATION_PAIRS {
-        if (a_lower.contains(neg) && !b_lower.contains(neg))
-            || (b_lower.contains(neg) && !a_lower.contains(neg))
-        {
-            return true;
-        }
-    }
-
-    // Opposite-direction claims with NO negation word in either memory.
-    //
-    // The scan above keys off the asymmetric presence of an explicit negation,
-    // so it cannot see "X hurts accuracy" against "X improves accuracy" -- there
-    // is nothing negated in either. That is precisely the shape of the real-world
-    // failure this guard exists for: an authoritative finding and a fresh claim
-    // asserting opposite directions about the same subject.
-    //
-    // Both sides are required to be present, in opposite memories. That is much
-    // stricter than the asymmetric-presence test and is why these words can be
-    // checked at all: on their own, "hurts" or "slower" appear in plenty of
-    // memories that contradict nothing. Combined with the >= 4 shared substantive
-    // words gate above, this means "same subject, opposite direction".
-    for (neg, opp) in ANTONYM_PAIRS {
-        let a_neg = a_lower.contains(neg);
-        let b_neg = b_lower.contains(neg);
-        let a_opp = a_lower.contains(opp);
-        let b_opp = b_lower.contains(opp);
-        if (a_neg && b_opp && !b_neg && !a_opp) || (b_neg && a_opp && !a_neg && !b_opp) {
-            return true;
-        }
-    }
-    // Mutually exclusive VALUES for the same attribute.
-    //
-    // This is the most common real-world contradiction and neither test above can
-    // see it: "Priya holds a Bachelor degree in computer science from Leeds"
-    // against "Priya holds a Master of Science degree in computer science from
-    // Leeds" contains no negation and no antonym, yet both cannot be true. It is
-    // also the shape MemConflict is built to measure, where every published system
-    // scores poorly.
-    //
-    // The distinguishing signal is DIVERGENCE versus ELABORATION. If the two
-    // memories overlap heavily but NEITHER's substantive vocabulary is a subset of
-    // the other's, they are asserting different things in the same slot. If one IS
-    // a subset of the other, it is an elaboration ("works in Leeds" versus "works
-    // in Leeds and London") and must not be flagged.
-    //
-    // Requires a high overlap floor so this only fires on memories that are
-    // demonstrably about the same subject, and requires each side to contribute at
-    // least one distinctive term so trivial rewordings do not qualify.
-    {
-        // Strip surrounding punctuation before comparing. Without this, "X" and
-        // "X," are distinct tokens, so a strict elaboration (A plus two extra
-        // words) looks like mutual divergence and gets flagged as a conflict.
-        // Caught by antonym_detection_does_not_fire_on_agreement_or_unrelated_text.
-        let norm = |set: &std::collections::HashSet<&str>| -> std::collections::HashSet<String> {
-            set.iter()
-                .map(|w| {
-                    w.trim_matches(|c: char| !c.is_alphanumeric())
-                        .to_string()
-                })
-                .filter(|w| w.len() > 3)
-                .collect()
-        };
-        let a_words = norm(&a_words);
-        let b_words = norm(&b_words);
-        let shared = a_words.intersection(&b_words).count();
-        let union = a_words.union(&b_words).count();
-        let overlap = if union == 0 {
-            0.0
-        } else {
-            shared as f32 / union as f32
-        };
-        let a_only = a_words.difference(&b_words).count();
-        let b_only = b_words.difference(&a_words).count();
-        // Both sides distinctive => divergence, not elaboration.
-        let diverges = a_only > 0 && b_only > 0;
-        // Keep the divergence small relative to the shared core: two memories that
-        // merely touch the same topic will diverge in many terms, whereas a
-        // same-attribute conflict differs in only a few.
-        let small_divergence = (a_only + b_only) <= shared;
-        if overlap >= 0.6 && diverges && small_divergence {
-            return true;
-        }
-    }
-
-    // Correction signal: require ≥6 shared substantive words so we know the
-    // two memories are on the SAME subject, and require the signal to appear
-    // in exactly one of them (asymmetric — the memory with the correction
-    // marker is the one superseding the other). Previously fired on ANY
-    // signal in EITHER memory, which caught every bug-fix memory against
-    // every related memory as a pairwise contradiction.
-    if shared_words >= 6 {
-        for signal in CORRECTION_SIGNALS {
-            let in_a = a_lower.contains(signal);
-            let in_b = b_lower.contains(signal);
-            if in_a != in_b {
-                return true;
-            }
-        }
-    }
-    false
+    vestige_core::advanced::contradiction::appears_contradictory(
+        a,
+        b,
+        vestige_core::advanced::contradiction::SubjectIdentity::FromTextOverlap,
+    )
 }
 
 /// What fraction of the QUERY's substantive words appear in `content`?
@@ -1364,7 +1200,8 @@ mod tests {
     #[test]
     fn elaboration_is_not_flagged_as_contradiction() {
         let base = "Priya works in the Leeds office on the payments platform team";
-        let more = "Priya works in the Leeds office on the payments platform team and mentors interns";
+        let more =
+            "Priya works in the Leeds office on the payments platform team and mentors interns";
         assert!(
             !super::appears_contradictory(base, more),
             "a superset elaboration must not be a contradiction"

--- a/crates/vestige-mcp/src/tools/search_unified.rs
+++ b/crates/vestige-mcp/src/tools/search_unified.rs
@@ -460,10 +460,42 @@ pub async fn execute(
     // ====================================================================
     // STAGE 1: Hybrid search with Nx over-fetch for reranking pool
     // ====================================================================
+    // Candidate depth fed to the cross-encoder reranker.
+    //
+    // The reranker's own configuration declares DEFAULT_RETRIEVAL_COUNT = 50
+    // (crates/vestige-core/src/search/reranker.rs:23), but this call path never
+    // gave it 50. At the default limit of 10 the old multipliers produced 10
+    // candidates in precise mode and 30 in balanced -- so precise mode ran a
+    // cross-encoder over a pool small enough that it could only REORDER what
+    // keyword+vector already found, never rescue anything they ranked poorly.
+    // That is most of the value of having a reranker at all.
+    //
+    // T2-RAGBench (arXiv 2604.01733, 23,088 queries) measured the depth curve:
+    // 20 candidates -> Recall@5 0.458, 50 -> 0.826, 100 -> 0.888. There is a
+    // cliff below 50. These multipliers put balanced at 50 and precise at 30.
+    //
+    // Cost is latency only: more pairs scored, no extra DB round trips beyond
+    // the larger fetch, and the .min(100) cap below still bounds the load.
+    // CAVEAT: that curve is one benchmark in one domain (financial text and
+    // tables). The direction is well supported; the exact constants should be
+    // re-validated against Vestige's own eval harness before being treated as
+    // tuned rather than merely better.
+    // Measured on a real 2,926-memory store, 7 queries, median latency:
+    //   balanced 3->5:  3399ms -> 4705ms  (+38%)
+    //   precise  1->3:  1472ms -> 2983ms  (+103%)
+    //
+    // Balanced takes the depth increase: it is the quality mode, the reranker's
+    // own config asks for 50 candidates, and T2-RAGBench measures a recall cliff
+    // below that depth (20 candidates -> Recall@5 0.458, 50 -> 0.826).
+    //
+    // Precise stays at 1. It is documented as the fast, token-efficient path, and
+    // doubling its latency to buy unmeasured recall is the wrong trade for a mode
+    // whose entire purpose is speed. Revisit once the eval harness can price the
+    // recall gain against that cost instead of assuming it.
     let overfetch_multiplier = match retrieval_mode {
-        "precise" => 1,    // No overfetch — return exactly what's asked
-        "exhaustive" => 5, // Deep overfetch for maximum recall
-        _ => 3,            // Balanced default
+        "precise" => 1,    // unchanged: speed is this mode's contract
+        "exhaustive" => 5, // unchanged
+        _ => 5,            // balanced: 50 @ limit=10, matching the reranker's config
     };
     // When a tag_prefix OR source filter is requested, double the overfetch
     // (capped at the same 100 ceiling) so the post-filter has enough headroom

--- a/crates/vestige-mcp/src/tools/search_unified.rs
+++ b/crates/vestige-mcp/src/tools/search_unified.rs
@@ -1129,10 +1129,6 @@ fn is_literal_query(query: &str) -> bool {
 /// string value starts with `prefix`. Empty prefix matches every result with
 /// at least one tag (and never matches a tagless result).
 ///
-/// Case-sensitive by design: the existing tag-match semantics in
-/// `memory_timeline` / `export` / `gc` are exact-match (case-sensitive), so
-/// keeping this consistent avoids surprise. Operators wanting case-insensitive
-/// prefix-search should normalize tags at ingest time.
 /// Case-INSENSITIVE tag prefix match.
 ///
 /// Reported from production (2026-08-15): filtering on `Reflection` returned zero

--- a/crates/vestige-mcp/src/tools/search_unified.rs
+++ b/crates/vestige-mcp/src/tools/search_unified.rs
@@ -746,6 +746,10 @@ pub async fn execute(
     // Skipped in precise mode (no need) and exhaustive mode (want all results)
     // ====================================================================
     let mut suppressed_count = 0_usize;
+    // Memories that WOULD have been suppressed by retrieval competition but were
+    // spared because they are the dissenting side of a live contradiction. These
+    // are surfaced so the caller can see it was shown the other side.
+    let mut contradiction_protected: Vec<String> = Vec::new();
     if retrieval_mode == "balanced"
         && filtered_results.len() > 1
         && let Ok(mut cog) = cognitive.try_lock()
@@ -759,8 +763,72 @@ pub async fn execute(
             })
             .collect();
         if let Some(result) = cog.competition_mgr.run_competition(&candidates, 0.7) {
-            // Apply suppression: losers get penalized
-            for suppressed_id in &result.suppressed_ids {
+            // The winner's text, needed to test whether a loser CONTRADICTS it
+            // rather than merely resembling it.
+            let winner_content = filtered_results
+                .iter()
+                .find(|r| r.node.id == result.winner_id)
+                .map(|r| r.node.content.clone());
+            let winner_live = filtered_results
+                .iter()
+                .find(|r| r.node.id == result.winner_id)
+                .map(|r| r.node.is_currently_valid())
+                .unwrap_or(false);
+
+            // Apply suppression: losers get penalized, EXCEPT the losing side of
+            // a live contradiction.
+            //
+            // Retrieval-induced forgetting suppresses the loser of a competition
+            // between SIMILAR memories, and a contradiction is near-identical text
+            // with opposite meaning -- "Never use X on Windows" against a stored
+            // "Always use X on Windows" measures 0.928 cosine here. Contradicting
+            // memories are therefore not merely vulnerable to this penalty, they
+            // are the most suppressible class of memory in the store. Every time
+            // an agent retrieves and acts on one side, the evidence that would
+            // correct it gets demoted and can fall out of the returned window.
+            // That is precisely how a memory system buries its own correction.
+            //
+            // Anderson & McCulloch (1999), JEP:LMC 25:608-629, "Integration as a
+            // general boundary condition on retrieval-induced forgetting": material
+            // the rememberer has INTEGRATED shows little or no RIF. A detected
+            // contradiction pair is integrated by construction -- there is an
+            // explicit epistemic edge between the two. Exempting it is the faithful
+            // reading of the mechanism, not a special case bolted onto it.
+            //
+            // LIVE-vs-LIVE ONLY. If either side is expired or superseded, the
+            // penalty still applies. Protecting a pair whose loser has valid_until
+            // set would re-float a fact that is deliberately dead -- reintroducing
+            // the as-of resurrection bug fixed in #173.
+            for (suppressed_id, similarity) in result
+                .suppressed_ids
+                .iter()
+                .zip(result.suppressed_similarities.iter())
+            {
+                let protected = match (&winner_content, winner_live) {
+                    (Some(winner_text), true) => filtered_results
+                        .iter()
+                        .find(|r| &r.node.id == suppressed_id)
+                        .map(|r| {
+                            r.node.is_currently_valid()
+                                && crate::tools::cross_reference::appears_contradictory(
+                                    winner_text,
+                                    &r.node.content,
+                                )
+                        })
+                        .unwrap_or(false),
+                    _ => false,
+                };
+                if protected {
+                    tracing::debug!(
+                        winner = %result.winner_id,
+                        dissent = %suppressed_id,
+                        similarity,
+                        "contradiction-protected: withholding retrieval-competition \
+                         suppression from the losing side of a live contradiction"
+                    );
+                    contradiction_protected.push(suppressed_id.clone());
+                    continue;
+                }
                 if let Some(r) = filtered_results
                     .iter_mut()
                     .find(|r| &r.node.id == suppressed_id)
@@ -954,6 +1022,21 @@ pub async fn execute(
         response["contextReinstatement"] = ri;
     }
     // Include competition stats
+    // Dissent slot. When retrieval competition would have demoted the losing side
+    // of a live contradiction and we withheld that penalty, say so explicitly.
+    // The value of protecting the dissenting memory is only realised if the caller
+    // can SEE that a contradiction was in play -- otherwise the agent reads a
+    // slightly-reordered list and never learns it was shown two incompatible
+    // claims. This makes "the agent was presented with the other side" an
+    // auditable fact rather than an inference.
+    if !contradiction_protected.is_empty() {
+        response["contradictionProtected"] = serde_json::json!({
+            "memoryIds": contradiction_protected,
+            "notice": "These memories contradict a higher-ranked result and were \
+                       exempted from retrieval-competition suppression. Read both \
+                       sides before acting; do not treat the top result as settled.",
+        });
+    }
     if suppressed_count > 0 {
         response["competitionSuppressed"] = serde_json::json!(suppressed_count);
     }
@@ -1018,8 +1101,27 @@ fn is_literal_query(query: &str) -> bool {
 /// `memory_timeline` / `export` / `gc` are exact-match (case-sensitive), so
 /// keeping this consistent avoids surprise. Operators wanting case-insensitive
 /// prefix-search should normalize tags at ingest time.
+/// Case-INSENSITIVE tag prefix match.
+///
+/// Reported from production (2026-08-15): filtering on `Reflection` returned zero
+/// results while `reflection` returned the expected set, with no error and no
+/// warning. One capital letter silently blanked an entire recall. For a memory
+/// system that is the worst possible failure shape -- the caller cannot tell an
+/// empty result caused by a typo from an empty result meaning "you never learned
+/// this", so a silent zero reads as confident absence.
+///
+/// Everything adjacent already normalises: `query_time_range` compares node_type
+/// with `LOWER(node_type) = LOWER(?)`, and the storage-layer tag filter relies on
+/// SQL `LIKE`, which is case-insensitive for ASCII by default. This Rust-side
+/// filter was the one path that did not, so identical-looking queries behaved
+/// differently depending on which code path served them.
+///
+/// ASCII-lowercase specifically, matching SQLite's `LIKE` semantics, so the two
+/// paths agree rather than diverging in a new way for non-ASCII tags.
 fn tags_match_prefix(tags: &[String], prefix: &str) -> bool {
-    tags.iter().any(|t| t.starts_with(prefix))
+    let needle = prefix.to_ascii_lowercase();
+    tags.iter()
+        .any(|t| t.to_ascii_lowercase().starts_with(&needle))
 }
 
 /// Retrieval namespace policy. Every ordinary query is scoped, including a
@@ -2412,8 +2514,21 @@ mod tests {
         // wildcard" semantics — a tagless memory has no tag-prefix to satisfy.
         assert!(tags_match_prefix(&with_meeting, ""));
         assert!(!tags_match_prefix(&tagless, ""));
-        // Case-sensitive (consistent with existing exact-tag matching).
-        assert!(!tags_match_prefix(&with_meeting, "Meeting:"));
+        // Case-INSENSITIVE. This assertion previously required the opposite,
+        // justified as "consistent with existing exact-tag matching" -- but that
+        // premise was false. The storage-layer tag filter is
+        // `tags LIKE '%"tag"%'`, and SQLite's LIKE is case-insensitive for ASCII
+        // by default (verified directly: both '%"reflection"%' and
+        // '%"Reflection"%' match a stored "reflection"). So this Rust-side filter
+        // was the ONE path that was case-sensitive, and it disagreed with the
+        // SQL path it claimed to be consistent with.
+        //
+        // A user hit this in production on 2026-08-15: filtering on `Reflection`
+        // returned zero results, `reflection` returned the expected set, and
+        // nothing reported an error. For a memory system a silent zero is the
+        // worst possible answer -- it is indistinguishable from "you never
+        // learned this".
+        assert!(tags_match_prefix(&with_meeting, "Meeting:"));
         // Prefix must match from the start, not anywhere in the tag value.
         assert!(!tags_match_prefix(&with_meeting, "standup"));
     }
@@ -2867,5 +2982,26 @@ mod tests {
         if let Some(first) = value["results"].as_array().and_then(|a| a.first()) {
             assert!(first.get("createdAt").is_some(), "default keeps timestamps");
         }
+    }
+}
+
+#[cfg(test)]
+mod tag_case_tests {
+    use super::tags_match_prefix;
+
+    /// Reported 2026-08-15: a capital letter in a tag filter silently returned
+    /// zero results. A memory system must never make "you typed it differently"
+    /// indistinguishable from "you never learned this".
+    #[test]
+    fn tag_prefix_match_ignores_case_in_both_directions() {
+        let stored = vec!["reflection".to_string(), "vestige".to_string()];
+        assert!(tags_match_prefix(&stored, "Reflection"), "capitalised query must match");
+        assert!(tags_match_prefix(&stored, "reflection"), "lowercase query must still match");
+        assert!(tags_match_prefix(&stored, "REFLECT"), "shouty prefix must match");
+
+        let stored_caps = vec!["Reflection".to_string()];
+        assert!(tags_match_prefix(&stored_caps, "reflection"), "capitalised STORED tag must match");
+
+        assert!(!tags_match_prefix(&stored, "unrelated"), "a genuine miss must still miss");
     }
 }

--- a/crates/vestige-mcp/src/tools/search_unified.rs
+++ b/crates/vestige-mcp/src/tools/search_unified.rs
@@ -96,7 +96,7 @@ pub fn schema() -> Value {
             },
             "tag_prefix": {
                 "type": "string",
-                "description": "Optional tag-prefix filter. When set, only results carrying at least one tag whose value starts with this prefix are returned (case-sensitive). Example: tag_prefix=\"meeting:\" matches memories tagged 'meeting:standup', 'meeting:1-on-1', etc. Applied as a post-filter; combine with a larger 'limit' if you expect heavy thinning."
+                "description": "Optional tag-prefix filter. When set, only results carrying at least one tag whose value starts with this prefix are returned (case-insensitive). Example: tag_prefix=\"meeting:\" matches memories tagged 'meeting:standup', 'meeting:1-on-1', etc. Applied as a post-filter; combine with a larger 'limit' if you expect heavy thinning."
             },
             "scope": {
                 "type": "string",
@@ -3027,13 +3027,28 @@ mod tag_case_tests {
     #[test]
     fn tag_prefix_match_ignores_case_in_both_directions() {
         let stored = vec!["reflection".to_string(), "vestige".to_string()];
-        assert!(tags_match_prefix(&stored, "Reflection"), "capitalised query must match");
-        assert!(tags_match_prefix(&stored, "reflection"), "lowercase query must still match");
-        assert!(tags_match_prefix(&stored, "REFLECT"), "shouty prefix must match");
+        assert!(
+            tags_match_prefix(&stored, "Reflection"),
+            "capitalised query must match"
+        );
+        assert!(
+            tags_match_prefix(&stored, "reflection"),
+            "lowercase query must still match"
+        );
+        assert!(
+            tags_match_prefix(&stored, "REFLECT"),
+            "shouty prefix must match"
+        );
 
         let stored_caps = vec!["Reflection".to_string()];
-        assert!(tags_match_prefix(&stored_caps, "reflection"), "capitalised STORED tag must match");
+        assert!(
+            tags_match_prefix(&stored_caps, "reflection"),
+            "capitalised STORED tag must match"
+        );
 
-        assert!(!tags_match_prefix(&stored, "unrelated"), "a genuine miss must still miss");
+        assert!(
+            !tags_match_prefix(&stored, "unrelated"),
+            "a genuine miss must still miss"
+        );
     }
 }

--- a/crates/vestige-mcp/tests/e2e_real_binary.rs
+++ b/crates/vestige-mcp/tests/e2e_real_binary.rs
@@ -108,7 +108,7 @@ impl Server {
     /// which makes any test of it load-dependent. See the note on
     /// [`contradictions_are_returned_intact_and_flagged_as_protected`].
     fn spawn(data_dir: &Path) -> Self {
-        let mut command = Command::new(env!("CARGO_BIN_EXE_vestige-mcp"));
+        let mut command = Command::new(server_binary());
         command
             .env("VESTIGE_DATA_DIR", data_dir)
             .env("VESTIGE_DASHBOARD_ENABLED", "false")
@@ -439,6 +439,42 @@ impl Drop for Server {
 }
 
 /// A temporary Vestige data directory.
+/// A private copy of the server binary, made once per test process.
+///
+/// `CARGO_BIN_EXE_vestige-mcp` is the correct path and Cargo guarantees the
+/// binary is built before this test runs. It does NOT guarantee the file stays
+/// in place: under `cargo test --workspace` the binary at `target/<profile>/`
+/// can be relinked while these tests are already running, and a spawn landing
+/// in that window fails with a bare `NotFound` that reads like a missing
+/// build. Observed once in a full workspace run, never when this suite runs
+/// alone, which is exactly the signature of a race against the build directory
+/// rather than a defect in the product.
+///
+/// Copying once into this process's own temp directory removes the race
+/// instead of retrying around it, so a `NotFound` from here again would mean
+/// something genuinely wrong rather than a known flake.
+fn server_binary() -> &'static Path {
+    static BINARY: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+    BINARY.get_or_init(|| {
+        let source = Path::new(env!("CARGO_BIN_EXE_vestige-mcp"));
+        // Leaked deliberately: this must outlive every test in the process, and
+        // the OS reclaims it when the run ends.
+        let dir = Box::leak(Box::new(
+            tempfile::tempdir().expect("temporary directory for the server binary"),
+        ));
+        let destination = dir.path().join("vestige-mcp");
+        std::fs::copy(source, &destination)
+            .unwrap_or_else(|error| panic!("copy {} for the test run: {error}", source.display()));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&destination, std::fs::Permissions::from_mode(0o755))
+                .expect("make the copied server executable");
+        }
+        destination
+    })
+}
+
 fn data_dir() -> tempfile::TempDir {
     tempfile::tempdir().expect("temporary Vestige data directory")
 }

--- a/crates/vestige-mcp/tests/e2e_real_binary.rs
+++ b/crates/vestige-mcp/tests/e2e_real_binary.rs
@@ -1887,16 +1887,16 @@ fn tag_prefix_filtering_is_case_insensitive_on_the_hybrid_path() {
 /// | … PostgreSQL 14 … | … PostgreSQL 16 … | reinforce | 0.940 |
 /// | Priya holds a Bachelor degree … | Priya holds a Master of Science degree … | reinforce | 0.976 |
 ///
-/// The richer detector in
-/// `crates/vestige-mcp/src/tools/cross_reference.rs::appears_contradictory`
-/// already handles every one of these shapes — it has explicit unit tests for
-/// the antonym and Bachelor/Master cases — but it is only consulted at
-/// RETRIEVAL time. The retrieval-side contradiction protection can only protect
-/// memories that made it into the store; here the dissent is destroyed at
-/// ingest, one stage earlier, so that guard never gets the chance to run.
+/// That was the pre-fix state: the richer retrieval-side detector could see
+/// every one of these shapes, but the write path had its own blind copy, and
+/// retrieval-side protection cannot protect a memory destroyed at ingest one
+/// stage earlier. Both paths now consult the shared detector in
+/// `vestige-core/src/advanced/contradiction.rs`; this test locks the write
+/// path's behaviour over the real binary.
 #[test]
-#[ignore = "FAILS: documents a real ingest-gate defect (corrections are swallowed). \
-            Also needs the embedding runtime. Run with --ignored to reproduce."]
+#[ignore = "loads the real embedding runtime (~670 MB model); run with --ignored. \
+            (Documented the ingest-gate defect before the shared-detector fix; \
+            it now passes and guards the regression.)"]
 fn correction_must_not_be_swallowed_by_the_ingest_gate() {
     const NEGATIVE: &str =
         "Never use prompt diversity when the sampling temperature exceeds zero point six";

--- a/crates/vestige-mcp/tests/e2e_real_binary.rs
+++ b/crates/vestige-mcp/tests/e2e_real_binary.rs
@@ -1,0 +1,2104 @@
+//! Real-binary end-to-end regression suite.
+//!
+//! # Why this file exists
+//!
+//! The repository has ~281 e2e tests, and they run against mocks
+//! (`tests/e2e/src/mocks/mock_embedding.rs`) inside the process. Before this
+//! file, exactly one test spawned the shipped executable
+//! (`crates/vestige-mcp/tests/stdio_shutdown.rs`). Every defect worth catching
+//! at the seam between "the code is correct" and "the product works" lives in
+//! that gap: process startup, SQLite migration against a real file, integrity
+//! repair on a damaged store, JSON-RPC framing over a real pipe, and the actual
+//! embedding runtime being loaded rather than stubbed.
+//!
+//! Every test here drives `target/<profile>/vestige-mcp` as a child process and
+//! speaks line-framed JSON-RPC over its stdin/stdout, exactly as an MCP client
+//! does.
+//!
+//! # Running it
+//!
+//! ```sh
+//! # Fast suite. No model load, no network. This is what CI runs.
+//! cargo test -p vestige-mcp --test e2e_real_binary
+//!
+//! # Full suite, including tests that need the real embedding runtime.
+//! cargo test -p vestige-mcp --test e2e_real_binary -- --ignored
+//! ```
+//!
+//! # The embedding trap
+//!
+//! `smart_ingest` and `recall` behave differently before the ONNX embedding
+//! model finishes loading: ingest returns `hasEmbedding: false` and retrieval
+//! silently degrades to a keyword-only path. A test that ingests immediately
+//! after `initialize` and then asserts on semantic behaviour is measuring the
+//! fallback and proves nothing.
+//!
+//! Rather than sleeping blindly, [`Server::wait_for_embeddings`] blocks on the
+//! server's own readiness line on stderr, and [`Server::ingest_embedded`]
+//! additionally asserts `hasEmbedding == true` on every write. A test cannot
+//! silently drift onto the degraded path: it fails instead.
+//!
+//! Tests that genuinely need that runtime are `#[ignore]`d, because on a cold
+//! machine the first run downloads a ~670 MB model. Tests whose subject is
+//! embedding-independent by construction (FTS/BM25 keyword retrieval, SQLite
+//! integrity, migration, JSON-RPC framing, purge, suppression, durability) run
+//! by default and use [`Server::ingest_keyword_only`], which documents that
+//! choice at the call site.
+//!
+//! # Known product defect documented here
+//!
+//! [`correction_must_not_be_swallowed_by_the_ingest_gate`] is `#[ignore]`d
+//! because it FAILS against the current build. See its doc comment; the defect
+//! was not fixed here on purpose.
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, channel};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use rusqlite::Connection;
+use serde_json::{Value, json};
+
+// ============================================================================
+// Harness
+// ============================================================================
+
+/// How long to wait for a single JSON-RPC response before declaring a hang.
+/// Deliberately finite: "the server hung" must be a test failure, never a
+/// wedged CI job.
+const RPC_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// How long to wait for the embedding runtime. Generous because the first run
+/// on a cold machine downloads the model; warm it is well under a second.
+const EMBEDDING_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// The server's own readiness line. Waiting for this is strictly better than
+/// sleeping: it is the exact event we care about, and it fails loudly if the
+/// runtime never comes up instead of quietly proceeding on the fallback path.
+const EMBEDDINGS_READY: &str = "Legacy Nomic embedding service initialized successfully";
+
+/// A running `vestige-mcp` child process plus its stdio plumbing.
+///
+/// Reader threads drain stdout and stderr so the child can never block on a
+/// full pipe, and every read is bounded by a timeout. [`Drop`] kills the child,
+/// so a panicking test cannot leak a process.
+struct Server {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    stdout: Receiver<String>,
+    stderr: Arc<Mutex<Vec<String>>>,
+    next_id: u64,
+}
+
+impl Server {
+    /// Spawn the shipped binary against `data_dir`.
+    ///
+    /// The environment is pinned so a developer's own Vestige configuration can
+    /// never leak into a test: no dashboard, no HTTP transport, no inherited
+    /// data directory.
+    ///
+    /// `VESTIGE_AUTOPILOT_ENABLED=0` matters more than it looks. The autopilot
+    /// subscribes to `MemoryCreated` and takes a *blocking* `cognitive.lock()`
+    /// per event, while `recall`'s retrieval-competition stage takes a
+    /// *non-blocking* `try_lock()`. Leaving it on means a burst of ingests
+    /// followed immediately by a recall can silently skip that whole stage,
+    /// which makes any test of it load-dependent. See the note on
+    /// [`contradictions_are_returned_intact_and_flagged_as_protected`].
+    fn spawn(data_dir: &Path) -> Self {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_vestige-mcp"));
+        command
+            .env("VESTIGE_DATA_DIR", data_dir)
+            .env("VESTIGE_DASHBOARD_ENABLED", "false")
+            .env("VESTIGE_HTTP_ENABLED", "0")
+            .env("VESTIGE_AUTOPILOT_ENABLED", "0")
+            .env_remove("RUST_LOG")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = command.spawn().expect("spawn vestige-mcp");
+
+        let stdin = child.stdin.take().expect("child stdin");
+        let raw_stdout = child.stdout.take().expect("child stdout");
+        let raw_stderr = child.stderr.take().expect("child stderr");
+
+        let (tx, stdout) = channel();
+        std::thread::spawn(move || {
+            for line in BufReader::new(raw_stdout).lines() {
+                match line {
+                    Ok(line) => {
+                        if tx.send(line).is_err() {
+                            return;
+                        }
+                    }
+                    Err(_) => return,
+                }
+            }
+        });
+
+        let stderr = Arc::new(Mutex::new(Vec::new()));
+        {
+            let sink = Arc::clone(&stderr);
+            std::thread::spawn(move || {
+                for line in BufReader::new(raw_stderr).lines().map_while(Result::ok) {
+                    if let Ok(mut sink) = sink.lock() {
+                        sink.push(line);
+                    }
+                }
+            });
+        }
+
+        Self {
+            child,
+            stdin: Some(stdin),
+            stdout,
+            stderr,
+            next_id: 0,
+        }
+    }
+
+    /// Everything the server has written to stderr so far.
+    fn stderr_lines(&self) -> Vec<String> {
+        self.stderr.lock().expect("stderr sink").clone()
+    }
+
+    /// Every stderr line that the tracing subscriber marked as an error.
+    fn error_lines(&self) -> Vec<String> {
+        self.stderr_lines()
+            .into_iter()
+            .filter(|line| line.contains("ERROR"))
+            .collect()
+    }
+
+    fn is_running(&mut self) -> bool {
+        matches!(self.child.try_wait(), Ok(None))
+    }
+
+    fn write_line(&mut self, line: &str) {
+        let stdin = self.stdin.as_mut().expect("stdin still open");
+        stdin
+            .write_all(line.as_bytes())
+            .and_then(|()| stdin.write_all(b"\n"))
+            .and_then(|()| stdin.flush())
+            .unwrap_or_else(|error| {
+                panic!(
+                    "writing to vestige-mcp stdin failed ({error}); the server probably died. \
+                     stderr: {:?}",
+                    self.stderr_lines()
+                )
+            });
+    }
+
+    /// Read one line of output, failing the test rather than blocking forever.
+    fn read_line(&mut self) -> String {
+        match self.stdout.recv_timeout(RPC_TIMEOUT) {
+            Ok(line) => line,
+            Err(RecvTimeoutError::Timeout) => panic!(
+                "vestige-mcp produced no response within {RPC_TIMEOUT:?} (hang). stderr: {:?}",
+                self.stderr_lines()
+            ),
+            Err(RecvTimeoutError::Disconnected) => panic!(
+                "vestige-mcp closed stdout without responding (crash?). stderr: {:?}",
+                self.stderr_lines()
+            ),
+        }
+    }
+
+    /// Assert that the server sends nothing at all within `window`. Used to
+    /// prove that notifications and blank lines produce no response.
+    fn expect_silence(&mut self, window: Duration) {
+        if let Ok(unexpected) = self.stdout.recv_timeout(window) {
+            panic!("expected no response, got: {unexpected}");
+        }
+    }
+
+    /// Send a raw line and read one response line. For malformed-input tests.
+    fn raw_roundtrip(&mut self, line: &str) -> Value {
+        self.write_line(line);
+        let response = self.read_line();
+        serde_json::from_str(&response)
+            .unwrap_or_else(|error| panic!("server emitted non-JSON {response:?}: {error}"))
+    }
+
+    fn request(&mut self, method: &str, params: Option<Value>) -> Value {
+        self.next_id += 1;
+        let id = self.next_id;
+        let mut message = json!({ "jsonrpc": "2.0", "id": id, "method": method });
+        if let Some(params) = params {
+            message["params"] = params;
+        }
+        let response = self.raw_roundtrip(&message.to_string());
+        assert_eq!(
+            response["id"],
+            json!(id),
+            "response id must match the request id (framing desync): {response}"
+        );
+        assert_eq!(
+            response["jsonrpc"],
+            json!("2.0"),
+            "bad envelope: {response}"
+        );
+        response
+    }
+
+    fn notify(&mut self, method: &str, params: Option<Value>) {
+        let mut message = json!({ "jsonrpc": "2.0", "method": method });
+        if let Some(params) = params {
+            message["params"] = params;
+        }
+        self.write_line(&message.to_string());
+    }
+
+    fn result(&mut self, method: &str, params: Option<Value>) -> Value {
+        let response = self.request(method, params);
+        assert!(
+            response.get("error").is_none(),
+            "{method} returned an error: {response}"
+        );
+        response["result"].clone()
+    }
+
+    fn error(&mut self, method: &str, params: Option<Value>) -> Value {
+        let response = self.request(method, params);
+        assert!(
+            response.get("result").is_none(),
+            "{method} unexpectedly succeeded: {response}"
+        );
+        response["error"].clone()
+    }
+
+    fn handshake(&mut self) -> Value {
+        let result = self.result(
+            "initialize",
+            Some(json!({
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": { "name": "e2e-real-binary", "version": "1" },
+            })),
+        );
+        self.notify("notifications/initialized", None);
+        result
+    }
+
+    /// Block until the embedding runtime reports ready.
+    ///
+    /// This is the honest replacement for "sleep 45 seconds and hope": it waits
+    /// for the exact event, returns as soon as it happens, and panics with the
+    /// server's own log if it never does.
+    fn wait_for_embeddings(&mut self) {
+        let deadline = Instant::now() + EMBEDDING_TIMEOUT;
+        loop {
+            if self
+                .stderr_lines()
+                .iter()
+                .any(|line| line.contains(EMBEDDINGS_READY))
+            {
+                return;
+            }
+            assert!(
+                self.is_running(),
+                "vestige-mcp exited before the embedding runtime came up. stderr: {:?}",
+                self.stderr_lines()
+            );
+            if Instant::now() >= deadline {
+                panic!(
+                    "embedding runtime never became ready within {EMBEDDING_TIMEOUT:?}. \
+                     stderr: {:?}",
+                    self.stderr_lines()
+                );
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    /// Call a tool and return its structured payload.
+    ///
+    /// Vestige reports tool-level failures as `isError: true` with a JSON body,
+    /// not as a JSON-RPC error, so this returns the body either way and lets
+    /// the caller decide.
+    fn call_tool(&mut self, name: &str, arguments: Value) -> Value {
+        let result = self.result(
+            "tools/call",
+            Some(json!({ "name": name, "arguments": arguments })),
+        );
+        if let Some(structured) = result.get("structuredContent") {
+            return structured.clone();
+        }
+        let text = result["content"][0]["text"]
+            .as_str()
+            .unwrap_or_else(|| panic!("tool {name} returned no text content: {result}"));
+        serde_json::from_str(text).unwrap_or_else(|_| json!({ "raw": text }))
+    }
+
+    fn call_tool_ok(&mut self, name: &str, arguments: Value) -> Value {
+        let value = self.call_tool(name, arguments);
+        assert!(value.get("error").is_none(), "tool {name} failed: {value}");
+        value
+    }
+
+    /// Ingest a memory whose retrieval is exercised only through keyword/FTS
+    /// paths, so the embedding runtime is irrelevant to the assertion.
+    fn ingest_keyword_only(&mut self, content: &str, tags: &[&str]) -> String {
+        self.ingest_inner(content, tags, false)
+    }
+
+    /// Ingest a memory and assert the real embedding runtime produced a vector.
+    ///
+    /// This is the guard against silently testing the degraded no-embedding
+    /// path: if the model is not loaded, `hasEmbedding` is `false` and the test
+    /// fails here rather than producing a meaningless green.
+    fn ingest_embedded(&mut self, content: &str, tags: &[&str]) -> String {
+        self.ingest_inner(content, tags, true)
+    }
+
+    fn ingest_inner(&mut self, content: &str, tags: &[&str], require_embedding: bool) -> String {
+        let value = self.call_tool_ok(
+            "smart_ingest",
+            json!({ "content": content, "tags": tags, "forceCreate": true }),
+        );
+        assert_eq!(
+            value["success"],
+            json!(true),
+            "smart_ingest failed for {content:?}: {value}"
+        );
+        if require_embedding {
+            assert_eq!(
+                value["hasEmbedding"],
+                json!(true),
+                "the embedding runtime was not actually used for {content:?}; this test would \
+                 have measured the degraded keyword-only fallback. Response: {value}"
+            );
+        }
+        value["nodeId"]
+            .as_str()
+            .unwrap_or_else(|| panic!("smart_ingest returned no nodeId: {value}"))
+            .to_string()
+    }
+
+    /// Run `recall` and return the result ids in rank order.
+    fn recall_ids(&mut self, arguments: Value) -> Vec<String> {
+        let value = self.call_tool_ok("recall", arguments);
+        value["results"]
+            .as_array()
+            .map(|results| {
+                results
+                    .iter()
+                    .filter_map(|r| r["id"].as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn memory_found(&mut self, id: &str) -> bool {
+        self.call_tool("memory", json!({ "action": "get", "id": id }))["found"] == json!(true)
+    }
+
+    /// Close stdin and wait for a clean exit, the way an MCP client shuts a
+    /// stdio server down.
+    fn shutdown(mut self) {
+        self.stdin.take();
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            match self.child.try_wait().expect("poll vestige-mcp") {
+                Some(status) => {
+                    assert!(
+                        status.success(),
+                        "stdin EOF must be a clean shutdown, got {status}. stderr: {:?}",
+                        self.stderr_lines()
+                    );
+                    return;
+                }
+                None if Instant::now() >= deadline => {
+                    let _ = self.child.kill();
+                    let _ = self.child.wait();
+                    panic!("vestige-mcp did not exit within 30s of stdin EOF");
+                }
+                None => std::thread::sleep(Duration::from_millis(20)),
+            }
+        }
+    }
+
+    /// Give up on a server we expect to be dead or that we no longer need.
+    fn abandon(mut self) {
+        self.stdin.take();
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        // Guaranteed cleanup even when a test panics mid-conversation.
+        self.stdin.take();
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// A temporary Vestige data directory.
+fn data_dir() -> tempfile::TempDir {
+    tempfile::tempdir().expect("temporary Vestige data directory")
+}
+
+fn db_path(dir: &Path) -> PathBuf {
+    dir.join("vestige.db")
+}
+
+/// Open the store directly. Only ever called while no server is running.
+fn open_db(dir: &Path) -> Connection {
+    Connection::open(db_path(dir)).expect("open vestige.db directly")
+}
+
+fn quick_check(conn: &Connection) -> Vec<String> {
+    let mut statement = conn.prepare("PRAGMA quick_check").expect("prepare");
+    let rows = statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .expect("quick_check");
+    rows.map(|row| row.expect("quick_check row")).collect()
+}
+
+fn foreign_key_violations(conn: &Connection) -> i64 {
+    conn.query_row("SELECT COUNT(*) FROM pragma_foreign_key_check", [], |row| {
+        row.get(0)
+    })
+    .expect("foreign_key_check")
+}
+
+fn schema_version(conn: &Connection) -> i64 {
+    conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_version",
+        [],
+        |row| row.get(0),
+    )
+    .expect("schema_version")
+}
+
+/// Assert the store on disk is healthy: no corruption, no dangling children.
+fn assert_store_is_healthy(dir: &Path) {
+    let conn = open_db(dir);
+    assert_eq!(
+        quick_check(&conn),
+        vec!["ok".to_string()],
+        "store failed PRAGMA quick_check"
+    );
+    assert_eq!(
+        foreign_key_violations(&conn),
+        0,
+        "store has dangling foreign keys"
+    );
+}
+
+/// Put the review gate into `fast` mode.
+///
+/// In the default `risk_gated` mode a destructive or suppressive mutation is
+/// intercepted and turned into a pending Memory PR rather than applied, so a
+/// test that wants to observe the mutation itself has to opt out of review
+/// first. See [`purge_with_confirm_is_review_gated_by_default`], which pins the
+/// default behaviour.
+fn disable_review_gate(dir: &Path) {
+    std::fs::write(dir.join("review_mode.json"), r#"{"mode":"fast"}"#)
+        .expect("write review_mode.json");
+}
+
+// ============================================================================
+// 1. Protocol surface
+// ============================================================================
+
+/// `server/discover` must answer with no handshake at all, and must not claim a
+/// protocol revision the server does not implement.
+///
+/// Catches: gating discovery behind `initialize` (which makes it useless, since
+/// its entire purpose is to precede the handshake), and advertising
+/// `2026-07-28` — a revision whose stateless core, `resultType` and MRTR are
+/// not implemented here. A false version claim fails conformance for real.
+#[test]
+fn discover_answers_before_any_handshake_and_does_not_overclaim() {
+    let dir = data_dir();
+    let mut server = Server::spawn(dir.path());
+
+    // Deliberately no initialize.
+    let result = server.result("server/discover", None);
+
+    assert_eq!(result["serverInfo"]["name"], json!("vestige"));
+    assert!(
+        result["serverInfo"]["version"].is_string(),
+        "discover must report a version: {result}"
+    );
+    assert_eq!(result["capabilities"]["tools"]["listChanged"], json!(false));
+
+    let versions: Vec<String> = result["protocolVersions"]
+        .as_array()
+        .expect("protocolVersions array")
+        .iter()
+        .map(|v| v.as_str().expect("version string").to_string())
+        .collect();
+    assert!(
+        versions.contains(&"2025-11-25".to_string()),
+        "discover must advertise the revision the server actually speaks: {versions:?}"
+    );
+    assert!(
+        !versions.contains(&"2026-07-28".to_string()),
+        "the server does not implement 2026-07-28 (stateless core / resultType / MRTR); \
+         advertising it would be a false conformance claim: {versions:?}"
+    );
+    // Every advertised revision must be one initialize will actually accept.
+    for version in &versions {
+        let mut probe = Server::spawn(dir.path());
+        let negotiated = probe.result(
+            "initialize",
+            Some(json!({
+                "protocolVersion": version,
+                "capabilities": {},
+                "clientInfo": { "name": "probe", "version": "1" },
+            })),
+        );
+        assert_eq!(
+            negotiated["protocolVersion"],
+            json!(version),
+            "discover advertised {version} but initialize negotiated something else"
+        );
+        probe.abandon();
+    }
+
+    server.shutdown();
+}
+
+/// Everything except `initialize` and `server/discover` must be refused before
+/// the handshake, and refused cleanly rather than by panicking.
+#[test]
+fn uninitialized_requests_are_refused_but_discover_is_exempt() {
+    let dir = data_dir();
+    let mut server = Server::spawn(dir.path());
+
+    for method in ["tools/list", "resources/list", "ping"] {
+        let error = server.error(method, None);
+        assert_eq!(
+            error["code"],
+            json!(-32003),
+            "{method} before initialize must be 'not initialized': {error}"
+        );
+    }
+    assert!(
+        server.result("server/discover", None)["protocolVersions"].is_array(),
+        "server/discover must remain callable before initialize"
+    );
+
+    server.handshake();
+    assert!(server.result("tools/list", None)["tools"].is_array());
+
+    server.shutdown();
+}
+
+/// `tools/list` must be byte-for-byte identical across independent server
+/// processes, and must carry the `CacheableResult` freshness hints.
+///
+/// Catches: a hand-ordered tool vec leaking into the wire order (any reorder
+/// silently busts every client's prompt cache and re-sends ~28 KB of schema on
+/// every session start), and a dropped `ttlMs`/`cacheScope`, which leaves the
+/// client no way to know it could have kept its copy.
+#[test]
+fn tools_list_is_deterministic_across_restarts_and_carries_cache_hints() {
+    let first_dir = data_dir();
+    let second_dir = data_dir();
+
+    let mut first = Server::spawn(first_dir.path());
+    first.handshake();
+    let a = first.result("tools/list", None);
+    first.shutdown();
+
+    let mut second = Server::spawn(second_dir.path());
+    second.handshake();
+    let b = second.result("tools/list", None);
+    second.shutdown();
+
+    assert_eq!(
+        a, b,
+        "tools/list must be identical across processes so clients can cache it"
+    );
+
+    assert_eq!(
+        a["ttlMs"],
+        json!(3_600_000u64),
+        "missing ttlMs freshness hint"
+    );
+    assert_eq!(
+        a["cacheScope"],
+        json!("private"),
+        "the tool list can vary per install, so it must not be shared-cacheable"
+    );
+
+    let names: Vec<String> = a["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .map(|t| t["name"].as_str().expect("tool name").to_string())
+        .collect();
+    assert!(!names.is_empty(), "tools/list returned nothing");
+    let mut sorted = names.clone();
+    sorted.sort();
+    assert_eq!(
+        names, sorted,
+        "tools must be emitted in a stable sorted order, got {names:?}"
+    );
+    let mut seen = HashMap::new();
+    for name in &names {
+        assert!(
+            seen.insert(name.clone(), ()).is_none(),
+            "duplicate tool advertised: {name}"
+        );
+    }
+    for required in ["recall", "smart_ingest", "memory", "suppress"] {
+        assert!(
+            names.contains(&required.to_string()),
+            "advertised surface lost {required}: {names:?}"
+        );
+    }
+
+    // High-payload tools must keep their truncation override, or large results
+    // get silently clipped at the client's 50K default and spilled to disk.
+    let recall = a["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t["name"] == json!("recall"))
+        .expect("recall tool");
+    assert_eq!(
+        recall["_meta"]["anthropic/maxResultSizeChars"],
+        json!(300_000),
+        "recall lost its result-size annotation: {recall}"
+    );
+}
+
+/// Malformed, unknown, oversized and structurally wrong input must all produce
+/// clean JSON-RPC errors, and the server must stay alive and in sync.
+///
+/// Catches: a panic or a hang on hostile input, and — via the trailing `ping` —
+/// a framing desync where one bad message shifts every later response onto the
+/// wrong request id.
+#[test]
+fn hostile_input_produces_clean_errors_without_panicking_or_desyncing() {
+    let dir = data_dir();
+    let mut server = Server::spawn(dir.path());
+    server.handshake();
+
+    // Truncated JSON and outright garbage: parse error, no id.
+    for bad in [
+        r#"{"jsonrpc":"2.0","id":99,"method":"#,
+        "this is not json at all",
+        "{",
+        "[]",
+    ] {
+        let response = server.raw_roundtrip(bad);
+        assert_eq!(
+            response["error"]["code"],
+            json!(-32700),
+            "expected a parse error for {bad:?}, got {response}"
+        );
+    }
+
+    assert_eq!(
+        server.error("nonexistent/method", None)["code"],
+        json!(-32601),
+        "unknown method must be -32601"
+    );
+    assert_eq!(
+        server.error("tools/call", None)["code"],
+        json!(-32602),
+        "tools/call with no params must be -32602"
+    );
+    assert_eq!(
+        server.error(
+            "tools/call",
+            Some(json!({ "name": "no_such_tool", "arguments": {} }))
+        )["code"],
+        json!(-32602),
+        "unknown tool must be -32602"
+    );
+    assert_eq!(
+        server.error(
+            "tools/call",
+            Some(json!({ "name": "recall", "arguments": "not-an-object" })),
+        )["code"],
+        json!(-32602),
+        "non-object arguments must be rejected, not coerced"
+    );
+
+    // Missing a required tool argument is a tool-level error, not a crash.
+    let missing = server.call_tool("recall", json!({}));
+    assert!(
+        missing["error"].is_string(),
+        "recall without `query` must report a tool error: {missing}"
+    );
+
+    // Oversized input must be bounded, not swallowed into the store.
+    let oversized = server.call_tool("smart_ingest", json!({ "content": "x".repeat(2_000_000) }));
+    assert!(
+        oversized["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("too large")),
+        "a 2 MB payload must be refused with a size error: {oversized}"
+    );
+
+    // Still alive, still in sync.
+    assert_eq!(server.result("ping", None), json!({}));
+    assert!(
+        server.error_lines().is_empty(),
+        "hostile input must not log server errors: {:?}",
+        server.error_lines()
+    );
+
+    server.shutdown();
+}
+
+/// Blank lines and notifications produce no output, and must not shift the
+/// response stream.
+///
+/// Catches: a transport that answers a notification (which would leave the
+/// client one response ahead forever) or that treats a blank keepalive line as
+/// a message.
+#[test]
+fn blank_lines_and_notifications_produce_no_response() {
+    let dir = data_dir();
+    let mut server = Server::spawn(dir.path());
+    server.handshake();
+
+    server.write_line("");
+    server.write_line("   ");
+    server.notify("notifications/cancelled", Some(json!({ "requestId": 1 })));
+    server.expect_silence(Duration::from_millis(400));
+
+    // The next real request must still get its own id back.
+    assert_eq!(server.result("ping", None), json!({}));
+
+    // A notification sent WITH an id is a protocol violation and must be told so.
+    let error = server.error("notifications/initialized", None);
+    assert_eq!(
+        error["code"],
+        json!(-32600),
+        "expected invalid request: {error}"
+    );
+
+    assert_eq!(server.result("ping", None), json!({}));
+    server.shutdown();
+}
+
+// ============================================================================
+// 2. Store integrity: the store must not be brickable
+// ============================================================================
+
+/// A corrupt FTS5 index must not strand the user's memories.
+///
+/// `knowledge_fts` is declared `content='knowledge_nodes'`, so it is derived
+/// state and always reconstructible. Catches the field failure where a store
+/// with thousands of intact memories became unopenable because one fts5 blob
+/// was damaged: the server must start, rebuild the index, keep every memory,
+/// and serve keyword search again.
+#[test]
+fn corrupt_fts_index_does_not_brick_the_store() {
+    let dir = data_dir();
+
+    let mut server = Server::spawn(dir.path());
+    server.handshake();
+    let mut ids = Vec::new();
+    for i in 0..5 {
+        ids.push(server.ingest_keyword_only(
+            &format!("Memory number {i} about the deployment rollout checklist"),
+            &[],
+        ));
+    }
+    server.shutdown();
+
+    // Corrupt the index the way an interrupted rebuild does.
+    {
+        let conn = open_db(dir.path());
+        conn.execute_batch(
+            "UPDATE knowledge_fts_data SET block = randomblob(200) \
+             WHERE id = (SELECT id FROM knowledge_fts_data WHERE id > 1 LIMIT 1);",
+        )
+        .expect("corrupt the fts index");
+        assert!(
+            conn.execute_batch(
+                "INSERT INTO knowledge_fts(knowledge_fts) VALUES('integrity-check');"
+            )
+            .is_err(),
+            "the fixture must actually corrupt the index, otherwise this test proves nothing"
+        );
+        assert_ne!(
+            quick_check(&conn),
+            vec!["ok".to_string()],
+            "the corrupted store must fail quick_check before reopening"
+        );
+    }
+
+    let mut reopened = Server::spawn(dir.path());
+    reopened.handshake();
+
+    for id in &ids {
+        assert!(
+            reopened.memory_found(id),
+            "memory {id} was lost when the derived FTS index was rebuilt"
+        );
+    }
+    let hits = reopened.recall_ids(json!({
+        "query": "deployment rollout checklist",
+        "limit": 10,
+        "concrete": true,
+    }));
+    assert_eq!(
+        hits.len(),
+        ids.len(),
+        "the rebuilt index must find every seeded memory again, got {hits:?}"
+    );
+
+    reopened.shutdown();
+    assert_store_is_healthy(dir.path());
+}
+
+/// A CASCADE-declared orphan row must be repaired on open, not treated as fatal.
+///
+/// Catches the regression where any store carrying deletion residue from a
+/// build that ran without `PRAGMA foreign_keys = ON` became unopenable, with no
+/// recovery short of manual SQLite surgery.
+#[test]
+fn foreign_key_orphans_are_repaired_instead_of_being_fatal() {
+    let dir = data_dir();
+
+    let mut server = Server::spawn(dir.path());
+    server.handshake();
+    let survivor =
+        server.ingest_keyword_only("A memory that must survive an orphan repair", &["repair"]);
+    server.shutdown();
+
+    // A child row whose knowledge_nodes parent is gone. Its own schema says
+    // ON DELETE CASCADE, so it is unreachable by construction.
+    {
+        let conn = open_db(dir.path());
+        conn.execute_batch("PRAGMA foreign_keys=OFF;")
+            .expect("disable fk enforcement for the fixture");
+        conn.execute(
+            "INSERT INTO node_embeddings(node_id, embedding, dimensions, model, created_at) \
+             VALUES ('ghost-parent-0001', X'00010203', 4, 'fixture', datetime('now'))",
+            [],
+        )
+        .expect("insert orphan child row");
+        assert_eq!(
+            foreign_key_violations(&conn),
+            1,
+            "the fixture must actually create a violation"
+        );
+    }
+
+    let mut reopened = Server::spawn(dir.path());
+    reopened.handshake();
+    assert!(
+        reopened.memory_found(&survivor),
+        "the orphan repair must not take live memories with it"
+    );
+    assert!(
+        reopened
+            .stderr_lines()
+            .iter()
+            .any(|line| line.contains("repaired orphaned child rows")),
+        "the repair must be logged, not silent. stderr: {:?}",
+        reopened.stderr_lines()
+    );
+    reopened.shutdown();
+
+    let conn = open_db(dir.path());
+    assert_eq!(
+        foreign_key_violations(&conn),
+        0,
+        "the orphan must be gone after the repair"
+    );
+    let ghosts: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM node_embeddings WHERE node_id = 'ghost-parent-0001'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count ghosts");
+    assert_eq!(
+        ghosts, 0,
+        "the unreachable child row should have been deleted"
+    );
+}
+
+/// Migration must survive another process holding a write lock on the database.
+///
+/// This is the scenario that damaged a real store: a second SQLite writer is
+/// live while the server starts and runs its migrations. Nothing else in the
+/// repository covers it, because every other test opens the store from inside
+/// one process.
+///
+/// The fixture takes a genuine `BEGIN IMMEDIATE` write lock without leaving any
+/// user table in the committed snapshot, so the server still sees a fresh store
+/// and runs the full migration chain — the maximum amount of migration work
+/// possible — with a competing writer on the file.
+#[test]
+fn migration_survives_a_concurrent_sqlite_writer() {
+    let dir = data_dir();
+
+    let squatter = Connection::open(db_path(dir.path())).expect("create the db file");
+    squatter
+        .execute_batch("PRAGMA journal_mode=WAL;")
+        .expect("WAL");
+    squatter
+        .execute_batch("BEGIN IMMEDIATE; CREATE TABLE squatter_uncommitted(x);")
+        .expect("take a write lock");
+
+    // Sanity: the committed snapshot the server will read is still empty, so it
+    // takes the fresh-store path rather than the "damaged non-empty db" refusal.
+    {
+        let observer = Connection::open(db_path(dir.path())).expect("second reader");
+        let tables: i64 = observer
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count tables");
+        assert_eq!(tables, 0, "the fixture must not publish a table");
+    }
+
+    let mut server = Server::spawn(dir.path());
+    // Let the server get well into its migration chain while the lock is held.
+    std::thread::sleep(Duration::from_secs(2));
+    squatter
+        .execute_batch("ROLLBACK;")
+        .expect("release the lock");
+    drop(squatter);
+
+    server.handshake();
+    assert!(
+        server.result("tools/list", None)["tools"].is_array(),
+        "the server must be fully functional after migrating under contention"
+    );
+    let written = server.ingest_keyword_only("Wrote after a contended migration", &["contention"]);
+    assert!(
+        server.memory_found(&written),
+        "post-migration write was lost"
+    );
+    server.shutdown();
+
+    let conn = open_db(dir.path());
+    assert_eq!(
+        quick_check(&conn),
+        vec!["ok".to_string()],
+        "a contended migration must not corrupt the store"
+    );
+    assert_eq!(foreign_key_violations(&conn), 0);
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM schema_version", [], |row| row.get(0))
+        .expect("count schema_version rows");
+    assert_eq!(
+        rows, 1,
+        "a partially replayed migration chain would leave more than one version row"
+    );
+    assert!(
+        schema_version(&conn) > 0,
+        "the migration chain must have completed, not stalled at version 0"
+    );
+    assert!(
+        !conn
+            .prepare("SELECT 1 FROM sqlite_master WHERE name='squatter_uncommitted'")
+            .and_then(|mut s| s.exists([]))
+            .expect("look for the rolled-back table"),
+        "the fixture's uncommitted table must never have landed"
+    );
+}
+
+/// Two servers racing to migrate the same data directory must not corrupt it.
+///
+/// A loser is allowed to fail — SQLite has one writer — but it must fail loudly
+/// and leave a complete, single-versioned, quick_check-clean store behind.
+/// Catches: a half-applied migration chain, duplicate `schema_version` rows, or
+/// a panic instead of a diagnosable "database is locked".
+#[test]
+fn concurrent_server_startups_leave_an_intact_store() {
+    let dir = data_dir();
+
+    let mut first = Server::spawn(dir.path());
+    let mut second = Server::spawn(dir.path());
+    std::thread::sleep(Duration::from_secs(6));
+
+    let mut healthy = 0usize;
+    for server in [&mut first, &mut second] {
+        if server.is_running() {
+            healthy += 1;
+        } else {
+            let errors = server.error_lines();
+            assert!(
+                !errors.is_empty(),
+                "a server that lost the migration race must say why it exited. stderr: {:?}",
+                server.stderr_lines()
+            );
+            assert!(
+                errors
+                    .iter()
+                    .any(|line| line.contains("Failed to initialize storage")),
+                "the loser must report a storage-init failure, not an opaque crash: {errors:?}"
+            );
+            assert!(
+                !server
+                    .stderr_lines()
+                    .iter()
+                    .any(|line| line.contains("panicked at")),
+                "losing the race must not panic: {:?}",
+                server.stderr_lines()
+            );
+        }
+    }
+    assert!(
+        healthy >= 1,
+        "at least one racing server must come up; otherwise a concurrent start is a total outage"
+    );
+
+    for mut server in [first, second] {
+        if server.is_running() {
+            server.handshake();
+            let id = server.ingest_keyword_only("Survived a startup race", &["race"]);
+            assert!(server.memory_found(&id));
+        }
+        server.abandon();
+    }
+
+    let conn = open_db(dir.path());
+    assert_eq!(
+        quick_check(&conn),
+        vec!["ok".to_string()],
+        "a startup race must not corrupt the store"
+    );
+    assert_eq!(foreign_key_violations(&conn), 0);
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM schema_version", [], |row| row.get(0))
+        .expect("count schema_version rows");
+    assert_eq!(
+        rows, 1,
+        "the migration chain must have been applied exactly once"
+    );
+    assert!(schema_version(&conn) > 0);
+}
+
+/// Everything ingested must still be there after a clean stop and restart.
+///
+/// Catches: writes that live only in an in-process cache, a WAL that is never
+/// checkpointed, and tags or content mangled on reload.
+#[test]
+fn a_clean_restart_preserves_every_memory() {
+    let dir = data_dir();
+
+    let mut first = Server::spawn(dir.path());
+    first.handshake();
+    let alpha = first.ingest_keyword_only(
+        "The invoicing reconciliation job runs at midnight in the Frankfurt region",
+        &["billing", "Ops:Nightly"],
+    );
+    let beta = first.ingest_keyword_only(
+        "The vendor onboarding checklist requires a signed data processing addendum",
+        &["legal"],
+    );
+    first.shutdown();
+
+    let mut second = Server::spawn(dir.path());
+    second.handshake();
+
+    for id in [&alpha, &beta] {
+        assert!(
+            second.memory_found(id),
+            "memory {id} did not survive a restart"
+        );
+    }
+
+    let node =
+        second.call_tool_ok("memory", json!({ "action": "get", "id": &alpha }))["node"].clone();
+    assert!(
+        node["content"]
+            .as_str()
+            .expect("content")
+            .contains("Frankfurt"),
+        "content was mangled across the restart: {node}"
+    );
+    assert_eq!(
+        node["tags"],
+        json!(["billing", "Ops:Nightly"]),
+        "tags must round-trip verbatim, including case: {node}"
+    );
+
+    let hits = second.recall_ids(json!({
+        "query": "reconciliation Frankfurt",
+        "limit": 10,
+        "concrete": true,
+    }));
+    assert_eq!(
+        hits,
+        vec![alpha.clone()],
+        "keyword index did not survive the restart"
+    );
+
+    second.shutdown();
+    assert_store_is_healthy(dir.path());
+}
+
+// ============================================================================
+// 3. Retrieval correctness (embedding-independent paths)
+// ============================================================================
+
+/// A capitalised tag must be findable by a lower-case prefix, and vice versa.
+///
+/// A silent zero here is the worst failure shape a memory system has: the
+/// caller asks for their `Infra:` memories, gets an empty list, and concludes
+/// nothing was ever saved. The tool schema still describes this filter as
+/// "case-sensitive", so the documented contract and the implemented one
+/// disagree; the implementation is the one users depend on.
+#[test]
+fn tag_prefix_filtering_is_case_insensitive_on_the_keyword_path() {
+    let dir = data_dir();
+    let mut server = Server::spawn(dir.path());
+    server.handshake();
+
+    let deploy = server.ingest_keyword_only(
+        "Rollout gate alpha for the payments service",
+        &["Infra:Deploy"],
+    );
+    let staging = server.ingest_keyword_only(
+        "Rollout gate beta for the payments service",
+        &["Infra:Staging"],
+    );
+    let office = server.ingest_keyword_only(
+        "Rollout gate gamma for the office kitchen",
+        &["Office:Kitchen"],
+    );
+
+    let unfiltered = server.recall_ids(json!({
+        "query": "Rollout gate",
+        "limit": 10,
+        "concrete": true,
+    }));
+    assert_eq!(
+        unfiltered.len(),
+        3,
+        "baseline query must see all three memories, got {unfiltered:?}"
+    );
+
+    // Every casing of the same prefix must select the same two memories.
+    for prefix in ["Infra:", "infra:", "INFRA:", "InFrA:"] {
+        let mut filtered = server.recall_ids(json!({
+            "query": "Rollout gate",
+            "limit": 10,
+            "concrete": true,
+            "tag_prefix": prefix,
+        }));
+        filtered.sort();
+        let mut expected = vec![deploy.clone(), staging.clone()];
+        expected.sort();
+        assert_eq!(
+            filtered, expected,
+            "tag_prefix {prefix:?} must match 'Infra:Deploy'/'Infra:Staging' regardless of case"
+        );
+        assert!(
+            !filtered.contains(&office),
+            "tag_prefix {prefix:?} must still exclude non-matching tags"
+        );
+    }
+
+    // And the filter must genuinely filter, not just pass everything through.
+    let none = server.recall_ids(json!({
+        "query": "Rollout gate",
+        "limit": 10,
+        "concrete": true,
+        "tag_prefix": "nonexistent:",
+    }));
+    assert!(
+        none.is_empty(),
+        "a prefix matching nothing must return nothing: {none:?}"
+    );
+
+    server.shutdown();
+}
+
+/// The memory that IS an identifier must outrank the memory that merely cites it.
+///
+/// Raw BM25 magnitude is unbounded while the literal-match bonus is capped, so
+/// a note repeating a UUID three times can outscore the exact match and invert
+/// the documented exact-lookup guarantee. Filler documents are required: with a
+/// tiny corpus BM25's IDF term is degenerate and the ranking proves nothing.
+#[test]
+fn exact_identifier_lookup_beats_a_memory_that_only_cites_it() {
+    let dir = data_dir();
+    let mut server = Server::spawn(dir.path());
+    server.handshake();
+
+    for i in 0..40 {
+        server.ingest_keyword_only(
+            &format!("Routine note {i} about deployment pipelines and review cadence"),
+            &[],
+        );
+    }
+
+    let needle = "PAYMENTS_REDIS_URL";
+    let exact = server.ingest_keyword_only(needle, &[]);
+    let citer = server.ingest_keyword_only(
+        &format!(
+            "See {needle} for the rollout; {needle} was rotated in review, and \
+             {needle} supersedes the older connection note entirely"
+        ),
+        &[],
+    );
+
+    let ranked = server.recall_ids(json!({ "query": needle, "limit": 5 }));
+    assert!(
+        ranked.len() >= 2,
+        "both the exact match and the citing note should surface: {ranked:?}"
+    );
+    assert_eq!(
+        ranked.first(),
+        Some(&exact),
+        "the memory that IS {needle} must rank above the one that merely cites it \
+         three times; got {ranked:?}"
+    );
+    assert!(
+        ranked.contains(&citer),
+        "the citing memory must still be retrievable, just not first"
+    );
+
+    server.shutdown();
+}
+
+/// Typographic punctuation must not swallow the words next to it.
+///
+/// An em dash, a curly apostrophe and an accented word all sit inside one
+/// memory alongside 25 unrelated ones. Catches the tokenizer regression where
+/// `window — carefully` indexed as a single unsearchable token and `naïve`
+/// could not be reached from `naive`. The filler corpus makes a hit meaningful:
+/// with one memory in the store every query "succeeds".
+#[test]
+fn unicode_and_typographic_content_stays_findable_by_keyword() {
+    let dir = data_dir();
+    let mut server = Server::spawn(dir.path());
+    server.handshake();
+
+    for i in 0..25 {
+        server.ingest_keyword_only(
+            &format!(
+                "Unrelated filler memory {i} covering invoicing, payroll and vendor onboarding"
+            ),
+            &[],
+        );
+    }
+    let target = server.ingest_keyword_only(
+        "The rollout window — carefully negotiated — is Tuesday; the team’s naïve estimate slipped",
+        &[],
+    );
+
+    // Words adjacent to the em dash, adjacent to the curly apostrophe, the
+    // accented word itself, and its unaccented spelling.
+    for term in [
+        "window",     // immediately before an em dash
+        "carefully",  // immediately after an em dash
+        "negotiated", // immediately before an em dash
+        "team",       // immediately before a curly apostrophe
+        "naïve",      // the accented word itself
+        "naive",      // the same word without the accent
+        "estimate",   // immediately after the accented word
+    ] {
+        let hits = server.recall_ids(json!({
+            "query": term,
+            "limit": 10,
+            "concrete": true,
+        }));
+        assert_eq!(
+            hits,
+            vec![target.clone()],
+            "keyword search for {term:?} must return exactly the typographic memory, got {hits:?}"
+        );
+    }
+
+    server.shutdown();
+}
+
+// ============================================================================
+// 4. Deletion, suppression and the review gate
+// ============================================================================
+
+/// In the default review mode a confirmed purge is held for review, not applied.
+///
+/// This is load-bearing and surprising: `memory(action='purge', confirm=true)`
+/// answers `purge_pending_review`, the memory stays fully retrievable, and
+/// nothing is erased until the Memory PR is decided. A caller that reads
+/// `confirm=true` as "erased" would be wrong. Catches a regression in either
+/// direction: silently erasing without review, or dropping the review record.
+#[test]
+fn purge_with_confirm_is_review_gated_by_default() {
+    let dir = data_dir();
+    let mut server = Server::spawn(dir.path());
+    server.handshake();
+
+    let subject = server.ingest_keyword_only(
+        "The quarterly revenue figure for the Helsinki office was 4.2 million euros",
+        &["finance"],
+    );
+
+    let unconfirmed = server.call_tool("memory", json!({ "action": "purge", "id": &subject }));
+    assert!(
+        unconfirmed["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("confirm=true")),
+        "purge without confirm must refuse: {unconfirmed}"
+    );
+
+    let gated = server.call_tool(
+        "memory",
+        json!({ "action": "purge", "id": &subject, "confirm": true }),
+    );
+    assert_eq!(
+        gated["action"],
+        json!("purge_pending_review"),
+        "default review mode must hold a destructive mutation: {gated}"
+    );
+    assert_eq!(gated["success"], json!(false));
+    assert_eq!(gated["pendingReview"], json!(true));
+    assert!(
+        gated["memoryPrsOpened"][0]["id"]
+            .as_str()
+            .is_some_and(|id| id.starts_with("pr_")),
+        "a Memory PR must be opened as the audit record: {gated}"
+    );
+
+    assert!(
+        server.memory_found(&subject),
+        "a pending purge must NOT have removed the memory"
+    );
+
+    server.shutdown();
+}
+
+/// An approved purge must remove the content and leave only a content-free
+/// tombstone.
+///
+/// Catches: a "delete" that only hides the row (the text stays greppable in the
+/// database), and a tombstone that leaks what it was told to forget — the audit
+/// record must prove a removal happened without retaining the removed content,
+/// its tags, or its reason.
+#[test]
+fn approved_purge_removes_content_and_leaves_a_content_free_tombstone() {
+    let dir = data_dir();
+    disable_review_gate(dir.path());
+    let mut server = Server::spawn(dir.path());
+    server.handshake();
+
+    let subject = server.ingest_keyword_only(
+        "The quarterly revenue figure for the Helsinki office was 4.2 million euros",
+        &["finance", "confidential"],
+    );
+    let survivor = server.ingest_keyword_only(
+        "The Helsinki office moved to a new building last spring",
+        &["office"],
+    );
+
+    let purged = server.call_tool_ok(
+        "memory",
+        json!({
+            "action": "purge",
+            "id": &subject,
+            "confirm": true,
+            "reason": "regulator erasure request",
+        }),
+    );
+    assert_eq!(purged["action"], json!("purge"));
+    assert_eq!(
+        purged["success"],
+        json!(true),
+        "purge did not apply: {purged}"
+    );
+
+    assert!(
+        !server.memory_found(&subject),
+        "purged memory is still readable"
+    );
+    assert!(
+        server.memory_found(&survivor),
+        "purge took an unrelated memory with it"
+    );
+
+    let remaining = server.recall_ids(json!({
+        "query": "Helsinki quarterly revenue",
+        "limit": 10,
+        "concrete": true,
+    }));
+    assert!(
+        !remaining.contains(&subject),
+        "purged memory still surfaces in retrieval: {remaining:?}"
+    );
+
+    server.shutdown();
+
+    let conn = open_db(dir.path());
+    let nodes: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM knowledge_nodes WHERE id = ?1",
+            [&subject],
+            |row| row.get(0),
+        )
+        .expect("count nodes");
+    assert_eq!(nodes, 0, "the row itself must be gone");
+    let embeddings: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM node_embeddings WHERE node_id = ?1",
+            [&subject],
+            |row| row.get(0),
+        )
+        .expect("count embeddings");
+    assert_eq!(embeddings, 0, "the embedding must be gone too");
+    let leaked: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM knowledge_nodes WHERE content LIKE '%4.2 million%'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("scan for leaked content");
+    assert_eq!(leaked, 0, "the purged text is still stored somewhere");
+
+    // Exactly one content-free tombstone: proof of removal, no payload.
+    let (marker, node_type, tags, reason): (String, String, String, Option<String>) = conn
+        .query_row(
+            "SELECT memory_id, node_type, tags, reason FROM deletion_tombstones",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("exactly one tombstone");
+    assert!(
+        marker.starts_with("opaque:"),
+        "the tombstone must not retain the raw memory id: {marker}"
+    );
+    assert!(
+        !marker.contains(&subject),
+        "the tombstone marker leaks the purged id: {marker}"
+    );
+    assert_eq!(
+        node_type, "fact",
+        "the tombstone should keep only content-free metadata"
+    );
+    assert_eq!(tags, "[]", "the tombstone must not retain tags: {tags}");
+    assert_eq!(
+        reason, None,
+        "the purge reason is user-supplied prose and must not be retained: {reason:?}"
+    );
+
+    assert_store_is_healthy(dir.path());
+}
+
+/// Suppression must persist and compound across a restart.
+///
+/// Active forgetting is not deletion: the memory stays, inhibited. Catches the
+/// failure where a restart rehydrates FSRS state from defaults and quietly
+/// restores a memory the user deliberately suppressed — the memory system
+/// undoing the user's decision behind their back.
+#[test]
+fn suppression_survives_a_restart_and_keeps_compounding() {
+    let dir = data_dir();
+    disable_review_gate(dir.path());
+
+    let mut first = Server::spawn(dir.path());
+    first.handshake();
+    let stale = first.ingest_keyword_only(
+        "The legacy billing exporter should be run manually every Friday afternoon",
+        &["ops"],
+    );
+
+    let before = first.call_tool_ok("memory", json!({ "action": "state", "id": &stale }));
+    let baseline_retrieval = before["components"]["retrievalStrength"]
+        .as_f64()
+        .expect("retrievalStrength");
+
+    let suppressed = first.call_tool_ok(
+        "suppress",
+        json!({ "id": &stale, "reason": "superseded by the scheduler" }),
+    );
+    assert_eq!(
+        suppressed["success"],
+        json!(true),
+        "suppress failed: {suppressed}"
+    );
+    assert_eq!(suppressed["suppressionCount"], json!(1));
+
+    let after = first.call_tool_ok("memory", json!({ "action": "state", "id": &stale }));
+    let suppressed_retrieval = after["components"]["retrievalStrength"]
+        .as_f64()
+        .expect("retrievalStrength");
+    assert!(
+        suppressed_retrieval < baseline_retrieval,
+        "suppression must actually inhibit retrieval ({suppressed_retrieval} vs {baseline_retrieval})"
+    );
+    first.shutdown();
+
+    let mut second = Server::spawn(dir.path());
+    second.handshake();
+
+    let restarted = second.call_tool_ok("memory", json!({ "action": "state", "id": &stale }));
+    assert_eq!(
+        restarted["components"]["retrievalStrength"]
+            .as_f64()
+            .expect("retrievalStrength"),
+        suppressed_retrieval,
+        "a restart restored a suppressed memory's retrieval strength: {restarted}"
+    );
+    assert!(
+        restarted["content"].is_string(),
+        "suppression is not deletion; the memory must still exist: {restarted}"
+    );
+
+    // The suppression ledger must have survived too, so a second call compounds
+    // rather than starting over.
+    let again = second.call_tool_ok("suppress", json!({ "id": &stale }));
+    assert_eq!(
+        again["priorCount"],
+        json!(1),
+        "the pre-restart suppression was forgotten: {again}"
+    );
+    assert_eq!(again["suppressionCount"], json!(2));
+
+    second.shutdown();
+    assert_store_is_healthy(dir.path());
+}
+
+// ============================================================================
+// 5. Tests that require the real embedding runtime
+//
+// These load a ~670 MB ONNX model (downloading it on a cold machine), so they
+// are ignored by default. Run them with:
+//     cargo test -p vestige-mcp --test e2e_real_binary -- --ignored
+// ============================================================================
+
+/// Baseline for every ignored test below: the real runtime must actually be in
+/// play, and hybrid retrieval must be the path taken.
+///
+/// If this fails, the rest of this section is measuring the keyword fallback
+/// and its results are meaningless.
+#[test]
+#[ignore = "loads the real embedding runtime (~670 MB model); run with --ignored"]
+fn the_real_embedding_runtime_produces_vectors_and_hybrid_retrieval() {
+    let dir = data_dir();
+    let mut server = Server::spawn(dir.path());
+    server.handshake();
+    server.wait_for_embeddings();
+
+    let id = server.ingest_embedded(
+        "The deployment pipeline uses blue-green rollout on the Kubernetes cluster",
+        &["infra"],
+    );
+
+    let node = server.call_tool_ok("memory", json!({ "action": "get", "id": &id }))["node"].clone();
+    assert_eq!(
+        node["hasEmbedding"],
+        json!(true),
+        "no vector was stored: {node}"
+    );
+    assert!(
+        node["embeddingModel"]
+            .as_str()
+            .is_some_and(|m| !m.is_empty()),
+        "the stored vector must record which model produced it: {node}"
+    );
+
+    // A paraphrase sharing NO content word with the memory. If the vector side
+    // is dead, BM25 alone cannot bridge this and the result set is empty.
+    let value = server.call_tool_ok(
+        "recall",
+        json!({
+            "query": "zero downtime release strategy",
+            "limit": 5,
+            "min_similarity": 0.3,
+        }),
+    );
+    assert_eq!(
+        value["method"],
+        json!("hybrid+cognitive"),
+        "expected the hybrid path, got {}",
+        value["method"]
+    );
+    let hit = value["results"]
+        .as_array()
+        .expect("results")
+        .iter()
+        .find(|r| r["id"] == json!(&id))
+        .unwrap_or_else(|| {
+            panic!("semantic retrieval failed to find a paraphrased match: {value}")
+        });
+    assert!(
+        hit["keywordScore"].is_null(),
+        "the paraphrase must have matched semantically, not lexically: {hit}"
+    );
+    assert!(
+        hit["semanticScore"].as_f64().is_some_and(|s| s > 0.3),
+        "expected a real semantic score on the paraphrase: {hit}"
+    );
+
+    server.shutdown();
+}
+
+/// Both sides of a contradiction must survive retrieval, and the dissenting
+/// side must be flagged rather than quietly demoted.
+///
+/// Retrieval-induced forgetting suppresses the loser of a competition between
+/// SIMILAR memories, and a contradiction is near-identical text with opposite
+/// meaning — the most suppressible class of memory there is. Without the
+/// exemption, every time an agent retrieves one side, the evidence that would
+/// correct it gets demoted and can fall out of the returned window. That is
+/// precisely how a memory system buries its own correction.
+///
+/// Covers both detectable shapes: an explicit negation pair ("Never X" /
+/// "Always X") and an antonym pair with no negation in either side
+/// ("X hurts accuracy" / "X improves accuracy").
+///
+/// # Note on the retry, and a product observation
+///
+/// The retrieval-competition stage that produces `contradictionProtected` is
+/// guarded by a NON-BLOCKING `cognitive.try_lock()`. If that lock is held when
+/// the recall runs, the entire stage — competition AND the contradiction
+/// exemption — is skipped, and the response says nothing about it: the caller
+/// gets a normal-looking result with the safeguard silently switched off.
+///
+/// This was observed here, not theorised. With the autopilot enabled (the
+/// shipped default) it subscribes to `MemoryCreated` and takes a *blocking*
+/// `cognitive.lock()` per event, so ingesting a burst of memories and recalling
+/// immediately afterwards reliably loses the flag under machine load: this test
+/// passed 3/3 in isolation and failed when run alongside the rest of the
+/// suite. The harness pins `VESTIGE_AUTOPILOT_ENABLED=0` to remove that
+/// contention; the bounded retry below covers the remaining best-effort window.
+///
+/// The invariant that must hold unconditionally — both sides returned — is
+/// asserted without any retry.
+#[test]
+#[ignore = "loads the real embedding runtime (~670 MB model); run with --ignored"]
+fn contradictions_are_returned_intact_and_flagged_as_protected() {
+    let dir = data_dir();
+    let mut server = Server::spawn(dir.path());
+    server.handshake();
+    server.wait_for_embeddings();
+
+    let never = server.ingest_embedded(
+        "Never use prompt diversity when the sampling temperature exceeds zero point six",
+        &[],
+    );
+    let always = server.ingest_embedded(
+        "Always use prompt diversity when the sampling temperature exceeds zero point six",
+        &[],
+    );
+    let hurts = server.ingest_embedded(
+        "Prompt diversity hurts accuracy on the competition benchmark evaluation",
+        &[],
+    );
+    let improves = server.ingest_embedded(
+        "Prompt diversity improves accuracy on the competition benchmark evaluation",
+        &[],
+    );
+
+    let query = json!({ "query": "prompt diversity sampling temperature", "limit": 10 });
+
+    // Unconditional invariant: nothing may be suppressed out of the window.
+    let value = server.call_tool_ok("recall", query.clone());
+    let ids: Vec<String> = value["results"]
+        .as_array()
+        .expect("results")
+        .iter()
+        .filter_map(|r| r["id"].as_str().map(str::to_string))
+        .collect();
+    for (label, id) in [
+        ("negation:never", &never),
+        ("negation:always", &always),
+        ("antonym:hurts", &hurts),
+        ("antonym:improves", &improves),
+    ] {
+        assert!(
+            ids.contains(id),
+            "{label} was suppressed out of the result window; the caller would never see \
+             the other side. Returned: {ids:?}"
+        );
+    }
+    assert!(
+        value["receipt"]["suppressed"]
+            .as_array()
+            .is_none_or(|s| s.is_empty()),
+        "no side of a live contradiction may be recorded as suppressed: {}",
+        value["receipt"]
+    );
+
+    // The explicit flag. Retried because the stage behind it is best-effort;
+    // see this test's doc comment.
+    let mut protected = value["contradictionProtected"].clone();
+    for _ in 0..10 {
+        if protected.is_object() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+        protected = server.call_tool_ok("recall", query.clone())["contradictionProtected"].clone();
+    }
+    assert!(
+        protected.is_object(),
+        "the dissenting side must be reported, not silently spared. The retrieval-competition \
+         stage never ran across 11 attempts, which means the contradiction safeguard is off \
+         and nothing in the response says so."
+    );
+    let protected_ids: Vec<String> = protected["memoryIds"]
+        .as_array()
+        .expect("memoryIds")
+        .iter()
+        .filter_map(|v| v.as_str().map(str::to_string))
+        .collect();
+    assert!(
+        !protected_ids.is_empty(),
+        "contradictionProtected must name the memories it spared: {protected}"
+    );
+    assert!(
+        protected_ids
+            .iter()
+            .all(|id| id == &never || id == &always || id == &hurts || id == &improves),
+        "contradictionProtected named a memory that is not part of either pair: {protected_ids:?}"
+    );
+    assert!(
+        protected["notice"]
+            .as_str()
+            .is_some_and(|n| n.contains("contradict")),
+        "the protection must come with a notice telling the caller to read both sides: {protected}"
+    );
+
+    server.shutdown();
+}
+
+/// Tag filtering must be case-insensitive on the full hybrid path too.
+///
+/// The keyword path and the hybrid path apply this filter in two different
+/// places, so covering only one leaves half the surface untested.
+#[test]
+#[ignore = "loads the real embedding runtime (~670 MB model); run with --ignored"]
+fn tag_prefix_filtering_is_case_insensitive_on_the_hybrid_path() {
+    let dir = data_dir();
+    let mut server = Server::spawn(dir.path());
+    server.handshake();
+    server.wait_for_embeddings();
+
+    let deploy = server.ingest_embedded(
+        "Rollout gate alpha guards the payments service release",
+        &["Infra:Deploy"],
+    );
+    let staging = server.ingest_embedded(
+        "Rollout gate beta guards the payments service release",
+        &["Infra:Staging"],
+    );
+    let office = server.ingest_embedded(
+        "Rollout gate gamma guards the office kitchen refit",
+        &["Office:Kitchen"],
+    );
+
+    let unfiltered = server.recall_ids(json!({ "query": "rollout gate guards", "limit": 10 }));
+    assert!(
+        unfiltered.contains(&office),
+        "baseline hybrid query must include the memory the filter should later drop: {unfiltered:?}"
+    );
+
+    for prefix in ["Infra:", "infra:", "INFRA:"] {
+        let mut filtered = server.recall_ids(
+            json!({ "query": "rollout gate guards", "limit": 10, "tag_prefix": prefix }),
+        );
+        filtered.sort();
+        let mut expected = vec![deploy.clone(), staging.clone()];
+        expected.sort();
+        assert_eq!(
+            filtered, expected,
+            "hybrid tag_prefix {prefix:?} must be case-insensitive and must exclude {office}"
+        );
+    }
+
+    server.shutdown();
+}
+
+/// A correction must not be swallowed by the ingest gate.
+///
+/// # THIS TEST FAILS AGAINST THE CURRENT BUILD. It documents a real defect and
+/// is deliberately NOT fixed here.
+///
+/// Reproduction, end to end over the real binary, with the embedding runtime
+/// loaded:
+///
+/// 1. ingest `"Never use prompt diversity when the sampling temperature exceeds
+///    zero point six"`
+/// 2. ingest `"Always use prompt diversity when the sampling temperature
+///    exceeds zero point six"`
+///
+/// Observed: the second ingest returns `decision: "reinforce"` at similarity
+/// 0.965. The correction is DISCARDED and the memory it contradicts is
+/// STRENGTHENED. `recall` afterwards returns only the stale "Never" memory.
+///
+/// Reversing the order changes the outcome: ingesting "Always" first and
+/// "Never" second returns `decision: "create"` and keeps both. Same two
+/// memories, same similarity — only the order differs.
+///
+/// Root cause: `crates/vestige-core/src/advanced/prediction_error.rs`. The
+/// near-identical branch is correctly guarded by `!best.appears_contradictory`,
+/// but the flag comes from `detect_contradiction` in that same file, which
+/// tests `new.contains(neg) && old.contains(pos)` — it only fires when the NEW
+/// content is the negative one. It also has no antonym branch and no
+/// mutually-exclusive-value branch, so these are swallowed identically
+/// (all measured over the real binary):
+///
+/// | first ingest | second ingest | decision | similarity |
+/// |---|---|---|---|
+/// | Never use prompt diversity … | Always use prompt diversity … | reinforce | 0.965 |
+/// | … hurts accuracy … | … improves accuracy … | reinforce | 0.962 |
+/// | … PostgreSQL 14 … | … PostgreSQL 16 … | reinforce | 0.940 |
+/// | Priya holds a Bachelor degree … | Priya holds a Master of Science degree … | reinforce | 0.976 |
+///
+/// The richer detector in
+/// `crates/vestige-mcp/src/tools/cross_reference.rs::appears_contradictory`
+/// already handles every one of these shapes — it has explicit unit tests for
+/// the antonym and Bachelor/Master cases — but it is only consulted at
+/// RETRIEVAL time. The retrieval-side contradiction protection can only protect
+/// memories that made it into the store; here the dissent is destroyed at
+/// ingest, one stage earlier, so that guard never gets the chance to run.
+#[test]
+#[ignore = "FAILS: documents a real ingest-gate defect (corrections are swallowed). \
+            Also needs the embedding runtime. Run with --ignored to reproduce."]
+fn correction_must_not_be_swallowed_by_the_ingest_gate() {
+    const NEGATIVE: &str =
+        "Never use prompt diversity when the sampling temperature exceeds zero point six";
+    const POSITIVE: &str =
+        "Always use prompt diversity when the sampling temperature exceeds zero point six";
+
+    // Control: the SAME two memories in the OPPOSITE order. This must pass, and
+    // it proves the failure below is an ordering defect in the detector rather
+    // than the gate simply never creating on near-identical text.
+    {
+        let control_dir = data_dir();
+        let mut control = Server::spawn(control_dir.path());
+        control.handshake();
+        control.wait_for_embeddings();
+        control.call_tool_ok("smart_ingest", json!({ "content": POSITIVE }));
+        let flipped = control.call_tool_ok("smart_ingest", json!({ "content": NEGATIVE }));
+        assert_eq!(
+            flipped["decision"],
+            json!("create"),
+            "control: ingesting the negative claim over the positive one is correctly \
+             detected as a contradiction and kept: {flipped}"
+        );
+        assert_eq!(
+            control
+                .recall_ids(json!({
+                    "query": "prompt diversity sampling temperature",
+                    "limit": 10,
+                }))
+                .len(),
+            2,
+            "control: both positions must be retrievable in this direction"
+        );
+        control.shutdown();
+    }
+
+    let dir = data_dir();
+    let mut server = Server::spawn(dir.path());
+    server.handshake();
+    server.wait_for_embeddings();
+
+    // Deliberately NOT forceCreate: this is the Prediction Error Gate under test.
+    let original = server.call_tool_ok("smart_ingest", json!({ "content": NEGATIVE }));
+    assert_eq!(original["decision"], json!("create"));
+    assert_eq!(original["hasEmbedding"], json!(true));
+    let original_id = original["nodeId"].as_str().expect("nodeId").to_string();
+
+    let correction = server.call_tool_ok("smart_ingest", json!({ "content": POSITIVE }));
+
+    assert_ne!(
+        correction["decision"],
+        json!("reinforce"),
+        "the gate reinforced the memory the user just contradicted, and discarded the \
+         correction. decision={} similarity={}. The control above proves the very same \
+         pair IS handled correctly in the opposite order, so this is a direction bug in \
+         detect_contradiction, not a threshold choice. This is the worst outcome the gate \
+         can produce: the stale claim gets stronger and the correction ceases to exist.",
+        correction["decision"],
+        correction["similarity"]
+    );
+
+    let ids = server.recall_ids(json!({
+        "query": "prompt diversity sampling temperature",
+        "limit": 10,
+    }));
+    assert!(
+        ids.len() >= 2,
+        "after a correction both positions must be retrievable, got {ids:?}"
+    );
+    assert!(
+        ids.contains(&original_id),
+        "the original claim vanished: {ids:?}"
+    );
+    let correction_id = correction["nodeId"].as_str().expect("nodeId").to_string();
+    assert!(
+        ids.contains(&correction_id),
+        "the correction is not retrievable: {ids:?}"
+    );
+
+    server.shutdown();
+}
+
+/// An approved purge must also drop the vector, not just the row.
+///
+/// The keyword-path purge test cannot prove this: with no embedding runtime
+/// there was never a vector to remove. This one seeds a real vector first.
+#[test]
+#[ignore = "loads the real embedding runtime (~670 MB model); run with --ignored"]
+fn approved_purge_removes_the_stored_embedding() {
+    let dir = data_dir();
+    disable_review_gate(dir.path());
+    let mut server = Server::spawn(dir.path());
+    server.handshake();
+    server.wait_for_embeddings();
+
+    let subject = server.ingest_embedded(
+        "The quarterly revenue figure for the Helsinki office was 4.2 million euros",
+        &["finance"],
+    );
+
+    {
+        // The vector must exist before we can claim the purge removed it.
+        let conn = open_db(dir.path());
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM node_embeddings WHERE node_id = ?1",
+                [&subject],
+                |row| row.get(0),
+            )
+            .expect("count embeddings");
+        assert_eq!(count, 1, "fixture must have stored a real vector first");
+    }
+
+    let purged = server.call_tool_ok(
+        "memory",
+        json!({ "action": "purge", "id": &subject, "confirm": true }),
+    );
+    assert_eq!(
+        purged["success"],
+        json!(true),
+        "purge did not apply: {purged}"
+    );
+    server.shutdown();
+
+    let conn = open_db(dir.path());
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM node_embeddings WHERE node_id = ?1",
+            [&subject],
+            |row| row.get(0),
+        )
+        .expect("count embeddings");
+    assert_eq!(count, 0, "the vector outlived the purged memory");
+}
+
+/// Everything, including vectors, must survive a restart.
+///
+/// Catches a rebuilt-on-boot vector index that silently drops rows: the memory
+/// is still listed but no longer semantically reachable, which looks like a
+/// ranking regression rather than data loss.
+#[test]
+#[ignore = "loads the real embedding runtime (~670 MB model); run with --ignored"]
+fn embeddings_and_semantic_retrieval_survive_a_restart() {
+    let dir = data_dir();
+
+    let mut first = Server::spawn(dir.path());
+    first.handshake();
+    first.wait_for_embeddings();
+    let id = first.ingest_embedded(
+        "The deployment pipeline uses blue-green rollout on the Kubernetes cluster",
+        &["infra"],
+    );
+    first.shutdown();
+
+    let mut second = Server::spawn(dir.path());
+    second.handshake();
+    second.wait_for_embeddings();
+
+    let node = second.call_tool_ok("memory", json!({ "action": "get", "id": &id }))["node"].clone();
+    assert_eq!(
+        node["hasEmbedding"],
+        json!(true),
+        "the stored vector did not survive the restart: {node}"
+    );
+
+    let ids = second.recall_ids(json!({
+        "query": "zero downtime release strategy",
+        "limit": 5,
+        "min_similarity": 0.3,
+    }));
+    assert!(
+        ids.contains(&id),
+        "semantic retrieval broke across the restart: {ids:?}"
+    );
+
+    second.shutdown();
+    assert_store_is_healthy(dir.path());
+}
+
+/// A corrupt FTS index must be rebuilt without losing vectors either.
+///
+/// The default-suite version of this test proves memories and keyword search
+/// survive. This one additionally proves the rebuild does not disturb the
+/// vector side of the store.
+#[test]
+#[ignore = "loads the real embedding runtime (~670 MB model); run with --ignored"]
+fn corrupt_fts_rebuild_preserves_embeddings() {
+    let dir = data_dir();
+
+    let mut server = Server::spawn(dir.path());
+    server.handshake();
+    server.wait_for_embeddings();
+    let mut ids = Vec::new();
+    for i in 0..5 {
+        ids.push(server.ingest_embedded(
+            &format!("Memory number {i} about the deployment rollout checklist"),
+            &[],
+        ));
+    }
+    server.shutdown();
+
+    {
+        let conn = open_db(dir.path());
+        conn.execute_batch(
+            "UPDATE knowledge_fts_data SET block = randomblob(200) \
+             WHERE id = (SELECT id FROM knowledge_fts_data WHERE id > 1 LIMIT 1);",
+        )
+        .expect("corrupt the fts index");
+        assert!(
+            conn.execute_batch(
+                "INSERT INTO knowledge_fts(knowledge_fts) VALUES('integrity-check');"
+            )
+            .is_err(),
+            "the fixture must actually corrupt the index"
+        );
+    }
+
+    let mut reopened = Server::spawn(dir.path());
+    reopened.handshake();
+    reopened.wait_for_embeddings();
+
+    for id in &ids {
+        let node =
+            reopened.call_tool_ok("memory", json!({ "action": "get", "id": id }))["node"].clone();
+        assert_eq!(
+            node["hasEmbedding"],
+            json!(true),
+            "memory {id} lost its vector during the FTS rebuild: {node}"
+        );
+    }
+    let semantic = reopened.recall_ids(json!({
+        "query": "what do we check before shipping a release",
+        "limit": 10,
+    }));
+    assert!(
+        !semantic.is_empty(),
+        "semantic retrieval must work again after the rebuild"
+    );
+
+    reopened.shutdown();
+    assert_store_is_healthy(dir.path());
+}

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,361 @@
+# Benchmarks
+
+This page documents the only retrieval benchmark Vestige currently stands
+behind, what it does and does not measure, how to reproduce it from a clean
+checkout, and where it is weak.
+
+> **Retraction notice — CauseBench.**
+> Vestige previously advertised a benchmark called **CauseBench**. It is
+> **formally withdrawn**. Its harness no longer exists, its repro command
+> 404'd, and its published numbers are retracted. **CauseBench must never be
+> cited**, in release notes, READMEs, issues, launch posts, or conversation —
+> not even as "an earlier result". A separate LongMemEval run was also
+> invalidated and must not be cited. See `CHANGELOG.md`
+> ("README rewrite; CauseBench replaced by Silent Rotation").
+>
+> That history is why this page is written the way it is. After a retraction,
+> a number that cannot be reproduced by a stranger is worse than no number at
+> all. Everything below is built so a stranger can re-run it and get the same
+> answer, or catch us being wrong.
+
+---
+
+## MemConflict
+
+**Paper:** [MemConflict: Evaluating Long-Term Memory Systems Under Memory
+Conflicts](https://arxiv.org/abs/2605.20926) (arXiv:2605.20926)
+**Upstream code and data:** <https://github.com/TaoZhen1110/MemConflict>
+**Pinned revision:** `ec51d5d36e87f7665d1337f3a88cbde95fc2a964`
+**Harness:** `benchmarks/memconflict/`
+
+MemConflict measures whether a long-term memory system retrieves and ranks the
+memory that is *temporally valid, factually correct, and contextually
+applicable* when the store also contains conflicting alternatives. It defines
+three conflict types:
+
+| Conflict type | Validity dimension | Core challenge |
+| --- | --- | --- |
+| Dynamic | Temporal validity | Identify the current state after real updates. |
+| Static | Factual correctness | Hold a true fact against a later false contradiction. |
+| Conditional | Contextual applicability | Recover the right condition-value binding. |
+
+This is the benchmark where Vestige *should* be strongest, because it ships
+contradiction inspection as a first-class tool (`recall(mode="contradictions")`)
+rather than as a post-hoc heuristic.
+
+### Published numbers, and one correction
+
+We verified the upstream numbers against the paper directly rather than
+trusting a secondhand summary. One widely-repeated framing is wrong, so state
+it precisely:
+
+**Table 3, Average Answer Accuracy (AA)** — this is what the commonly-quoted
+six-number list actually is:
+
+| System | Average AA |
+| --- | --- |
+| MemOS | 0.5539 |
+| Letta | 0.4871 |
+| A-Mem | 0.4452 |
+| Mem0 | 0.3612 |
+| Memobase | 0.3553 |
+| LangMem | 0.2822 |
+
+**Table 3, Conflict Recognition Score (CRS)** — a *different* column, defined
+only for static conflicts:
+
+| System | Static CRS |
+| --- | --- |
+| A-Mem | **0.2501** |
+| MemOS | 0.2361 |
+| LangMem | 0.2083 |
+| Letta | 0.2031 |
+| Mem0 | 0.1528 |
+| Memobase | 0.0694 |
+
+Both tables above were read directly out of the paper PDF (Table 3, headed
+"Dynamic AA / UOCS, Static AA / CRS, Conditional AA, Average AA"), not from a
+summary. The paper states it plainly: "CRS remains low for all systems, with
+the best score only reaching 0.2501" (MemConflict, arXiv:2605.20926, S4.3).
+
+The `0.5539 / 0.4871 / ...` figures are **Answer Accuracy, not Conflict
+Recognition Score**. Calling them CRS overstates the field by roughly a factor
+of two. The best CRS achieved by *any* of the six systems is **0.2501**
+(A-Mem). The entire field sits between 0.07 and 0.25 on actually recognising
+contradictions — that is the real headroom, and it is much larger than the AA
+column suggests.
+
+### What our harness measures
+
+For each simulated user, sessions are ingested in chronological order. After
+each session, that session's questions are asked. A question therefore only
+ever sees memories from sessions at or before it — no lookahead.
+
+Four arms answer every question. **All four run every time. None is optional.**
+
+| Arm | What it does | Why it exists |
+| --- | --- | --- |
+| `nomem` | No retrieval; reader gets an empty string. | The true floor. Anything scoring above ~0 here is measuring the judge, not memory. |
+| `random` | K memories drawn uniformly at random (fixed seed) from the same corpus. | **Blob-inflation control.** The judge gives partial credit for token overlap, so *any* K memories score above zero by chance. An arm that cannot beat `random` is reporting corpus statistics. |
+| `bm25` | Okapi BM25 (k1=1.5, b=0.75) over the identical corpus. | **The earned-complexity bar.** |
+| `vestige` | `recall(...)` against a live `vestige-mcp` server. | The system under test. |
+
+The BM25 and no-memory controls are non-negotiable because
+[MemDelta](https://arxiv.org/abs/2606.29914) (arXiv:2606.29914) showed that
+agent memory systems routinely fail against controlled baselines — agent
+self-memory scored 42% where basic retrieval scored 47% on LongMemEval-S — and
+that changing a single component (the embedding model alone shifted accuracy
+by 6.2pp, p=0.004) can reverse system rankings. A memory system that cannot
+beat naive BM25 on the same corpus, with the same reader and the same judge,
+has not earned its complexity. The harness prints that verdict explicitly.
+
+**Metrics** (ported faithfully from upstream `Evaluation/eval_scoring.py`):
+
+- `answer_accuracy` (AA) — partial-credit match against the gold answer.
+- `UOCS` — dynamic conflicts: did the output show update *and* ordering?
+- `CRS-lex` — static conflicts: upstream's exact keyword rule
+  (`inconsisten|conflict|contradict|cannot confirm|uncertain|mismatch`),
+  applied identically to every arm. Apples to apples.
+- `CRS-struct` — **Vestige only.** Did `recall(mode="contradictions")` return
+  at least one contradiction pair? Scored *structurally* from
+  `contradictionsFound`, never by keyword-matching the response, so the metric
+  cannot be satisfied by the server merely emitting the word "contradiction".
+
+Type-level means are macro-averaged, matching the paper's "Average AA" column.
+Metrics that do not apply to a conflict type are **omitted, never scored zero**,
+so denominators stay correct.
+
+### What this does NOT measure
+
+Read this section before quoting any number from this harness.
+
+1. **These numbers are not comparable to the paper's Table 3.** Upstream's
+   headline results used an **LLM judge (gpt-5.0-mini)** and an LLM reader. We
+   use upstream's deterministic **rule-based fallback judge** and a **non-LLM
+   reader**. Absolute values are on a different scale. Never place our AA next
+   to a published AA in the same table or sentence.
+2. **Only cross-arm differences within a single run are meaningful.** The arms
+   share one corpus, one reader, one judge, one K. That comparison is valid.
+   Nothing else is.
+3. **The reader is not an agent.** It concatenates the top-K retrieved memory
+   texts. It does not reason, disambiguate, or resolve conflicts. So AA here is
+   a *retrieval-quality proxy* — "was the evidence surfaced" — not end-to-end
+   task accuracy. This is deliberate: it removes the model confound that
+   MemDelta identifies as the field's main source of bogus results.
+4. **CRS-struct is not a head-to-head win.** BM25 and the random/no-memory
+   controls have no contradiction channel at all, so they are structurally 0
+   by construction, not by measured deficit. CRS-struct reports whether a
+   Vestige *capability* fires. It is not evidence that Vestige beats BM25 at
+   contradiction recognition, and must never be presented as such.
+5. **White-box metrics are not implemented.** The paper's SEH@K and SRS require
+   gold supporting-memory IDs. The released `Data/Step4_4.jsonl` questions carry
+   only `question / answer / conflict_type / ability_target / difficulty` — no
+   gold memory ID — so SEH@K and SRS **cannot be computed from the public data**
+   and are not reported. We will not estimate them.
+6. **Released data ≠ evaluated data.** The paper reports ~12 virtual users;
+   the released repo ships an *expanded* release of 30 instances. Our subset is
+   drawn from the 30. Our instance sample is therefore not the paper's sample.
+7. **Subset, not full benchmark.** Runs are capped by `--instances` and
+   `--sessions`. A capped run is a real measurement of a smaller slice, not an
+   estimate of the full 3,750-question benchmark. The cap is recorded in the
+   results JSON. Small subsets have wide error bars; we report no significance
+   tests and you should not infer any.
+8. **No statistical significance testing.** With a handful of static-conflict
+   questions per run, differences of a few points are noise. Do not read them
+   as signal.
+9. **Ingestion is user-turn only.** Assistant turns are excluded as agent
+   paraphrase rather than facts about the user. That is a modelling choice and
+   it changes the corpus every arm sees.
+
+### Reproducing
+
+Requires: Rust toolchain, Python 3.9+ (**standard library only — no pip
+install**), network access for the one-time dataset fetch.
+
+```sh
+# 1. Build the server
+cargo build -p vestige-mcp
+
+# 2. Fetch the pinned dataset (verifies SHA-256; refuses to run on a mismatch)
+python3 benchmarks/memconflict/fetch_dataset.py
+
+# 3. Run all four arms
+python3 benchmarks/memconflict/run.py --instances 2 --sessions 25 --top-k 5
+```
+
+The dataset is **not vendored**. It is downloaded at the pinned commit and
+hash-verified; a mismatch is a hard failure, never a warning.
+
+Every run writes `benchmarks/memconflict/results/memconflict-<UTC>.json`
+containing the exact command, the dataset revision and file hashes, the Vestige
+git commit / branch / dirty flag, the MCP `serverInfo`, full config (arms,
+top-k, recall mode, seed, reader, judge), the observed embedding-warmup record,
+machine specs, per-question records, and the caveat list. The console prints
+the exact reproduction command on exit.
+
+**Determinism.** Given the same dataset revision, Vestige commit, and flags,
+the `nomem`, `random` (seeded) and `bm25` arms are fully deterministic. The
+`vestige` arm is *not* guaranteed bit-identical across runs: FSRS retention
+state, timestamps, and consolidation are time-dependent by design. Re-running
+reproduces the ranking, not necessarily the fourth decimal place.
+
+**Embedding warmup.** The harness blocks for a mandatory warmup (default 45s)
+after `initialize` before the first `tools/call`. Skipping it silently measures
+a degraded keyword-only fallback — a failure that does not look like a failure.
+The observed warmup is recorded in every results file. Verify a run used real
+embeddings by checking that `semanticScore` is non-null in retrieval output.
+
+### Known limitations of the harness itself
+
+- Per-user isolation uses Vestige's `scope` namespace, not a fresh database per
+  user. This is a speed tradeoff: a fresh data dir per user would pay the
+  warmup cost repeatedly. Scope isolation is enforced by the server
+  (`includeCrossScope` defaults false), but it is a weaker guarantee than
+  process isolation.
+- `smart_ingest` batches at 20 items per call (the tool's cap). Ingest
+  throughput measured on the reference machine was ~7 units/s, which is what
+  bounds run size.
+- The rule-based judge is lexical. It rewards token overlap and cannot detect a
+  semantically correct paraphrase that shares no vocabulary with the gold
+  answer. It under-credits every arm, but it under-credits them *equally*,
+  which is what keeps the cross-arm comparison sound.
+
+---
+
+## First run: what the instrument actually reported
+
+Recorded so the instrument is judged on what it produced, not on what we hoped
+it would produce.
+
+```
+python3 benchmarks/memconflict/run.py --instances 2 --sessions 25 --top-k 5
+```
+
+2 simulated users, 25 sessions each, 2,207 memory units ingested, 98 questions,
+top-k 5, Vestige 2.4.1, Apple M1 Max. Full record:
+`benchmarks/memconflict/results/memconflict-20260830T173831Z.json`.
+
+| arm | macroAA | microAA | dynAA | UOCS | statAA | CRS-lex | condAA | chars |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| nomem | 0.0000 | 0.0000 | 0.0000 | 0.0000 | 0.0000 | 0.0000 | 0.0000 | 0 |
+| random | 0.0322 | 0.0867 | 0.0966 | 0.0000 | 0.0000 | 0.0000 | 0.0000 | 687 |
+| bm25 | **0.4881** | 0.2704 | 0.2500 | 0.1932 | 0.2143 | 0.0000 | 1.0000 | 736 |
+| vestige | 0.4416 | **0.3163** | **0.3011** | **0.3636** | **0.3571** | 0.0000 | 0.6667 | 854 |
+
+n: dynamic 88, static 7, conditional 3.
+
+**The controls behaved.** `nomem` scored a clean 0.0000 on everything, so the
+judge awards nothing for an empty answer. `random` scored 0.0322 macro, so
+blob-inflation is real but small. Both floors are where they should be, which is
+what licenses reading anything else on this table.
+
+**Vestige does not beat BM25 on the headline metric.** macro AA 0.4416 vs
+0.4881. Reported first because it is the metric the paper leads with and it is
+the one where Vestige loses.
+
+**But macro and micro disagree, and the reason is a 3-question subset.**
+`macroAA` weights conditional conflicts (n=3) the same as dynamic (n=88). BM25
+went 3/3 there and Vestige 2/3; that single question is the entire macro gap.
+On micro AA, Vestige leads 0.3163 to 0.2704, and it leads on dynamic AA, UOCS
+and static AA. **The honest statement is that this run does not separate them.**
+n=3 cannot support a ranking either way, and we ran no significance test.
+
+**The blob-size caveat on Vestige's micro-AA lead.** Vestige hands the judge 854
+chars per question against BM25's 736 (1.16x). Vestige merges near-duplicate
+units into composite nodes (marked `[MERGED]`, up to 719 chars) even under
+`batchMergePolicy=force_create`, so its retrieval units are larger. Content is
+not lost, but a token-overlap judge rewards more text. Vestige's micro-AA edge
+points the same direction as its larger blob, so that edge is **not clean**. The
+harness now records `reader_chars_mean` on every run and prints a CONFOUND
+WARNING past 1.25x; at 1.16x it did not fire, but the effect is not zero.
+
+### The finding that matters: contradiction recognition did not fire
+
+**CRS-struct = 0.0000. CRS-lex = 0.0000 for every arm.**
+
+On the benchmark built to test contradiction handling, on the capability Vestige
+ships as a first-class tool, `recall(mode="contradictions")` returned **zero**
+contradiction pairs for all 7 static-conflict questions.
+
+This is not a harness artifact. We checked:
+
+- Raising `limit` from the default 50 to the maximum 200: still 0.
+- Short keyword topics (`university`, `gender`, `residence`) instead of full
+  question text: still 0.
+- No topic at all (scan recent memories), limit 200: still 0.
+- **The contradicting evidence is present and retrievable.** A `lookup` recall
+  returns both "I studied at MIT" and the Cal State Long Beach memory, and both
+  "I have a Bachelor degree" and "I have a Master of Science", from the same
+  store, in the same scope. The pairs are there. The detector does not fire on
+  them.
+
+For scale, the published field ceiling on this metric is 0.2501 (A-Mem), and the
+paper's own summary is that CRS is low for every system it tested. Vestige is
+currently at 0.0000 against that ceiling on this subset.
+
+Two engine-side issues surfaced while establishing this, neither of which we
+changed (out of scope for this harness work):
+
+1. **`recall(mode="contradictions")` accepts no `scope` parameter.** It calls
+   `hybrid_search` / `get_all_nodes` without namespace filtering, so it reads
+   across every project scope in the database. In this harness that means the
+   probe was not isolated per simulated user. It is also a correctness concern
+   outside benchmarking.
+2. **Detection is a strict lexical heuristic** (`topic_overlap >= 0.4` plus
+   `appears_contradictory`), which is a plausible reason it misses
+   contradictions phrased in natural conversational language, which is exactly
+   what MemConflict plants.
+
+Neither is diagnosed further here. The harness's job was to surface them
+measurably, and it did.
+
+## LongMemEval_S — sanity check only
+
+**Harness:** `benchmarks/memconflict/longmemeval.py`
+**Dataset:** `xiaowu0162/longmemeval-cleaned` (MIT, ungated)
+**Pinned revision:** `98d7416c24c778c2fee6e6f3006e7a073259d48f`
+**Status:** wired and runnable. **Not a headline benchmark. Never quote these
+numbers as a LongMemEval score.**
+
+A previous Vestige LongMemEval run was **invalidated** (absolute-value scoring
+bug, 8192-byte truncation, no-op weights) and **must not be cited**.
+
+While pinning this we found a second, independent reason that any older Vestige
+LongMemEval number is unusable: **the original `xiaowu0162/longmemeval` dataset
+is deprecated upstream.** It is replaced by `longmemeval-cleaned`, which removes
+noisy history sessions that interfered with answer correctness. A result
+computed against the deprecated original is invalid on that ground alone,
+regardless of the scoring bugs. This harness pins the cleaned release.
+
+**What it measures.** One metric: `evidence_recall@k` — after ingesting a
+question's haystack, does the concatenation of the top-k retrieved memories
+contain the gold answer string (normalised)? It is deliberately
+reader-independent and unambiguous, and asks exactly one thing: *did retrieval
+put the answer in front of the reader?*
+
+**What it does not measure.** Anything else. There is no reader, no judge, and
+no end-to-end task score. A real LongMemEval result needs both and would be a
+much larger claim. This exists to catch a silently broken harness — a retriever
+returning nothing, an ingest path dropping content, an embedding service that
+never warmed up — on a dataset entirely independent of MemConflict.
+
+```sh
+python3 benchmarks/memconflict/longmemeval.py --questions 5
+```
+
+The same four arms run here as in MemConflict. Default is 5 of 500 questions;
+each question carries a ~50-session haystack, so full runs are expensive and
+bounded by ingest throughput.
+
+---
+
+## Rules for citing any number from this page
+
+1. Always cite the arm, the dataset revision, the instance/session cap, and the
+   judge. A bare number is not a result.
+2. Never compare our absolute values to a published table.
+3. Always report the `bm25` control next to any `vestige` number. If Vestige
+   did not beat BM25, say so.
+4. Never cite CauseBench. Never cite the invalidated LongMemEval run.
+5. If a number cannot be reproduced from a clean checkout with the printed
+   command, it is not a number — retract it.

--- a/docs/UPGRADE-PLAN-2026-08.md
+++ b/docs/UPGRADE-PLAN-2026-08.md
@@ -15,6 +15,101 @@ Synthesized from seven parallel research lanes. Ranked by user-visible benefit �
 
 ---
 
+## POST-2.5.0 — the next phase (agreed Aug 30 2026)
+
+v2.5.0 shipped Tier 1 items 0, 1 and 2 (eval harness, reranker depth, #181). Four
+items were explicitly deferred to the release after it. Items 1 to 3 were agreed
+in conversation; item 4 was measured afterwards and is the best-evidenced of the
+four.
+
+### 1. Granite-embedding-311m-multilingual-r2 as an opt-in profile
+
+Full write-up in **TIER 2 #2** below, including the zero-downtime staging plan on
+PR #168's reversible profiles. Nothing to restate here.
+
+### 2. RRF-native fusion
+
+Replace the remaining multiplicative score blending with rank-based fusion, on the
+principle that independent signals should join as ranked lists and never as
+multipliers: a multiplier lets one signal's scale silently dominate, while a rank
+is scale-free by construction.
+
+Validate with **team-draft interleaving**, which is 10-100x more sensitive than
+split A/B for ranker comparison because both rankers serve the same query and only
+the click attribution differs.
+
+Note the constraint already recorded in the headline above: core hybrid search is
+ALREADY RRF (`sqlite.rs:6044`, `k=60`), and the 0.3/0.7 weights are dead outside
+benches. So this item is about the stages layered on top of that fusion, not about
+the fusion itself. Scope it precisely before starting, or it becomes a rewrite of
+finished work. **TIER 2 #6** (make RRF `k` configurable and measure) is the
+adjacent, smaller piece.
+
+### 3. Staleness prediction via backcalculation
+
+Brookmeyer & Gail 1986, the epidemiological method for inferring current unobserved
+prevalence from an observed lag distribution. Applied here: infer which memories
+have most likely gone stale from the distribution of observed staleness discoveries,
+rather than waiting to be told a memory is wrong.
+
+Speculative and unmeasured. It should be gated behind the eval harness like every
+other ranking change, and it is the weakest-evidenced of these four. Sequence it
+last unless it acquires supporting measurement.
+
+### 4. The accessibility state machine runs 2 of its 4 states
+
+**Measured Aug 30 2026, read-only against the live 2,930-memory store.** This
+supersedes an earlier, wrong claim in conversation that the stage was inert and
+changed no ordering; that came from a 50-result sample, not the corpus.
+
+| bucket | multiplier | count | share |
+|---|---|---|---|
+| Active | x1.00 | 873 | 29.8% |
+| Dormant | x0.70 | 2,057 | 70.2% |
+| Silent | x0.30 | **0** | 0% |
+| Unavailable | x0.05 | **0** | 0% |
+
+`retention_strength` spans **0.6129 to 1.0**, mean 0.7005. State is derived from it
+alone (`search_unified.rs:700-708`) at thresholds 0.7 / 0.4 / 0.1.
+
+Two consequences, and they point in opposite directions:
+
+- The stage is **not** inert. A binary x1.00 / x0.70 across a 70/30 split does
+  reorder results: a Dormant hit at score 1.0 falls to 0.7 and loses to an Active
+  hit at 0.8. It discriminates.
+- But **half the designed model is unreachable.** Silent and Unavailable cannot
+  fire, because nothing in the store falls below 0.61. Memories reach **217 days**
+  since last access (mean 37.9) and still do not decay into them. A four-state
+  forgetting model is operating as a two-state one, and the two states carrying
+  the actual forgetting semantics are decorative.
+
+Proximate cause, in source: the FSRS review path hardcodes
+`let new_retrieval_strength = 1.0;` (`sqlite.rs:4095`), so
+`retention = 0.7 + min(storage/10, 1.0) * 0.3` is **floored at 0.7** for anything
+reviewed. `apply_decay` pulls it down from there, but empirically never past 0.61.
+
+**The work is a decision, not a retune.** Determine whether this is a defect (decay
+too flat, or `retrieval_strength` wrongly pinned) or deliberate conservatism, then
+either fix the decay curve or delete the two dead states and stop advertising a
+four-state model. Do not blind-tune the constants.
+
+Two hard constraints:
+
+- This changes ranking for **every** memory of **every** user. It is gated on the
+  eval harness (`benchmarks/memconflict/`) like every other ranking change, and it
+  needs a before/after on the same seeds.
+- It interacts with the v2.4.0 suppression fix. `suppress` and `demote` deliberately
+  no longer stamp `last_accessed`, because `apply_decay` recomputes retention from
+  `days_since(last_accessed)`. Any change to that recomputation must not silently
+  re-break inhibition. See the v2.4.0 CHANGELOG entry before touching it.
+
+**Recommended order:** 4, then 1, then 2, then 3. Item 4 is measured, self-contained,
+and affects every query today. Item 1 is well-specified and independent of ranking.
+Item 2 needs scoping before it can be estimated. Item 3 needs evidence before it
+deserves a slot.
+
+---
+
 ## TIER 1 — do next
 
 ### 0. Stand up the retrieval eval harness (medium, prerequisite for 4 items below)

--- a/docs/UPGRADE-PLAN-2026-08.md
+++ b/docs/UPGRADE-PLAN-2026-08.md
@@ -1,0 +1,316 @@
+# Vestige Upgrade Plan — August 30, 2026
+
+Synthesized from seven parallel research lanes. Ranked by user-visible benefit ÷ migration cost. Every claim traced to a primary source or to verified repo source. Where lanes contradicted each other, the contradiction is stated, not smoothed.
+
+---
+
+## The headline
+
+**Three of the seven lanes independently concluded "measure on Vestige's own corpus before locking this in."** Reranker depth, RRF `k`, HyDE gating, temporal-contiguity weight, and any int8 model swap are all blocked on the same missing thing: a retrieval eval harness. CauseBench is retracted (CHANGELOG.md:170-181) and LongMemEval v1 was invalidated. **The harness is the true item zero** — without it, four Tier-1 tunables become guesses, and you have no way to prove any of this worked.
+
+**Two corrections to the stack description, both verified in source:**
+
+1. Vestige does **not** use fixed 0.3/0.7 weighted fusion. `crates/vestige-core/src/storage/sqlite.rs:6042` reads `let _ = (keyword_weight, semantic_weight);` and line 6044 calls `reciprocal_rank_fusion(&keyword_results, &semantic_results, 60.0)`. The 0.3/0.7 constants are dead outside benches. Any advice to "move to RRF" is advice to redo finished work.
+2. Vestige does **not** advertise MCP 2026-07-28. `crates/vestige-mcp/src/protocol/types.rs:9` is `2025-11-25`; `server.rs:68` lists four supported revisions, none of them 2026-07-28. It answers `server/discover` as a compat probe with a doc comment (server.rs:315-328) explaining the deliberate exclusion. That is correct and honest — do not "fix" it.
+
+---
+
+## TIER 1 — do next
+
+### 0. Stand up the retrieval eval harness (medium, prerequisite for 4 items below)
+
+Not an upgrade; the instrument that makes the rest of this plan executable. LongMemEval_S (~115K tokens, 40 sessions) as the sanity baseline, **MemConflict (arXiv 2605.20926) as the flagship**. MemConflict is where the entire field fails: MemOS 0.5539, Letta 0.4871, A-Mem 0.4452, Mem0 0.3612, Memobase 0.3553, LangMem 0.2822, and the best Conflict Recognition Score across all six is 0.2501. Vestige ships contradiction inspection as a first-class tool; none of the six does.
+
+Run the no-memory and naive-BM25 controls **first** and publish them alongside — MemDelta (arXiv 2606.29914) shows memory systems routinely underperform controlled baselines, and after the CauseBench retraction a second unreproducible number is fatal. Preregister the protocol and ship the harness in-repo.
+
+### 1. Fix reranker starvation — `overfetch_multiplier` 3→5, precise 1→3 (small, largest measured recall delta per line changed)
+
+`crates/vestige-mcp/src/tools/search_unified.rs:463-467`. Verified in source:
+
+```rust
+let overfetch_multiplier = match retrieval_mode {
+    "precise" => 1,    // No overfetch — return exactly what's asked
+    "exhaustive" => 5, // Deep overfetch for maximum recall
+    _ => 3,            // Balanced default
+};
+```
+
+T2-RAGBench (arXiv 2604.01733, Apr 2 2026, 23,088 queries / 7,318 docs) reranker-depth ablation: **20 candidates → Recall@5 0.458; 50 → 0.826; 100 → 0.888.** There is a cliff below 50. At the default `limit` of 10, balanced mode feeds the cross-encoder 30 candidates and precise mode feeds it **10** — precise mode runs a cross-encoder over a pool small enough that it can only reorder, never rescue.
+
+There is an internal inconsistency worth naming: `crates/vestige-core/src/search/reranker.rs:23` already declares `DEFAULT_RETRIEVAL_COUNT: usize = 50`. The reranker's own config says 50; the MCP tool path never gives it 50. The `.min(100)` cap at line 479 already bounds DB load.
+
+Cost: latency only, +67% pairs scored in balanced mode. Precise mode is documented as "fast, token-efficient" — use 3x there, not 5x. Single benchmark, single domain (financial text-and-table), so validate on the harness from item 0 before locking the constant.
+
+### 2. Fix #181 — stale per-process vector index via `PRAGMA data_version` watermark (small, closes an open bug)
+
+Verified: the index is rebuilt from `embedding_profile_vectors` at startup (`sqlite.rs:1413`, `build_embedding_profile_index` at :1425) and is **never persisted** — `save()`/`load()`/`view()` in `search/vector.rs` have zero production callers. The index is pure derived state over SQLite, so there is no index file to reconcile, only rows past a watermark to `add()`. `usearch` 2.23.0 already supports incremental `add()` on a live index. `PRAGMA data_version` increments on a connection when another commits, so the staleness check is effectively free per query.
+
+Today, concurrent MCP server processes are semantically blind to each other's writes — silent duplicates through the prediction-error gate, incomplete recall. The FTS5 leg reads SQLite directly and is unaffected, which is exactly why this failure is partial and hard to notice.
+
+Risk: `semantic_search_raw` (sqlite.rs:6308) holds the reader lock and the index `Mutex` in a fixed order; a reload path inside it can deadlock against non-reentrant lock ordering. Decide explicitly on reload failure — degrade to keyword-only **and say so in the response**, never silently return a partial result.
+
+### 3. Bump fastembed 5.11 → 6.0.2, candle 0.10.2 → 0.11.0 (small, enabler for everything downstream)
+
+`crates/vestige-core/Cargo.toml:143-146`, verified. No re-embed. This is the gate on every subsequent embeddings/runtime lever, because 5.11 exposes none of `with_intra_threads`, `with_execution_providers`, `with_max_length`, `with_dimension_override`. Vestige currently passes exactly `.with_show_download_progress(true).with_cache_dir(cache_dir)` at `embeddings/local.rs:122` and `search/reranker.rs:131` — nothing else.
+
+6.0.2 pins `ort = "=2.0.0-rc.13"` (ONNX Runtime 1.28, opset 24) vs the 1.24-era runtime behind 5.11.
+
+Three things to handle:
+- **Breaking:** `fastembed::Error` moved from an `anyhow::Error` alias to a `thiserror` enum (PR #278). Two call sites, both currently plain `match` on Ok/Err.
+- Align Vestige's own `candle-core`/`candle-nn` pins to 0.11.0 in the same PR or you compile two copies of candle.
+- Both Nomic builtin profiles pin `immutable_model_revision: "fastembed-catalog-5.11"`. That string is load-bearing — revise it deliberately, not incidentally.
+- **Re-run `scripts/check-glibc-floor.sh`.** A fastembed major can pull a new `ort-sys`, which can move the symbol floor this branch exists to hold at GLIBC_2.34.
+- Keep `tokenizers` at 0.22.2 — it exactly matches fastembed 6.0.2's own pin. Moving to 0.23.1 ahead of fastembed buys nothing.
+
+**Known sharp edge:** rc.13 has a teardown SIGSEGV under `load-dynamic` when the loaded libonnxruntime is older than 1.23 (pykeio/ort#614; exit 139 on ORT 1.20/1.22, exit 0 on 1.23.2). The fix (ort#610) merged 2026-08-23, **after** rc.13 shipped — it lands in rc.14. Vestige ships this exact configuration as its `ort-dynamic` feature. Until rc.14, document a minimum system ONNX Runtime of 1.23.
+
+### 4. Unpin usearch =2.23.0 → 2.26.1 (medium — **two lanes contradict each other here**)
+
+`Cargo.toml:170`, with an in-file comment reading "unum-cloud/usearch#746. Unpin when the upstream fix lands." **Issue #746 closed 2026-04-18**, fixed in v2.25.0; four releases have shipped since without reopening. The comment's own condition is met. 2.26.1 additionally carries "Fixed Windows CRT selection via Cargo," directly relevant to the Windows MSVC release job, plus hash-lookup tombstone reclamation under churn (which matters — Vestige removes/re-adds vectors on suppress and purge).
+
+**Unresolved contradiction, do not skip:** the rust-runtime lane says preserve `features = ["fp16lib"]` through the bump (citing the Cargo.toml:160-163 comment recording PR #94 / issue #93, MSVC fatal C1021 from a `#warning` branch). The vector-index lane read usearch's **main-branch** Cargo.toml and reports `[features]` is now `numkong / openmp / simsimd` with `default = ["numkong"]` and **no `fp16lib` at all** — meaning the current feature line would fail to resolve.
+
+Resolve empirically before writing any code: pull the manifest for **2.26.1 specifically** (not main) and read it. If `fp16lib` is gone, both original constraints must be re-derived against NumKong v7 — (a) issue #71, does the config still avoid AVX2/FMA dispatch on pre-Haswell x86_64, and (b) issue #93, does Windows MSVC stay clean. Test matrix must include Windows MSVC, which `ci.yml` still does not cover (only `release.yml` compiles it). Also verify the on-disk index format is unchanged across 2.23→2.26, or every user's index silently invalidates.
+
+When this lands, **rewrite** the Cargo.toml:150-170 comment block for NumKong v7 rather than deleting it. It encodes two real production incidents; delete it and the next dependency cleanup re-breaks Windows exactly as before.
+
+### 5. Document and guard the x86-64-v3 CPU baseline (small, latent SIGILL affecting real users today)
+
+This is not on anyone's radar and it should be. ort's own docs: *"All x86-64 binaries are compiled with a baseline requirement of x86-64-v3"* — Intel Haswell 2013+, Gracemont, AMD Excavator or any Ryzen — and *"Linux binaries are compiled with Clang, not GCC, and depend on libc++."* Pre-2013 Intel and low-end Pentium/Celeron users get an **illegal instruction at first inference**, not a clean startup link error. That presents as a mystery crash report, not as the tidy glibc failure that got diagnosed on this branch.
+
+Cheap now: a documented CPU floor in README + release notes, and ideally a startup capability check that fails loudly with an actionable message. The structural fix is Tier 2 #1.
+
+### 6. Add `outputSchema` to the 14 advertised tools (small, real spec gap at the *current* revision)
+
+Vestige emits `structuredContent` (server.rs:644, 659, 1461, 1474) while declaring no `outputSchema` in `tools/list` (handle_tools_list, server.rs:367+). Spec: *"Clients SHOULD validate structured results against this schema."* No client can validate, no client gets type info, the LLM gets no parsing guidance. This is a gap at 2025-11-25, not a 2026-07-28 requirement.
+
+Sharp edge: once `outputSchema` is declared, servers **MUST** return conforming structured results. The error paths at server.rs:659/1474 also set `structured_content`, so the schema must admit the error shape. Start with `recall` and `smart_ingest`, not all 14 at once.
+
+### 7. Run the official MCP conformance suite (small, converts a claim into a number)
+
+`npx @modelcontextprotocol/conformance server --url http://localhost:PORT/mcp --requirements 2025-11-25`. Same suite that scored the Rust SDK 67/67 server / 50/50 client for its Tier 1 promotion on 2026-08-21. Read-only external client, breaks nothing. Run against the Streamable HTTP listener (`protocol/http.rs`, POST /mcp); dispatch is shared with stdio so findings apply to both. Then run it again with `--requirements 2026-07-28` to get an itemized gap list, which replaces guesswork about Tier 3 #1's scope.
+
+### 8. Fix the `metal` feature — it accelerates nothing Vestige ships (small, honesty fix)
+
+`Cargo.toml:87` declares `metal = ["fastembed/metal"]`. fastembed's `metal` resolves to `["qwen3", "nomic-v2-moe", "candle-core/metal", "candle-nn/metal"]` — **no `ort/*` entry at all**. Vestige's production embedder is `EmbeddingModel::NomicEmbedTextV15` on the ONNX path and its reranker is `RerankerModel::JINARerankerV1TurboEn`, also ONNX. Building with `--features metal` today pulls in candle + Metal kernels, inflates build time and binary size, and delivers zero acceleration to the two models that actually run.
+
+Either delete it or rename/document it as applying only to the optional qwen3 / nomic-v2-moe candle embedders. Call it out in CHANGELOG.md — it is a visible cargo feature change. The real Apple Silicon lever on the ONNX path is `with_intra_threads`, unlocked by item 3.
+
+---
+
+## TIER 1 sequencing
+
+```
+0. Eval harness (MemConflict + LongMemEval_S + controls)   ── unblocks 1, and Tier 2 measurement
+   │
+   ├─ 1. overfetch_multiplier          search_unified.rs      ── measure on harness, then land
+   ├─ 2. #181 watermark                sqlite.rs, vector.rs   ── independent
+   ├─ 6. outputSchema                  server.rs              ── independent
+   ├─ 7. conformance run               (external, no code)    ── run today, no dependencies
+   └─ 5. CPU baseline doc              README, release notes  ── independent
+
+3. fastembed 6.0.2 + candle 0.11 ──┬── 8. metal feature fix   (same Cargo.toml block)
+   (re-run check-glibc-floor.sh)   └── 4. usearch 2.26.1      (same Cargo.toml block)
+                                        ↑ resolve fp16lib contradiction FIRST
+```
+
+**File conflicts to plan around:**
+- Items 3, 4, 8 all edit `crates/vestige-core/Cargo.toml` lines 87 and 139-170. Land them as **one dependency PR**, not three — and per the project's own "don't stack is competition-only" rule, batching product fixes into one mega-PR with the suite green is the correct pattern here.
+- Items 1 and 2 touch different crates (`vestige-mcp/tools/search_unified.rs` vs `vestige-core/storage/sqlite.rs`) but both change retrieval behavior. Land **2 before 1** — fixing the stale index changes what candidates exist before you tune how many get reranked, and doing it the other way round confounds the depth measurement.
+- Item 7 has zero code dependencies. Run it today, in parallel with everything.
+- Items 3+4 must precede any Tier 2 embedding or runtime work.
+
+---
+
+## TIER 2 — worth doing, needs a migration plan
+
+### 1. Replace pyke prebuilts with Microsoft's own ONNX Runtime tarball (medium — structurally fixes the bug this branch exists for)
+
+**Root cause of the GLIBC_2.38 break, primary source:** every Linux row in `pykeio/ort-artifacts/.github/workflows/build.yml` is `runs-on: ubuntu-24.04`. Confirmed by the maintainer in pykeio/ort#523 (opened 2026-01-29, closed the next day): *"I believe I had to switch to the Ubuntu 24.04 runner because ONNX Runtime started requiring it… I'll look into downgrading to 22.04 for future builds, but that's only glibc 2.35."*
+
+Microsoft builds its own Linux artifacts in a **manylinux_2_28** container — glibc 2.28 floor, covering RHEL/Alma/Rocky 8, Amazon Linux 2023, Debian 10+, every Ubuntu from 18.04. Upstream's best offer is 2.35. Switching to Microsoft's artifact is strictly better than waiting, and it kills the x86-64-v3 SIGILL from Tier 1 #5 at the same time. ONNX Runtime 1.29.0 (2026-08-12): Linux x64 11.1 MB, aarch64 10.0 MB, osx-arm64 41.6 MB.
+
+Cost: Vestige stops shipping one self-contained static binary on Linux. `release.yml` must fetch and unpack per target. **`ORT_DYLIB_PATH` resolves relative to the executable**, and cargo examples/tests build into `target/<profile>/examples` and `.../deps` — a classic way to break CI without breaking the release. Prefer `ort::init_from(dylib_path)` at startup over the env var. You also trade pyke's build attestation for Microsoft's checksums.
+
+Verify before committing (I did not download the tarball):
+```
+objdump -T libonnxruntime.so | grep -o 'GLIBC_[0-9.]*' | sort -uV | tail -1
+```
+Do **not** use the `alfatraining/ort-artifacts` fork — stale since 2026-01-26, still building ORT 1.23.2, 4 stars.
+
+### 2. Granite-embedding-311m-multilingual-r2 as a new opt-in profile (medium, forces re-embed — staging plan below)
+
+`ibm-granite/granite-embedding-311m-multilingual-r2`, arXiv 2605.13521, May 14 2026. Apache 2.0. **32,768-token context (4× nomic's 8,192).** 768d native with official Matryoshka to exactly 256d. Official ONNX + OpenVINO weights. No query/document prefixes.
+
+Paper Table 5: **65.2 MMTEB Multilingual Retrieval vs EmbeddingGemma-300m's 62.5** in the same table. Table 8 gives explicit 256d truncation results: 64.7 multilingual (−0.5 vs full 768d), 51.6 English, 63.4 code — so Vestige's existing 256d storage decision costs almost nothing on this model.
+
+**Honest gap:** I could not find a same-source benchmark comparing Granite R2 directly to nomic-embed-text-v1.5. Vestige's prior research recorded nomic at MTEB v1 62.28@768d / 61.04@256d, which is **not comparable** to MMTEB Retrieval numbers. The defensible public claim is the head-to-head win over EmbeddingGemma plus 4× context at identical licence — not a numeric delta against nomic.
+
+Integration cost: Granite is **not** in fastembed's catalogue (I enumerated all 46 `EmbeddingModel` variants in 6.0.2; absent). Needs `TextEmbedding::try_new_from_user_defined` with `UserDefinedEmbeddingModel` + `InitOptionsUserDefined`. Architecture is ModernBERT (alternating attention, GeGLU, RoPE, 262,152-token Gemma-3 vocab) — a real ONNX-export risk in principle, **de-risked twice**: IBM ships official ONNX itself, and fastembed already carries `ModernBertEmbedLarge`, proving the ModernBERT-through-ort path works. Download grows from ~90MB to a 311M-param ONNX; use the quantized build.
+
+### How PR #168's reversible profiles stage this with zero downtime
+
+`crates/vestige-core/src/embedding/profile.rs` already contains everything a model swap needs. **Do not build new migration machinery.**
+
+1. **Add, don't replace.** Register Granite as an *additional* builtin `EmbeddingProfileId`. `NomicRetrieval256` stays the default. No existing user is disturbed; no upgrade re-embeds anything.
+2. **Pin the artifacts.** The registry *rejects* a profile whose `verified_model_artifact_hashes` is empty, so pin the ONNX hashes and `immutable_model_revision` exactly the way `QWEN_06B_REVISION` / `qwen_06b_artifacts` already do. This is the mechanism that makes the migration reversible rather than lossy.
+3. **Set `EncodingTemplate::Raw`.** Granite needs no prefixes, unlike nomic's `search_query:`/`search_document:`. Because templates are per-profile, prefix conventions cannot drift invisibly at call sites.
+4. **Opt in per user, resume via cursor.** `EmbeddingProfileMigration` already carries `source_profile_id`, `destination_profile_id`, and `last_memory_id` — a resumable re-embed cursor. Drive the corpus through it in the background.
+5. **Scope search to one `profile_id` until the cursor completes.** `EmbeddingProfileId` is the foreign key on stored vectors, so Nomic and Granite vectors never mix in a single ANN query. During migration, semantic search stays on the source profile; it flips atomically when `last_memory_id` reaches the end.
+6. **Rollback is free.** The source profile's vectors were never deleted. Reverting is a default-profile flip, not a restore.
+
+Same machinery covers **any** future re-embed, including the int8 nomic swap in Tier 3 — which is exactly why that must never be a silent config flip.
+
+### 3. MemSecBench — publish a Selective Repair Success Rate (medium, security differentiator on existing machinery)
+
+arXiv 2607.27080, Jul 29 2026, Zhejiang UT. 24 configurations, 310 cases from 48 contexts: **84.2% memory-poisoning success, 50.3% end-to-end attack success, 56.1% selective repair success.** The decisive number is a **30.2-point gap** between removing the poisoned memory (86.3%) and repairing without collateral damage to benign memories (56.1%). Current systems cannot delete one bad memory without destroying good ones.
+
+Vestige's purge (content removed, embeddings removed, content-free tombstone retained) plus suppress is precisely the primitive that gap describes, and the paper concludes no current backend has it.
+
+**Run this AFTER Tier 1 #2 and #4.** Running it honestly will expose whether purge actually removes embeddings from the in-process HNSW index rather than only from SQLite. HNSW deletes are soft; usearch 2.23.0 tombstones rather than compacts (2.26.0 adds hash-lookup tombstone reclamation, which is why the version bump comes first). If purge leaves a recoverable vector, the benchmark will find it — fix that before publishing, not after.
+
+### 4. Async write path (medium)
+
+"Async writes by default" is production requirement #1 in mem0's State of AI Agent Memory 2026 (Aug 29 2026). MemOS 2.0 "Stardust" (Aug 17 2026, Apache 2.0) ships MemScheduler; Letta's sleep-time agents fire every N steps (default 5). Vestige's FSRS-6 scheduling machinery means the scheduler concept is half-built; what's missing is decoupling the write from the agent turn.
+
+Breaks read-after-write consistency — any test or hook that ingests then immediately recalls goes flaky. Needs an explicit flush/await path for tests and the save-guard hook, plus a durable queue so a crash between accept and index does not silently lose a memory.
+
+**Blocked on #180.** See the open-bugs section.
+
+### 5. Adaptive IDF fusion weighting (medium)
+
+vstash (arXiv 2604.15484, Apr 20 2026) is a near-exact architectural twin of Vestige — local-first, single SQLite file, FTS5 + vector, RRF, small local embedding model. Adaptive per-query weighting from mean IDF of stemmed query terms, read from SQLite's `fts5vocab` virtual table. No LLM, no model, no network.
+
+NDCG@10 across 5 BEIR datasets, zero regressions: SciFact +0.1%, NFCorpus +1.8%, SciDocs +1.7%, FiQA +3.4%, ArguAna +21.4%. **The paper itself states the ArguAna number comes primarily from a companion distance-cutoff change, not IDF weighting.** The defensible IDF-only band is +1.7% to +3.4%.
+
+Requires moving from rank-based RRF to weighted RRF or a normalized convex combination. Interacts with the existing `keyword_bypass_threshold` (search_unified.rs:581) — both are lexical-confidence mechanisms; do not double-count.
+
+### 6. Make RRF `k` configurable and measure (small, but do NOT blind-swap)
+
+`HybridSearchConfig` already carries an `rrf_k` field defaulting to 60.0 that the live sqlite.rs:6044 path ignores. Wiring it through is the change.
+
+Three sources say 60 is not optimal: T2-RAGBench (k=60 → Recall@5 0.695; k=10 → 0.716), OpenSearch's 6-dataset BEIR benchmark (RRF 3.86% *lower* NDCG@10 than tuned score-normalization fusion), and Qdrant's guidance that best `k` tracks relevant-docs-per-query (k=2–5 when ~1 relevant doc). Memory recall typically has few relevant memories per query, arguing for low `k`.
+
+**Counter-evidence, reported honestly:** Bruch et al. (arXiv 2210.11934) find NDCG swings wildly with RRF parameters and that tuned parametric RRF does not generalize out-of-domain. Hence "configurable and measure," not "set k=10."
+
+### 7. Gate HyDE behind measurement (small)
+
+T2-RAGBench Table I: HyDE was the **worst of ten methods** — Recall@5 0.544 vs vanilla dense 0.587 vs BM25 0.644 vs hybrid RRF 0.695. Explicit recommendation: *"Avoid HyDE for domains with precise numerical or entity-centric queries."* Vestige's protected exact-lookup semantics are entity-centric by definition.
+
+**Scope limit, stated honestly:** Vestige's HyDE (sqlite.rs:6321-6333) is *template-based query-variant expansion averaged into a centroid*, not LLM-generated pseudo-documents. The paper's causal mechanism — an LLM hallucinating wrong figures and dragging the query embedding off-target — does not directly apply. This is strong suggestive evidence to A/B, not proof to delete. The literal/concrete bypass at search_unified.rs:94 already protects the highest-risk cases. Keep `centroid_embedding()` and `expand_query()` exported; `benches/search_bench.rs` uses them.
+
+### 8. Multi-signal ranking: recency + trust + graph proximity (small, with one hard constraint)
+
+Both independent 2026 surveys (Vectorize Mar 14, bymar Apr 16) list multi-strategy search as an expected capability. Reference implementation on the identical substrate: engram-mcp scores `0.6 × cosine + 0.2 × recency + 0.2 × importance` over SQLite FTS5 + ONNX. Vestige already computes FSRS-6 retention and holds a graph — the signals exist and are simply not in the ranker.
+
+**Hard constraint:** recency weighting actively harms exact-lookup (env vars, UUIDs, paths, quoted strings) — a behavior CLAUDE.md explicitly protects. The new signals must be zero-weighted on the exact-lookup path. Gate behind a config flag and A/B it.
+
+### 9. Temporal contiguity / context reinstatement (small, genuine gap, unmeasured benefit)
+
+Verified gap: zero matches for `contiguity` or `temporal_neighbor` across all crates. `neuroscience/context_memory.rs` implements Tulving & Thomson (1973) encoding specificity as static context *matching*, which cannot surface a memory temporally adjacent to a hit but semantically dissimilar.
+
+Mechanism: Howard & Kahana (2002) Temporal Context Model, confirmed to operate in modern LLMs at ICML 2026 (Pink et al., poster Jul 8 2026) — localized to a one-dimensional temporal code reinstated by a single attention head, whose ablation significantly degraded temporal-order performance. Same class of win as `retroactive_backfill.rs`: surfaces episodically related memories that pure semantic similarity structurally cannot reach.
+
+Reads `created_at` timestamps that already exist, adds a re-ranking boost. No schema change, no re-embed, pure Rust, no new dependency. **The ICML paper measures LLM internals, not Vestige-shaped retrieval** — the gain size is unmeasured. Default the weight low, validate on the item-0 harness before default-on.
+
+### 10. Recency-weighted FSRS-6 optimizer loss (small, small measured benefit)
+
+`crates/vestige-core/src/fsrs/optimizer.rs` trains 21 weights with no sample weighting (grep for recency/sample_weight returns nothing). srs-benchmark (9,999 collections, 349.9M reviews, table re-run 2026-08-29): FSRS-rs (FSRS-6 + recency weighting) LogLoss **0.3443** / RMSE(bins) **0.0635** / AUC **0.7074** vs plain FSRS-6 at 0.3460 / 0.0653 / 0.7034. Same 21 parameters, same model — the gain is purely the training loss weighting. The effect replicates independently within FSRS-7 (0.3370 recency vs 0.3401 plain).
+
+Zero stored-state change; `ReviewLog` already carries `elapsed_days` as f64. Users who have already optimized get slightly different weights on their next run. Do this when you next touch the optimizer.
+
+### 11. Qwen3-Reranker-0.6B as an opt-in high-accuracy tier (medium, NOT a default swap)
+
+BEIR nDCG@10 **56.94 vs 49.60** for jina-reranker-v1-turbo-en, roughly +7.3. **Comparability caveat:** 56.94 is from Jina's July 2026 v3.5 table, 49.60 is Jina's own 17-dataset figure on the v1-turbo model card — different protocols. Treat the delta as directionally large, not exact. Apache 2.0, commercially clean.
+
+Not in fastembed's `RerankerModel` enum (verified in the vendored source: exactly `BGERerankerBase`, `BGERerankerV2M3`, `JINARerankerV1TurboEn`, `JINARerankerV2BaseMultiligual`), so it needs `TextRerank::try_new_from_user_defined`. Harder: Qwen3-Reranker is a **decoder** with left-padding that scores via a yes/no token logit, not a sequence-classification head — fastembed's logit extraction needs a shim. fp32/fp16 ONNX are deliberately absent upstream (single-file size limit), so you are committed to int8 or q4. Download grows ~150MB → 400MB–1.2GB.
+
+**Latency is the blocker to default adoption.** ~380ms/query CPU reported (weak source) vs ~85ms on a T4; mxbai's comparable 0.5B needs 0.67s on an A100. Benchmark on the M1 Max at 50 candidates before this goes anywhere near the default path. **No re-embed** — rerankers score (query, document-text) pairs at query time and never touch stored vectors. A user with 10,000 memories migrates for free.
+
+---
+
+## TIER 3 — interesting, speculative, or blocked
+
+| Item | Status |
+|---|---|
+| **MCP 2026-07-28 implementation** | Large. Every result needs `resultType`; sessions/`Mcp-Session-Id` become dead (SEP-2567); `handle_initialize` bypassed (SEP-2575); per-request `_meta` parsing is new code. Vestige has **zero exposure** to every deprecation (no roots/sampling/logging, already on Streamable HTTP not HTTP+SSE, already uses -32602, already deterministic tools/list). Nothing urgent. Run Tier 1 #7 with `--requirements 2026-07-28` first to get the exact scenario list. |
+| **rmcp 3.1.4 adoption** | Large, and the strategic *alternative* to the above, not an addition. Rust SDK promoted to Tier 1 on 2026-08-21 (67/67 server, 50/50 client, same-day spec tracking). Would outsource all future spec churn. But rmcp owns the server loop, transport, and dispatch — Vestige's `match method.as_str()`, its 22 hidden deprecated-tool redirects, `anthropic/maxResultSizeChars` handling, `vestige/` custom methods, and `protocol/auth.rs` all need re-homing, into a project that currently has **zero** MCP dependencies. Prototype behind a feature flag and diff conformance scores before committing. |
+| **FSRS-7** | **Blocked on ecosystem.** Measurably better (LogLoss 0.3370 vs 0.3460, AUC 0.7220 vs 0.7034) but **no shipped Rust implementation** — crates.io `fsrs` max is 6.6.2, and the benchmark itself labels "FSRS-rs" as the Rust port of FSRS-6. Work is in unmerged fsrs-rs PRs #395/#426, last activity 2026-07-06. Anki 26.09b1 still ships FSRS-6. **Do not hand-roll it**: FSRS-7 redefines stability (S is no longer the interval at R=90%), and its 8-parameter dual-trace power-law mixture has no closed-form inverse, making interval computation a root-find. That is a from-scratch reimplementation plus migration of every stored stability value for ~2.6% LogLoss. Watch PR #426. **Note when it lands:** FSRS-7 fits Vestige *better* than Anki — its headline change is fractional intervals and realistic same-day predictions, and Vestige's "reviews" are accesses at arbitrary sub-day times, the exact regime FSRS-6 handles worst. `ReviewLog` already stores `elapsed_days` as f64. |
+| **MemReranker-0.6B** | **Blocked on licence.** The single most domain-matched model found: distilled specifically for agent-memory retrieval (temporal constraints, causal reasoning, coreference), LoCoMo MAP 0.7150 / nDCG@10 0.7540 — beating BGE-reranker-v2-m3 by 4.4pp MAP **and** the 7× larger Qwen3-Reranker-4B. ~200ms. **The weights licence is unverified** — MemOS repo is Apache 2.0, the paper is silent, and the HF model page returned HTTP 401. No ONNX export exists. Verify the licence field, then benchmark, then decide. LoCoMo is dialogue-memory, not code/technical memory, so gains may not transfer. |
+| **int8 nomic (`NomicEmbedTextV15Q`)** | Already in fastembed's registry, no new dependency. M1 Max meets the hardware precondition (ARMv8.2 SDOT/UDOT, the exact instruction class ONNX Runtime's quantization doc names), and ORT has been adding Arm64 low-precision kernels through 2026. **But ONNX Runtime publishes no headline int8 CPU speedup and warns "it is not rare to get worse performance on old devices."** And this is a **silent migration event**: dimensionality is unchanged (768→256), so nothing errors and no schema check fires — the corpus just degrades as new memories land in a slightly different space. Must go through the PR #168 profile machinery, never a config flip. Measure recall@k, not just latency; a 30% latency win that costs recall is a bad trade for a product whose value proposition is retrieval quality. |
+| **ort-tract / ort-candle** | Timeboxed spike only. `alternative-backend` sets `ort-sys/disable-linking` — nothing downloaded, nothing linked against libc++, no glibc floor, no x86-64-v3 baseline. Structurally deletes the entire packaging problem. **But** fastembed pins ort with `api-24` while both backends declare `ort-sys` at `api-17` — anything above that returns a null function pointer **at runtime, not compile time**. Both backends document only a partial API and "Only Tensor types are supported." ort-tract demands rust-version 1.91, raising MSRV. Budget a spike answering exactly two questions: do both models load, and do the vectors match fp32 ONNX within tolerance. |
+| **arroy 0.8.0** | Only if the #181 watermark fix proves unworkable under the existing lock ordering. LMDB-backed, structurally multi-process (*"many processes may share the same data and atomically modify the vectors"*), eliminates the startup rebuild. But it is a random-projection forest, not HNSW — `connectivity`/`expansion_add`/`expansion_search` have no equivalent, `n_trees`/`search_k` need re-tuning from scratch, and it adds a second on-disk store, so purge/unlearning must stay honest across two backends. Do not lead with this. |
+| **sqlite-vec** | Architecturally the best long-term answer (index inside the same SQLite file, so #181 cannot recur) but **not ready**: stable is 0.1.9, ANN indexing only exists in the 0.1.10 alpha cycle with `ivf` marked experimental and DiskANN still getting statement-cleanup fixes as of 0.1.10-alpha.4 (2026-05-18). Also adds a loadable-extension distribution story across seven release targets. Revisit at 0.1.10 stable. |
+| **Consolidation / reflection layer** | The recommendation to be **most** skeptical of. Hindsight leads BEAM at every tier (73.4% @100K, 64.1% @10M vs Honcho 40.6%, RAG 24.9%) on the strength of synthesizing higher-order knowledge. But it requires an LLM in the write path — collides head-on with local-first — and it manufactures derived memories that can be wrong, compounding the contradiction problem MemConflict measures. **See RecMem (arXiv 2605.16045, ACL 2026 Findings) for the right shape if you ever do it:** recurrence-gated consolidation cuts memory-construction token cost by up to 87% while exceeding accuracy, and the recurrence detector is a clustering pass over embeddings Vestige already computes. Do this after the MemConflict and MemSecBench numbers land, never before. |
+| **EmbeddingGemma-300m** | Deliberately **de-prioritized** despite being the obvious pick and a one-line change in fastembed 6. Two disqualifiers: **2,048-token context vs nomic's 8,192** — a 4× regression against profiles declaring `maximum_token_limit: 8192` with `ChunkingStrategy::WholeDocument`, silently truncating any memory over 2K tokens; and the model card licence is **`gemma`** (ai.google.dev/gemma/terms), **not Apache 2.0**. The HF launch blog says Apache 2.0 and is **wrong**; the model card is authoritative. Gemma terms carry a Prohibited Use Policy and redistribution obligations — a live issue for a self-contained binary with a paid tier. Keep as the fallback if Granite's custom-ONNX integration stalls. |
+
+---
+
+## Do NOT change — verified still current
+
+**Architecture and design decisions that are correct today.** This list is as load-bearing as the upgrade list.
+
+- **The two-stage architecture (hybrid recall → cross-encoder rerank).** This is the single highest-leverage thing Vestige already owns. "Beyond the Reranker" (arXiv 2606.28367): removing the cross-encoder collapses retrieval outright and costs **30 points of answer F1**, an effect no other pipeline enhancement approaches. T2-RAGBench: Hybrid+Rerank 0.816 Recall@5 vs hybrid RRF alone 0.695, BM25 0.644, dense 0.587. Fix the depth; do not redesign the stage.
+- **RRF over linear fusion in the live path.** Already done and correctly reasoned (comment at sqlite.rs:6038-6041). The old linear path used max-only normalization (`score / max_keyword`, hybrid.rs:78-88) — the weakest normalization choice and the likely cause of the paraphrase-burying it replaced.
+- **256d Matryoshka truncation.** Validated, not merely tolerated. Granite Table 8: 64.7@256d vs 65.2@768d (−0.5). EmbeddingGemma card: 68.37@256d vs 69.67@768d. Truncation is close to free on modern MRL-trained models. Keep the layer-norm → truncate → L2-normalize implementation.
+- **The embedding-profile system itself.** Needs no redesign. `EmbeddingProfileId` as the vector foreign key, pinned `immutable_model_revision` + `verified_model_artifact_hashes` with registry enforcement, per-profile encoding templates, and `EmbeddingProfileMigration` with a `last_memory_id` cursor. Every model swap in this plan rides on it.
+- **The existing Qwen3-Embedding profiles.** Apache 2.0, 32K context, MRL 32–1024d, 64.33 MTEB multilingual, correctly built with pinned revisions and hashes. Note for later: Qwen3 is decoder-only on the candle backend, not the ONNX path, and at least one practitioner benchmark has EmbeddingGemma beating Qwen3-0.6B at comparable size — so 0.6B is a fine opt-in, not an obvious default.
+- **HNSW as the algorithm, usearch as the implementation.** At 256d with a low-thousands corpus, brute force is already sub-millisecond; no index change produces a user-visible win. Six releases Dec 2025–Aug 2026, still in-process, still dependency-light.
+- **f32 vector storage — do not quantize.** i8 saves ~0.75MB per 1000 memories at 256d, noise on a 64GB machine, and costs measurable accuracy: MonaVec (arXiv 2606.19458) measures usearch-i8 at 0.928 vs 0.960 full-precision on AG News. Vestige is already lossy once via Matryoshka. Revisit above ~1M vectors.
+- **ONNX Runtime as the runtime.** Checked against burn (training framework, 0.22 still pre-release), mistral.rs (crates.io stranded at 0.8.1 from April, and it's an LLM serving stack), llama-cpp-2 (GGUF-only, trades one C++ packaging problem for another), mlx-rs (last release 2025-12-16, self-described "unofficial"). Nothing is a drop-in for a 137M BERT encoder + 37M cross-encoder.
+- **CoreML EP — do NOT enable.** This is the upgrade I expected to recommend and the evidence says no. Measured on M2 Max (k2-fsa/sherpa-onnx#2910, 2025-12-18, Transformer/Conformer): CoreML RTF 0.470 vs CPU 0.427 at 2 threads; 0.457 vs **0.372** at 10 threads. CoreML lost at both and lost by *more* as CPU threads scaled. ORT's only CoreML performance note is *"performance may be negatively impacted by inputs with dynamic shapes"* — exactly a text embedder's regime.
+- **No LLM-built knowledge graph.** GraphRAG-Bench (arXiv 2506.02404v3, 1,018 questions, 7M-word corpus, nine SOTA systems): best GraphRAG (HippoRAG) 72.64 vs **plain BM25 71.66**; two methods score *below* the no-retrieval baseline. Construction cost 33M–84M LLM tokens, 1.4–5.7 hours. Paying 33M tokens for +0.98 points is a local-first non-starter. Vestige's LLM-free `spreading_activation.rs` (stage 6 of search_unified.rs:796-814) is the correct call.
+- **No query decomposition.** arXiv 2606.05658: on MuSiQue, decomposition collapsed MRR from 0.469 to **0.102** and Success@5 from 1.0 to 0.063; even where it helped, latency went 21s → 48s. Corroborated by T2-RAGBench (multi-query 0.640 vs BM25 0.644, a wash).
+- **Late chunking is a non-issue.** Vestige does not chunk memories — atomic, embedded whole to MAX_TEXT_LENGTH 8192 (`embeddings/local.rs:26,321`). And the late-chunking paper's own nomic column (arXiv 2409.04701v3, Table 2) shows SciFact 70.7 → 70.6 (a *regression*) and NFCorpus 35.3 → 35.3 (flat). The widely-quoted +6.5pp is the jina-v2-small column, not nomic.
+- **No late-interaction / ColBERT rerank stage.** Late interaction's payoff is in *first-stage* retrieval with a multi-vector index — many vectors per memory, a storage-engine and usearch redesign that *would* force a re-embed, which none of the Tier 1/2 reranker items do. As a rerank stage over 50 candidates it gives up the query-document attention that is why a cross-encoder wins.
+- **The BM25-like term-overlap fallback when the cross-encoder is unavailable.** Correct local-first graceful degradation. Keep regardless of model choice.
+- **Do NOT move to the BGE reranker line.** `bge-reranker-v2-m3` is a one-line change in fastembed's enum and it is tempting, but it dates to **February 2024** — same generation as the model it would replace. 568M params for a result the MemReranker paper shows a 0.6B distilled model beats by 4.4pp MAP. BAAI has shipped nothing newer than bge-reranker-v2.5-gemma2-lightweight (July 2024). The line is stagnant. A 15× latency hit to land on a two-year-old model is the worst trade in the stack.
+- **Eager LLM consolidation — actively do not add it.** The strongest evidence in the whole synthesis: "Useful Memories Become Faulty When Continuously Updated by LLMs" (arXiv 2605.12978, May 13 2026) shows memory utility rises then degrades *below* the no-memory baseline — GPT-5.4 failed **54%** of ARC-AGI problems it had previously solved without memory, after consolidating from verified solutions. Their prescription is to keep raw episodes as first-class evidence and gate consolidation explicitly, which is exactly what Vestige does with preserved raw memories + explicit `advanced/merge_supersede.rs`. External validation of an existing design decision.
+- **Retrieval-induced forgetting, interference, encoding specificity, retroactive salience backfill.** All already shipped (`neuroscience/memory_states.rs` with RIF + competition_loss persisted in migrations.rs:405; `active_forgetting.rs` citing Anderson 1994; `context_memory.rs`; `advanced/retroactive_backfill.rs` as a faithful port of Zaki/Cai 2024 Nature 637:145-155 including the backward-only asymmetry). No 2025-2026 result supersedes any of them.
+- **FSRS-6 itself.** `fsrs/algorithm.rs` implements the correct 21 weights and the correct power forgetting curve including personalizable decay w20. Matches what Anki 26.09b1 ships today.
+- **SM-20 — non-starter.** Proprietary cloud API, early-access rate limits (100 reps/day free, 10,000 historical import cap), no Rust binding, not in srs-benchmark so no independent comparison. Cannot back a local-first core.
+- **Neural schedulers (RWKV/LSTM/GRU) — do not adopt despite topping the benchmark.** RWKV-Instant leads (LogLoss 0.2773, AUC 0.8329) but uses 2.76M parameters, trains across 5,000 users rather than per-user, needs features Vestige doesn't have (answer duration, sibling cards, deck hierarchy), and is not evaluated with TimeSeriesSplit unlike FSRS — not like-for-like. GRU needs Reptile pre-training on 100 users' histories, which a single-user local system cannot obtain.
+- **MCP version negotiation as written.** Do not add 2026-07-28 to `supported_protocol_versions()` before the work is actually done — that would be a false claim and would fail conformance.
+- **SQLite as canonical store with FTS5 hybrid.** Convergent with where the field landed. MemOS 2.0's own local plugin (Aug 17 2026) is SQLite + hybrid FTS5 + vector — the architecture Vestige has run for a year. Nobody credible argues for a heavyweight vector DB in a local agent memory server anymore.
+- **Local-first single Rust binary, MCP-native, purge-with-tombstone, exact-lookup preservation.** All still correct and increasingly rare. The 2026 field is Python + Docker + external DBs (cognee needs PostgreSQL/LanceDB/Kuzu; Zep retired self-hosted CE entirely). Rust competitors that exist are toys — palace-rs has 4 stars, engram-mcp 15. MemSecBench just turned purge semantics from a hygiene feature into a measured security capability the field lacks.
+- **LanceDB, DiskANN — rejected.** lancedb 0.37.1 pulls ~184MB of Arrow 58 / DataFusion 54 / Tokio transitive deps. DiskANN exists to keep billion-scale indexes off RAM; Vestige's entire index fits in a few megabytes.
+
+**One thing to write down in the repo so nobody burns a week on it in six months:** jina-reranker **v2, v3, and v3.5 are all CC BY-NC 4.0**. jina-reranker-v3.5 (0.6B, Jul 20 2026, BEIR 63.20, arXiv 2607.18152) is the best reranker in the world at its size and is **permanently unavailable to Vestige** while it has any commercial tier. v1-turbo-en is the last permissively-licensed Jina reranker. Someone will find that 63.20 number.
+
+**One thing to react to correctly:** MemPalace hit 43,458 GitHub stars in **eight days** (OSS Insight, Apr 13 2026), later ~54k, positioned as local-first MCP memory. Vectorize's Apr 12 2026 teardown found its 96.6% LongMemEval measured raw ChromaDB over uncompressed text, its LoCoMo 100% used `top_k=50` against 19-32-session datasets (retrieving the whole corpus), its "30× lossless" compression is lossy and regresses 12.4 points, and its advertised contradiction detection and multi-hop traversal **do not exist in the code**. Do not react architecturally. Do note that a well-marketed local-first MCP memory server can take 40k stars in a week — that is a distribution lesson, not a technical one.
+
+---
+
+## Open bugs
+
+### #181 — stale per-process vector index: **FIXED by Tier 1 #2**
+
+Direct fix, small cost, no new dependency, using API already present in the pinned usearch 2.23.0. Detailed above. Tier 2 #1 (arroy) is the structural fallback if lock ordering defeats the watermark; do not reach for it first.
+
+Secondary benefit: **usearch 2.26.0's hash-lookup tombstone reclamation under high churn** (Tier 1 #4) directly serves the suppress/purge path, which removes and re-adds vectors. That interaction is also what makes Tier 2 #3 (MemSecBench) honest — soft HNSW deletes are exactly what a poisoning benchmark probes for.
+
+### #180 — apply_plan atomicity: **NOT fixed by anything in this plan**
+
+Being explicit because it matters. No lane surfaced a dependency, model, or protocol upgrade that touches it, and none will. Verified in source: `SqliteStorage::apply_plan` (sqlite.rs:12198) performs a sequence of independent `self.*` calls — `get_plan`, `plan_status`, `get_node`, `read_bitemporal` per invalidated id, then mutations — with **no enclosing transaction**. A crash or error partway through the `PlanKind::Merge` arm leaves the survivor mutated and some absorbed nodes not, with a partial undo blob. The `plan_status` "already applied" guard (12210-12220) is a check-then-act with no lock, so it is also racy under the concurrency #181 exposes.
+
+**Two hard sequencing consequences:**
+
+1. **#181's fix makes #180 more reachable, not less.** Once concurrent processes actually see each other's writes, concurrent `apply_plan` calls on overlapping node sets become a live race rather than a theoretical one.
+2. **Tier 2 #4 (async write path) must not land before #180 is fixed.** Moving writes off the request path multiplies the number of interleaved mutations against exactly this non-transactional code. Fix #180 first, or explicitly exclude merge/supersede from the async path.
+
+Fixing #180 is cheap relative to everything above — wrap the whole `apply_plan` body in an `IMMEDIATE` transaction so the status check and the mutations commit or roll back together. It is not in Tier 1 only because no lane's research produced it; on benefit/cost it belongs alongside Tier 1 #2, and I would land the two in the same PR since they touch the same file and the same concurrency story.
+
+---
+
+## What I could not verify
+
+Stated plainly so nothing here gets quoted as settled:
+
+- **The usearch `fp16lib` feature contradiction** (Tier 1 #4). Two lanes read different manifests. Resolve against the 2.26.1 manifest specifically before writing code.
+- **Granite R2 vs nomic-embed-text-v1.5 head-to-head.** No same-source benchmark exists. The MTEB v1 numbers Vestige has recorded for nomic are not comparable to MMTEB Retrieval.
+- **MemReranker-0.6B weights licence.** HF page returned 401.
+- **Microsoft's ONNX Runtime 1.29.0 Linux tarball glibc floor.** manylinux_2_28 is the documented build container; confirm with `objdump -T` on the extracted artifact.
+- **usearch on-disk index format stability across 2.23 → 2.26.** A silent serialization change would invalidate every user's index.
+- **ort-tract/ort-candle `api-17` vs fastembed's `api-24`.** Incompatibility surfaces as a null function pointer at runtime, not a compile error.
+- **Microsoft Harrier-OSS-v1** (announced Mar 30 2026, MTEB Multilingual v2 SOTA claim) — single secondary source (MarkTechPost), licence, MRL support, and ONNX availability all unverified; its 640d output does not truncate cleanly to 256 without confirmed MRL. Found but not recommended.
+- **The ONNX Runtime plugin-EP transition.** Separate release tags are now being cut (plugin-ep-webgpu/v0.3.0 Aug 24, plugin-ep-cuda/v0.1.0 Aug 17). No CoreML plugin exists today, but if one ships, the "one archive per EP combination" constraint that shapes ort's whole distribution model relaxes and the Tier 2 #1 packaging calculus changes. Re-check in a few months.

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -1,7 +1,7 @@
 {
   "identifier": "samvallad33-vestige",
   "name": "Vestige",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "author": "samvallad33",
   "authorUrl": "https://github.com/samvallad33",
   "category": "developer",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vestige",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "private": true,
   "description": "Cognitive memory for AI - MCP server with FSRS-6 spaced repetition",
   "author": "Sam Valladares",

--- a/packages/vestige-init/package.json
+++ b/packages/vestige-init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vestige/init",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Configure Vestige local memory for MCP-compatible AI agents",
   "bin": {
     "vestige-init": "bin/init.js"

--- a/packages/vestige-mcp-npm/package.json
+++ b/packages/vestige-mcp-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vestige-mcp-server",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "mcpName": "io.github.samvallad33/vestige",
   "description": "Vestige MCP Server — local cognitive memory for MCP-compatible AI agents",
   "bin": {

--- a/packages/vestige-mcpb/manifest.json
+++ b/packages/vestige-mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "vestige",
   "display_name": "Vestige",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "AI memory system built on 130 years of cognitive science. Reaches backward through time to find a failure's root cause (Retroactive Salience Backfill), FSRS-6 spaced repetition, synaptic tagging, and local-first storage.",
   "author": {
     "name": "Sam Valladares",

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/samvallad33/vestige",
     "source": "github"
   },
-  "version": "2.4.1",
+  "version": "2.5.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "vestige-mcp-server",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "transport": {
         "type": "stdio"
       }

--- a/tests/phase_1/Cargo.toml
+++ b/tests/phase_1/Cargo.toml
@@ -11,7 +11,7 @@ tempfile = "3"
 uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"
 serde_json = "1"
-rusqlite = { version = "0.38", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 
 [[test]]
 name = "trait_round_trip"


### PR DESCRIPTION
Merges the released v2.5.0 into main. Tag v2.5.0 is already cut at 6f53557 and the GitHub release is live; this PR brings main up to the released commit.

18 commits: the 16-commit correctness branch (unified contradiction detection, FTS self-heal, cross-process vector-index refresh #181, dissent-protected retrieval, case-insensitive tag prefix, schema V31 code-memory anchors, server/discover for MCP 2026-07-28, MemConflict harness, SQLite 3.53.2 / CVE-2026-11822), the post-2.5.0 plan doc, and the pre-release audit fix (detector paired-evidence tightening measured 82.8% to 13.1% on a real 2,929-memory store, feature-gate compile repairs, doc and lockfile corrections).

Gate at head: 1954 workspace tests, clippy -D warnings, e2e 16 default + 7 real-embedding, no-vector-search feature-combo checks, real-store probe. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)