### PR TITLE
fix(maintenance): report real activationNetworkSize instead of always 0

### DIFF
--- a/crates/vestige-mcp/src/tools/maintenance.rs
+++ b/crates/vestige-mcp/src/tools/maintenance.rs
@@ -258,7 +258,7 @@ pub async fn execute_system_status(
 
     // === Cognitive health ===
     let cognitive_health = if let Ok(cog) = cognitive.try_lock() {
-        let activation_count = cog.activation_network.get_associations("_probe_").len();
+        let activation_count = cog.activation_network.edge_count();
         let prediction_accuracy = cog.predictive_memory.prediction_accuracy().unwrap_or(0.0);
         let scheduler_stats = cog.consolidation_scheduler.get_activity_stats();
         Some(serde_json::json!({


### PR DESCRIPTION
## Problem

`system_status` / maintenance always reports `activationNetworkSize: 0`, even on a warm engine with thousands of hydrated edges.

The metric is computed in `crates/vestige-mcp/src/tools/maintenance.rs`:

```rust
let activation_count = cog.activation_network.get_associations("_probe_").len();
```

`"_probe_"` is a hardcoded sentinel node id that is never inserted into the network, so `get_associations` returns an empty vec and the count is **always 0** regardless of the real network size. Spreading activation itself works fine — only this status number is wrong, which makes the panel look like the cognitive layer is empty when it isn't.

## Fix

`ActivationNetwork` already exposes a real accessor (`crates/vestige-core/src/neuroscience/spreading_activation.rs`):

```rust
pub fn edge_count(&self) -> usize { self.edges.len() }
```

Use it instead of the sentinel probe:

```rust
let activation_count = cog.activation_network.edge_count();
```

One line. `activationNetworkSize` now reflects the actual edge count.

## Notes

- `node_count()` also exists if you'd prefer node count semantics; edge count seemed the closer match for "network size."
- Reproduced against latest `main` (bug is present through v2.5.0).
- I don't have the Rust toolchain on this machine, so this is **not** locally compiled — the change is trivial and uses an existing public method, but a CI build check is the real verification.