### PR TITLE
release: v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,83 @@ All notable changes to Vestige will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - 2026-09-01 — "Share your brain, not your memories"
+
+The dashboard becomes VestigeOS: a living WebGPU observatory of your memory,
+a share loop that lets you show the world the shape of your store without
+exposing a single memory, and the first native HTTP and receipt surface for
+Retroactive Salience Backfill. 501 files, five transformation phases, every
+one of them gated.
+
+### Added — The share loop (zero memory text, by construction)
+
+- **Deterministic loop export.** One tap renders the Observatory's full
+  720-frame, 12-second loop offline, frame by frame, straight into a
+  hardware-encoded mp4 (Mediabunny over WebCodecs). It is not a screen
+  recording: the loop clock is a pure function of the frame index, so every
+  machine exports the byte-identical clip of the same loop. A slow laptop
+  takes longer; it never drops a frame.
+- **Brain print.** A `vb1-…` signature hashed (FNV-1a) from your store's
+  shape only: counts, type mix, retention buckets, edge density. Same store,
+  same print, every time; two stores never collide. It seeds the Observatory,
+  names your exported clips, and gives you a permalink that carries structure
+  and nothing else.
+- **Wrapped card and `?brain=` permalinks.** A shareable card drawn from the
+  shape vector and trait chips, and a permalink that reconstructs the same
+  field on someone else's machine with no backend and no memory content.
+- **Receipts replay clip preset.** A loop-export preset focused on the
+  recall-path demo with receipt ids: watch your agent's memory decide.
+
+### Added — Native Backfill receipts and the HTTP surface
+
+- `ReceiptEvidence::Backfill` joins the unified evidence stream with a
+  stable schema URI, `schema_version`, and an explicit candidate-only claim
+  boundary. Fail-closed: a backfill renders only when the receipt carries a
+  complete, ordered `path_ids`; nothing is inferred by the renderer.
+- `POST /api/backfill` runs the full trace pipeline (record call, execute,
+  record result, save receipt), clamps inputs, and the Black Box salience
+  rescue is wired to it live. The `backfill_candidate` evidence edge is now
+  always persisted, idempotently, even in dry-run previews; promotion is
+  gated on the edge existing, so a receipt can never claim an edge the graph
+  does not hold.
+- Receipt attestation covers the new evidence kind: the redaction-safe
+  binding gains a `Backfill` variant and the attested memory set includes
+  the failure id, path ids, and candidate ids.
+
+### Changed — VestigeOS: one registry, breathing everywhere
+
+- `os-routes.ts` is the single route registry; dock, rail, palette, and
+  mobile navigation all derive from it. Explore absorbed Activation as a
+  Walk/Spread physics toggle (Spread runs a real edge-weighted BFS over the
+  graph); Stats absorbed the dream ritual; patterns, importance, schedule,
+  activation, and settings are hidden from navigation.
+- Ambient time is monotonic live and wrapped only in capture and export, so
+  the 12-second loop no longer snaps at the seam. AmbientField living base
+  coats sit under the DOM organs, fed by real vitals.
+- A camera rig, hover states, pick receipts, and wired pickers: clicking a
+  memory in the Observatory field lands on that memory in `/memories` via a
+  real `?memory=` deep link.
+- Route event pulses, feed jumps, timeline audit, memory state chips and
+  legend, an error page, and the de-violet: the legacy silent `#8b5cf6` is
+  gone, replaced by fossil cyan, per the palette doctrine.
+
+### Fixed — Truth
+
+- The websocket store no longer reports zeros while disconnected, and no
+  longer hardcodes a dev port (a 5173-only branch had silently killed the
+  live layer on every other port).
+- Memory PR diffs render before/after instead of asking you to approve blind.
+- Roughly 17,400 lines of dead dashboard code removed (the old Graph3D stack,
+  orphaned components, a dead reasoning GPU pipeline).
+
+### Verification
+
+- `cargo test --workspace`: 1,961 passed, 0 failed; `clippy -D warnings`
+  clean; svelte-check 0 errors across 1,001 files; vitest 826/826; production
+  build clean; live-verified against a seeded demo store: `/api/backfill`
+  returns real receipts with `path_ids`, the brain print is deterministic,
+  the export produces a playable mp4.
+
 ## [2.6.1] - 2026-09-01 — "1.x stores open again"
 
 ### Fixed — 1.x stores open again after upgrading (#191)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5086,7 +5086,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vestige-core"
-version = "2.6.1"
+version = "2.7.0"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "vestige-mcp"
-version = "2.6.1"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.6.1"
+version = "2.7.0"
 edition = "2024"
 license = "AGPL-3.0-only"
 repository = "https://github.com/samvallad33/vestige"

--- a/apps/dashboard/package-lock.json
+++ b/apps/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vestige/dashboard",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vestige/dashboard",
-      "version": "2.6.1",
+      "version": "2.7.0",
       "dependencies": {
         "three": "^0.172.0"
       },

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vestige/dashboard",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/crates/vestige-core/Cargo.toml
+++ b/crates/vestige-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vestige-core"
-version = "2.6.1"
+version = "2.7.0"
 edition = "2024"
 rust-version = "1.91"
 authors = ["Vestige Team"]

