### PR TITLE
release: v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@ All notable changes to Vestige will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.6.0] - 2026-08-30 — "Nothing deletes your memories except you"
-
-## [Unreleased]
+## [2.6.1] - 2026-09-01 — "1.x stores open again"
 
 ### Fixed — 1.x stores open again after upgrading (#191)
 
@@ -45,6 +43,8 @@ of results and marks it `currentlyValid: false` (it stays retrievable for
 audit through `validAt`), so stale state stops polluting the top of recall
 on its own instead of by discipline. Requested by @aaronukgarcia after seven
 months of enforcing the same rule by hand (#182, #190).
+
+## [2.6.0] - 2026-08-30 — "Nothing deletes your memories except you"
 
 ### Fixed — Consolidation can no longer delete your memories
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5086,7 +5086,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vestige-core"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "vestige-mcp"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.6.0"
+version = "2.6.1"
 edition = "2024"
 license = "AGPL-3.0-only"
 repository = "https://github.com/samvallad33/vestige"

--- a/apps/dashboard/package-lock.json
+++ b/apps/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vestige/dashboard",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vestige/dashboard",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "dependencies": {
         "three": "^0.172.0"
       },

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vestige/dashboard",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/vestige-core/Cargo.toml
+++ b/crates/vestige-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vestige-core"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2024"
 rust-version = "1.91"
 authors = ["Vestige Team"]

--- a/crates/vestige-mcp/Cargo.toml
+++ b/crates/vestige-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vestige-mcp"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2024"
 description = "Cognitive memory MCP server for AI agents - FSRS-6, spreading activation, synaptic tagging, 3D dashboard, and 130 years of memory research"
 authors = ["samvallad33"]
@@ -62,7 +62,7 @@ path = "src/bin/cli.rs"
 # Only `bundled-sqlite` is always on. `embeddings` and `vector-search` are
 # toggled via vestige-mcp's own feature flags below so `--no-default-features`
 # actually works (previously hardcoded here, which silently defeated the flag).
-vestige-core = { version = "2.6.0", path = "../vestige-core", default-features = false, features = ["bundled-sqlite"] }
+vestige-core = { version = "2.6.1", path = "../vestige-core", default-features = false, features = ["bundled-sqlite"] }
 
 # ============================================================================
 # MCP Server Dependencies

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -1,7 +1,7 @@
 {
   "identifier": "samvallad33-vestige",
   "name": "Vestige",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "author": "samvallad33",
   "authorUrl": "https://github.com/samvallad33",
   "category": "developer",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vestige",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "private": true,
   "description": "Cognitive memory for AI - MCP server with FSRS-6 spaced repetition",
   "author": "Sam Valladares",

--- a/packages/vestige-init/package.json
+++ b/packages/vestige-init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vestige/init",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Configure Vestige local memory for MCP-compatible AI agents",
   "bin": {
     "vestige-init": "bin/init.js"

--- a/packages/vestige-mcp-npm/package.json
+++ b/packages/vestige-mcp-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vestige-mcp-server",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "mcpName": "io.github.samvallad33/vestige",
   "description": "Vestige MCP Server \u2014 local cognitive memory for MCP-compatible AI agents",
   "bin": {

--- a/packages/vestige-mcpb/manifest.json
+++ b/packages/vestige-mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "vestige",
   "display_name": "Vestige",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "AI memory system built on 130 years of cognitive science. Reaches backward through time to find a failure's root cause (Retroactive Salience Backfill), FSRS-6 spaced repetition, synaptic tagging, and local-first storage.",
   "author": {
     "name": "Sam Valladares",

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/samvallad33/vestige",
     "source": "github"
   },
-  "version": "2.6.0",
+  "version": "2.6.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "vestige-mcp-server",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
### Fixed — 1.x stores open again after upgrading (#191)

A store created on Vestige 1.x holds raw 768-dimension Nomic vectors. The
2.x migration registered it under the 256-dimension legacy profile, so the
strict dimension check aborted storage init and the MCP connection closed at
session start. Reported with a full diagnosis, a rehearsed workaround, and
fix directions by @aaronukgarcia in #191 and the field report in #190.

- Legacy-profile vectors whose width disagrees with the profile are now
  repaired on open: Matryoshka-truncated to the declared dimension and
  L2-renormalized in place, no model or network needed, memories untouched.
  Undersized vectors are dropped for the background backfill to regenerate.
  Scoped strictly to the legacy profile; a mismatch on a pinned profile stays
  a hard error.
- New `vestige-cli upgrade --dry-run`: copies the store (with WAL/SHM) to a
  temp directory, reports what the strict checks see on disk, runs every
  migration against the copy, and leaves the original untouched.
- `vestige-cli health` no longer prints "Embedding Service: Not Ready" as if
  it were a store verdict; the CLI never starts the embedder, and it now says
  so. `consolidate` explains 0 generated embeddings the same way.
- `embeddings install` on the released Nomic profile now explains that Nomic
  needs no install, that legacy stores are repaired on open, and where the
  legal `migrate` targets are listed, instead of a bare refusal.

### Added — `state` node type that expires by default

"Current state" memories (version numbers, progress percentages,
inventories) are the rot class that pollutes recall worst: they stay true in
the store long after they stopped being true in the world. `smart_ingest`
now accepts `node_type: "state"`, which sets `validUntil` to
`VESTIGE_STATE_TTL_DAYS` (default 30, `0` disables) after ingest unless the
caller gives one. Once expired, recall down-ranks the memory to the bottom
of results and marks it `currentlyValid: false` (it stays retrievable for
audit through `validAt`), so stale state stops polluting the top of recall
on its own instead of by discipline. Requested by @aaronukgarcia after seven
months of enforcing the same rule by hand (#182, #190).

**Full changelog:** https://github.com/samvallad33/vestige/blob/main/CHANGELOG.md