--- a/crates/vestige-core/src/storage/sqlite.rs
+++ b/crates/vestige-core/src/storage/sqlite.rs
@@ -19316,13 +19316,20 @@ mod tests {
             }
         }
 
-        // Corrupt the FTS index the way an interrupted rebuild does.
+        // Corrupt the FTS index the way an interrupted rebuild does. The
+        // damage is a FIXED byte pattern, not randomblob(): an unseeded random
+        // block sometimes wrecks the segment so badly that quick_check itself
+        // fails with SQLITE_NOMEM before the heal gate can classify the rows,
+        // and the store (correctly) refuses loudly. That path is documented
+        // shipped behavior, but it made this test flake in CI; a deterministic
+        // pattern exercises the rebuild path every run.
         {
             let conn = Connection::open(&path).expect("raw open");
-            conn.execute_batch(
-                "UPDATE knowledge_fts_data SET block = randomblob(200) \
-                 WHERE id = (SELECT id FROM knowledge_fts_data WHERE id > 1 LIMIT 1);",
-            )
+            let pattern = "A5".repeat(200);
+            conn.execute_batch(&format!(
+                "UPDATE knowledge_fts_data SET block = x'{pattern}' \
+                 WHERE id = (SELECT id FROM knowledge_fts_data WHERE id > 1 LIMIT 1);"
+            ))
             .expect("corrupt");
             let corrupt = conn
                 .execute_batch(

--- a/crates/vestige-mcp/Cargo.toml
+++ b/crates/vestige-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vestige-mcp"
-version = "2.6.1"
+version = "2.7.0"
 edition = "2024"
 description = "Cognitive memory MCP server for AI agents - FSRS-6, spreading activation, synaptic tagging, 3D dashboard, and 130 years of memory research"
 authors = ["samvallad33"]
@@ -62,7 +62,7 @@ path = "src/bin/cli.rs"
 # Only `bundled-sqlite` is always on. `embeddings` and `vector-search` are
 # toggled via vestige-mcp's own feature flags below so `--no-default-features`
 # actually works (previously hardcoded here, which silently defeated the flag).
-vestige-core = { version = "2.6.1", path = "../vestige-core", default-features = false, features = ["bundled-sqlite"] }
+vestige-core = { version = "2.7.0", path = "../vestige-core", default-features = false, features = ["bundled-sqlite"] }
 
 # ============================================================================
 # MCP Server Dependencies

--- a/crates/vestige-mcp/tests/e2e_real_binary.rs
+++ b/crates/vestige-mcp/tests/e2e_real_binary.rs
@@ -851,8 +851,14 @@ fn corrupt_fts_index_does_not_brick_the_store() {
     {
         let conn = open_db(dir.path());
         conn.execute_batch(
-            "UPDATE knowledge_fts_data SET block = randomblob(200) \
-             WHERE id = (SELECT id FROM knowledge_fts_data WHERE id > 1 LIMIT 1);",
+            // Fixed byte pattern, not randomblob(): an unseeded random block
+            // sometimes damages the segment so badly that quick_check itself
+            // fails with SQLITE_NOMEM, and the test flakes (Aug 30, Sep 1).
+            &format!(
+                "UPDATE knowledge_fts_data SET block = x'{}' \
+                 WHERE id = (SELECT id FROM knowledge_fts_data WHERE id > 1 LIMIT 1);",
+                "A5".repeat(200)
+            ),
         )
         .expect("corrupt the fts index");
         assert!(
@@ -2100,8 +2106,14 @@ fn corrupt_fts_rebuild_preserves_embeddings() {
     {
         let conn = open_db(dir.path());
         conn.execute_batch(
-            "UPDATE knowledge_fts_data SET block = randomblob(200) \
-             WHERE id = (SELECT id FROM knowledge_fts_data WHERE id > 1 LIMIT 1);",
+            // Fixed byte pattern, not randomblob(): an unseeded random block
+            // sometimes damages the segment so badly that quick_check itself
+            // fails with SQLITE_NOMEM, and the test flakes (Aug 30, Sep 1).
+            &format!(
+                "UPDATE knowledge_fts_data SET block = x'{}' \
+                 WHERE id = (SELECT id FROM knowledge_fts_data WHERE id > 1 LIMIT 1);",
+                "A5".repeat(200)
+            ),
         )
         .expect("corrupt the fts index");
         assert!(

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -1,7 +1,7 @@
 {
   "identifier": "samvallad33-vestige",
   "name": "Vestige",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "author": "samvallad33",
   "authorUrl": "https://github.com/samvallad33",
   "category": "developer",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vestige",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "private": true,
   "description": "Cognitive memory for AI - MCP server with FSRS-6 spaced repetition",
   "author": "Sam Valladares",

--- a/packages/vestige-init/package.json
+++ b/packages/vestige-init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vestige/init",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "Configure Vestige local memory for MCP-compatible AI agents",
   "bin": {
     "vestige-init": "bin/init.js"

--- a/packages/vestige-mcp-npm/package.json
+++ b/packages/vestige-mcp-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vestige-mcp-server",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "mcpName": "io.github.samvallad33/vestige",
   "description": "Vestige MCP Server \u2014 local cognitive memory for MCP-compatible AI agents",
   "bin": {

--- a/packages/vestige-mcpb/manifest.json
+++ b/packages/vestige-mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "vestige",
   "display_name": "Vestige",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "AI memory system built on 130 years of cognitive science. Reaches backward through time to find a failure's root cause (Retroactive Salience Backfill), FSRS-6 spaced repetition, synaptic tagging, and local-first storage.",
   "author": {
     "name": "Sam Valladares",

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/samvallad33/vestige",
     "source": "github"
   },
-  "version": "2.6.1",
+  "version": "2.7.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "vestige-mcp-server",
-      "version": "2.6.1",
+      "version": "2.7.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
The dashboard becomes VestigeOS: a living WebGPU observatory of your memory,
a share loop that lets you show the world the shape of your store without
exposing a single memory, and the first native HTTP and receipt surface for
Retroactive Salience Backfill. 501 files, five transformation phases, every
one of them gated.

### Added — The share loop (zero memory text, by construction)

- **Deterministic loop export.** One tap renders the Observatory's full
  720-frame, 12-second loop offline, frame by frame, straight into a
  hardware-encoded mp4 (Mediabunny over WebCodecs). It is not a screen
  recording: the loop clock is a pure function of the frame index, so every
  machine exports the byte-identical clip of the same loop. A slow laptop
  takes longer; it never drops a frame.
- **Brain print.** A `vb1-…` signature hashed (FNV-1a) from your store's
  shape only: counts, type mix, retention buckets, edge density. Same store,
  same print, every time; two stores never collide. It seeds the Observatory,
  names your exported clips, and gives you a permalink that carries structure
  and nothing else.
- **Wrapped card and `?brain=` permalinks.** A shareable card drawn from the
  shape vector and trait chips, and a permalink that reconstructs the same
  field on someone else's machine with no backend and no memory content.
- **Receipts replay clip preset.** A loop-export preset focused on the
  recall-path demo with receipt ids: watch your agent's memory decide.

### Added — Native Backfill receipts and the HTTP surface

- `ReceiptEvidence::Backfill` joins the unified evidence stream with a
  stable schema URI, `schema_version`, and an explicit candidate-only claim
  boundary. Fail-closed: a backfill renders only when the receipt carries a
  complete, ordered `path_ids`; nothing is inferred by the renderer.
- `POST /api/backfill` runs the full trace pipeline (record call, execute,
  record result, save receipt), clamps inputs, and the Black Box salience
  rescue is wired to it live. The `backfill_candidate` evidence edge is now
  always persisted, idempotently, even in dry-run previews; promotion is
  gated on the edge existing, so a receipt can never claim an edge the graph
  does not hold.
- Receipt attestation covers the new evidence kind: the redaction-safe
  binding gains a `Backfill` variant and the attested memory set includes
  the failure id, path ids, and candidate ids.

### Changed — VestigeOS: one registry, breathing everywhere

- `os-routes.ts` is the single route registry; dock, rail, palette, and
  mobile navigation all derive from it. Explore absorbed Activation as a
  Walk/Spread physics toggle (Spread runs a real edge-weighted BFS over the
  graph); Stats absorbed the dream ritual; patterns, importance, schedule,
  activation, and settings are hidden from navigation.
- Ambient time is monotonic live and wrapped only in capture and export, so
  the 12-second loop no longer snaps at the seam. AmbientField living base
  coats sit under the DOM organs, fed by real vitals.
- A camera rig, hover states, pick receipts, and wired pickers: clicking a
  memory in the Observatory field lands on that memory in `/memories` via a
  real `?memory=` deep link.
- Route event pulses, feed jumps, timeline audit, memory state chips and
  legend, an error page, and the de-violet: the legacy silent `#8b5cf6` is
  gone, replaced by fossil cyan, per the palette doctrine.

### Fixed — Truth

- The websocket store no longer reports zeros while disconnected, and no
  longer hardcodes a dev port (a 5173-only branch had silently killed the
  live layer on every other port).
- Memory PR diffs render before/after instead of asking you to approve blind.
- Roughly 17,400 lines of dead dashboard code removed (the old Graph3D stack,
  orphaned components, a dead reasoning GPU pipeline).

### Verification

- `cargo test --workspace`: 1,961 passed, 0 failed; `clippy -D warnings`
  clean; svelte-check 0 errors across 1,001 files; vitest 826/826; production
  build clean; live-verified against a seeded demo store: `/api/backfill`
  returns real receipts with `path_ids`, the brain print is deterministic,
  the export produces a playable mp4.

**Full changelog:** https://github.com/samvallad33/vestige/blob/main/CHANGELOG.md
