### PR TITLE
Interactive Pro & Operator welcome opens the live account site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Interactive postinstall / `vestige` welcome for Vestige Pro & Operator: after
   a successful binary install, a TTY session prints the announcement and waits
-  for Enter to open the live account site at
-  `https://vestige-pro-production.fly.dev` (`q` / Ctrl-C / 15s timeout skip).
+  for Enter to open the Pro screen at
+  `https://github.com/samvallad33/vestige#vestige-pro` (`q` / Ctrl-C / 15s
+  timeout skip).
   CI, `npm -y`, and non-TTY installs never block. `vestige` with no args and
   `vestige health` carry the same short block. Local memory stays free.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Interactive postinstall / `vestige` welcome for Vestige Pro & Operator: after
   a successful binary install, a TTY session prints the announcement and waits
-  for Enter to open the Pro screen at
-  `https://github.com/samvallad33/vestige#vestige-pro` (`q` / Ctrl-C / 15s
-  timeout skip).
-  CI, `npm -y`, and non-TTY installs never block. `vestige` with no args and
-  `vestige health` carry the same short block. Local memory stays free.
+  for Enter to open `https://vestige-pro-production.fly.dev`
+  (`q` / Ctrl-C / 15s timeout skip). CI, `npm -y`, and non-TTY installs never
+  block. `vestige` with no args and `vestige health` carry the same short
+  block. Local memory stays free.
 
 ## [2.7.1] - 2026-09-02 — "The first cloud write is never unconditional"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to Vestige will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Interactive postinstall / `vestige` welcome for Vestige Pro & Operator: after
+  a successful binary install, a TTY session prints the announcement and waits
+  for Enter to open the live account site at
+  `https://vestige-pro-production.fly.dev` (`q` / Ctrl-C / 15s timeout skip).
+  CI, `npm -y`, and non-TTY installs never block. `vestige` with no args and
+  `vestige health` carry the same short block. Local memory stays free.
+
 ## [2.7.1] - 2026-09-02 — "The first cloud write is never unconditional"
 
 ### Fixed — Managed Continuity first upload

--- a/crates/vestige-mcp/src/bin/cli.rs
+++ b/crates/vestige-mcp/src/bin/cli.rs
@@ -39,10 +39,9 @@ struct Cli {
     command: Option<Commands>,
 }
 
-/// Destination opened from the Pro & Operator welcome — the live Vestige
-/// Pro account site (sign up, email, pay). Named so we can retarget later
-/// without hunting copy.
-const VESTIGE_PRO_SCREEN_URL: &str = "https://vestige-pro-production.fly.dev";
+/// Destination opened from the Pro & Operator welcome. Named so we can
+/// retarget later without hunting copy.
+const VESTIGE_PRO_SCREEN_URL: &str = "https://github.com/samvallad33/vestige#vestige-pro";
 
 const VESTIGE_PRO_AFTER_HELP: &str = "\
 ✦  Vestige Pro & Operator — out now.
@@ -50,7 +49,7 @@ const VESTIGE_PRO_AFTER_HELP: &str = "\
    Continuity across every machine.
    Receipt → permit → effect. Fail closed.
 
-   https://vestige-pro-production.fly.dev";
+   https://github.com/samvallad33/vestige#vestige-pro";
 
 const VESTIGE_PRO_WELCOME_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -4190,10 +4189,10 @@ mod tests {
     }
 
     #[test]
-    fn pro_screen_url_is_the_named_account_site() {
+    fn pro_screen_url_is_the_named_pro_section() {
         assert_eq!(
             VESTIGE_PRO_SCREEN_URL,
-            "https://vestige-pro-production.fly.dev"
+            "https://github.com/samvallad33/vestige#vestige-pro"
         );
         assert!(VESTIGE_PRO_AFTER_HELP.contains("Vestige Pro & Operator — out now."));
         assert!(VESTIGE_PRO_AFTER_HELP.contains("Receipt → permit → effect. Fail closed."));

--- a/crates/vestige-mcp/src/bin/cli.rs
+++ b/crates/vestige-mcp/src/bin/cli.rs
@@ -5,15 +5,16 @@
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
-use std::io::{BufWriter, Write};
+use std::io::{self, BufWriter, IsTerminal, Write};
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::{Arc, OnceLock};
+use std::time::Duration;
 
 use anyhow::Context;
 use chrono::{NaiveDate, Utc};
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand};
 use colored::Colorize;
 use vestige_core::{
     IngestInput, PortableImportMode, SecretConfidence, SecretPolicy, Storage, scan_secrets,
@@ -28,17 +29,30 @@ use vestige_core::{
 #[command(
     long_about = "Vestige is a cognitive memory system based on 130 years of memory research.\n\nIt implements FSRS-6, spreading activation, synaptic tagging, and more."
 )]
-#[command(
-    after_help = "Vestige Pro: your memory on every machine, end-to-end encrypted. $19/mo -> https://github.com/samvallad33/vestige#vestige-pro"
-)]
+#[command(after_help = VESTIGE_PRO_AFTER_HELP)]
 struct Cli {
     /// Use a specific Vestige data directory for this command.
     #[arg(long, global = true, value_name = "DIR")]
     data_dir: Option<PathBuf>,
 
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 }
+
+/// Destination opened from the Pro & Operator welcome — the live Vestige
+/// Pro account site (sign up, email, pay). Named so we can retarget later
+/// without hunting copy.
+const VESTIGE_PRO_SCREEN_URL: &str = "https://vestige-pro-production.fly.dev";
+
+const VESTIGE_PRO_AFTER_HELP: &str = "\
+✦  Vestige Pro & Operator — out now.
+
+   Continuity across every machine.
+   Receipt → permit → effect. Fail closed.
+
+   https://vestige-pro-production.fly.dev";
+
+const VESTIGE_PRO_WELCOME_TIMEOUT: Duration = Duration::from_secs(15);
 
 static CLI_DB_PATH: OnceLock<PathBuf> = OnceLock::new();
 
@@ -423,7 +437,12 @@ fn main() -> anyhow::Result<()> {
             .map_err(|_| anyhow::anyhow!("data directory was initialized more than once"))?;
     }
 
-    match cli.command {
+    let command = match cli.command {
+        Some(command) => command,
+        None => return run_bare_invocation(),
+    };
+
+    match command {
         Commands::Stats { tagging, states } => run_stats(tagging, states),
         Commands::Health => run_health(),
         Commands::Consolidate => run_consolidate(),
@@ -2082,6 +2101,97 @@ fn print_distribution_bar(label: &str, count: usize, total: usize, color: &str) 
     );
 }
 
+fn env_flag_enabled(name: &str) -> bool {
+    env::var(name)
+        .ok()
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn should_offer_pro_screen_with(
+    stdout_tty: bool,
+    stdin_tty: bool,
+    ci: bool,
+    continuous_integration: bool,
+    npm_yes: bool,
+) -> bool {
+    if ci || continuous_integration || npm_yes {
+        return false;
+    }
+    stdout_tty && stdin_tty
+}
+
+fn should_offer_pro_screen() -> bool {
+    should_offer_pro_screen_with(
+        io::stdout().is_terminal(),
+        io::stdin().is_terminal(),
+        env_flag_enabled("CI"),
+        env_flag_enabled("CONTINUOUS_INTEGRATION"),
+        env_flag_enabled("npm_config_yes"),
+    )
+}
+
+fn print_pro_operator_notice() {
+    println!("{}", "✦  Vestige Pro & Operator — out now.".cyan().bold());
+    println!();
+    println!("   Continuity across every machine.");
+    println!("   Receipt → permit → effect. Fail closed.");
+    println!();
+    println!("   {}", VESTIGE_PRO_SCREEN_URL.white());
+}
+
+fn open_pro_screen() {
+    if open::that(VESTIGE_PRO_SCREEN_URL).is_err() {
+        println!("Could not open the browser. Open this URL:");
+        println!("   {VESTIGE_PRO_SCREEN_URL}");
+    }
+}
+
+fn offer_pro_screen_interactive() -> anyhow::Result<()> {
+    if !should_offer_pro_screen() {
+        return Ok(());
+    }
+
+    println!();
+    println!("   Press Enter to open the screen · q to skip");
+    io::stdout().flush()?;
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut line = String::new();
+        let _ = io::stdin().read_line(&mut line);
+        let _ = tx.send(line);
+    });
+
+    match rx.recv_timeout(VESTIGE_PRO_WELCOME_TIMEOUT) {
+        Ok(line) => {
+            if line.trim().is_empty() {
+                println!("Opening the screen…");
+                open_pro_screen();
+            }
+        }
+        Err(_) => {
+            println!();
+            println!("Timed out. Open the screen anytime:");
+            println!("   {VESTIGE_PRO_SCREEN_URL}");
+        }
+    }
+    Ok(())
+}
+
+/// `vestige` with no args: existing help, plus a one-shot TTY prompt.
+fn run_bare_invocation() -> anyhow::Result<()> {
+    let mut cmd = Cli::command();
+    cmd.print_help()?;
+    println!();
+    offer_pro_screen_interactive()
+}
+
 /// Run health check
 fn run_health() -> anyhow::Result<()> {
     let storage = open_storage()?;
@@ -2220,13 +2330,7 @@ fn run_health() -> anyhow::Result<()> {
     }
 
     println!();
-    println!(
-        "{} {}",
-        "Pro:".cyan().bold(),
-        "sync this memory across machines, end-to-end encrypted ($19/mo) — \
-         https://github.com/samvallad33/vestige#vestige-pro"
-            .white()
-    );
+    print_pro_operator_notice();
 
     Ok(())
 }
@@ -4083,5 +4187,39 @@ mod tests {
         assert_eq!(user_hooks[0]["command"], "/tmp/custom-user-hook.sh");
         assert!(settings["hooks"].get("Stop").is_none());
         assert_eq!(settings["other"], true);
+    }
+
+    #[test]
+    fn pro_screen_url_is_the_named_account_site() {
+        assert_eq!(
+            VESTIGE_PRO_SCREEN_URL,
+            "https://vestige-pro-production.fly.dev"
+        );
+        assert!(VESTIGE_PRO_AFTER_HELP.contains("Vestige Pro & Operator — out now."));
+        assert!(VESTIGE_PRO_AFTER_HELP.contains("Receipt → permit → effect. Fail closed."));
+        assert!(VESTIGE_PRO_AFTER_HELP.contains(VESTIGE_PRO_SCREEN_URL));
+        assert!(!VESTIGE_PRO_AFTER_HELP.contains("$19"));
+    }
+
+    #[test]
+    fn pro_screen_gate_requires_a_real_tty_and_skips_ci() {
+        assert!(should_offer_pro_screen_with(
+            true, true, false, false, false
+        ));
+        assert!(!should_offer_pro_screen_with(
+            true, true, true, false, false
+        ));
+        assert!(!should_offer_pro_screen_with(
+            true, true, false, true, false
+        ));
+        assert!(!should_offer_pro_screen_with(
+            true, true, false, false, true
+        ));
+        assert!(!should_offer_pro_screen_with(
+            false, true, false, false, false
+        ));
+        assert!(!should_offer_pro_screen_with(
+            true, false, false, false, false
+        ));
     }
 }

--- a/crates/vestige-mcp/src/bin/cli.rs
+++ b/crates/vestige-mcp/src/bin/cli.rs
@@ -41,7 +41,7 @@ struct Cli {
 
 /// Destination opened from the Pro & Operator welcome. Named so we can
 /// retarget later without hunting copy.
-const VESTIGE_PRO_SCREEN_URL: &str = "https://github.com/samvallad33/vestige#vestige-pro";
+const VESTIGE_PRO_SCREEN_URL: &str = "https://vestige-pro-production.fly.dev";
 
 const VESTIGE_PRO_AFTER_HELP: &str = "\
 ✦  Vestige Pro & Operator — out now.
@@ -49,7 +49,7 @@ const VESTIGE_PRO_AFTER_HELP: &str = "\
    Continuity across every machine.
    Receipt → permit → effect. Fail closed.
 
-   https://github.com/samvallad33/vestige#vestige-pro";
+   https://vestige-pro-production.fly.dev";
 
 const VESTIGE_PRO_WELCOME_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -4189,10 +4189,10 @@ mod tests {
     }
 
     #[test]
-    fn pro_screen_url_is_the_named_pro_section() {
+    fn pro_screen_url_is_the_named_account_site() {
         assert_eq!(
             VESTIGE_PRO_SCREEN_URL,
-            "https://github.com/samvallad33/vestige#vestige-pro"
+            "https://vestige-pro-production.fly.dev"
         );
         assert!(VESTIGE_PRO_AFTER_HELP.contains("Vestige Pro & Operator — out now."));
         assert!(VESTIGE_PRO_AFTER_HELP.contains("Receipt → permit → effect. Fail closed."));

--- a/packages/vestige-mcp-npm/package.json
+++ b/packages/vestige-mcp-npm/package.json
@@ -10,7 +10,9 @@
   },
   "scripts": {
     "postinstall": "node scripts/postinstall.js",
-    "test:pnpm-global-install": "node --test tests/pnpm-global-install.test.js"
+    "test": "node --check scripts/postinstall.js && node --check scripts/welcome.js && node --test tests/*.test.js",
+    "test:pnpm-global-install": "node --test tests/pnpm-global-install.test.js",
+    "test:welcome": "node --test tests/welcome.test.js"
   },
   "keywords": [
     "mcp",

--- a/packages/vestige-mcp-npm/scripts/postinstall.js
+++ b/packages/vestige-mcp-npm/scripts/postinstall.js
@@ -7,6 +7,8 @@ const os = require('os');
 const crypto = require('crypto');
 const { execFileSync } = require('child_process');
 
+const { offerWelcome } = require('./welcome');
+
 const packageJson = require('../package.json');
 const VERSION = packageJson.version;
 const BINARY_VERSION = VERSION;
@@ -265,9 +267,13 @@ async function main() {
     console.log('  2. Restart your MCP client.');
     console.log('  3. Test with: "remember that my preferred editor is VS Code"');
     console.log('');
-    console.log('Local memory is free forever. Vestige Pro syncs it across machines,');
-    console.log('end-to-end encrypted ($19/mo): https://github.com/samvallad33/vestige#vestige-pro');
+    console.log('Local memory is free forever.');
     console.log('');
+
+    // TTY-only: announces Pro & Operator and waits for Enter. CI / `npm -y` /
+    // non-TTY installs return immediately so the binary download path stays
+    // identical and never hangs a pipeline.
+    await offerWelcome();
 
   } catch (err) {
     console.error('');

--- a/packages/vestige-mcp-npm/scripts/welcome.js
+++ b/packages/vestige-mcp-npm/scripts/welcome.js
@@ -1,0 +1,204 @@
+'use strict';
+
+const { spawn } = require('child_process');
+
+/**
+ * Destination opened when the user presses Enter on the Pro & Operator
+ * welcome — the live Vestige Pro account site (sign up, email, pay).
+ * Named so we can retarget later without hunting through install copy.
+ */
+const VESTIGE_PRO_SCREEN_URL = 'https://vestige-pro-production.fly.dev';
+const WELCOME_TIMEOUT_MS = 15_000;
+
+const WELCOME_BANNER = [
+  '✦  Vestige Pro & Operator — out now.',
+  '',
+  '   Continuity across every machine.',
+  '   Receipt → permit → effect. Fail closed.',
+  '',
+  '   Press Enter to open the screen · q to skip',
+].join('\n');
+
+function envFlagEnabled(value) {
+  if (value == null) return false;
+  const normalized = String(value).trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes';
+}
+
+/**
+ * Interactive welcome is for a real human at a terminal. CI, `npm -y`,
+ * Docker builds, and piped/non-TTY `npm i` must never block.
+ */
+function shouldOfferWelcome({
+  env = process.env,
+  stdoutIsTTY = Boolean(process.stdout && process.stdout.isTTY),
+  stdinIsTTY = Boolean(process.stdin && process.stdin.isTTY),
+} = {}) {
+  if (envFlagEnabled(env.CI) || envFlagEnabled(env.CONTINUOUS_INTEGRATION)) {
+    return false;
+  }
+  if (envFlagEnabled(env.npm_config_yes)) {
+    return false;
+  }
+  return Boolean(stdoutIsTTY && stdinIsTTY);
+}
+
+function openDestinationUrl(
+  url = VESTIGE_PRO_SCREEN_URL,
+  { spawnFn = spawn, platform = process.platform } = {}
+) {
+  const detached = { stdio: 'ignore', detached: true };
+  let child;
+  if (platform === 'darwin') {
+    child = spawnFn('open', [url], detached);
+  } else if (platform === 'win32') {
+    child = spawnFn('cmd', ['/c', 'start', '', url], {
+      ...detached,
+      windowsHide: true,
+    });
+    if (child && typeof child.on === 'function') {
+      child.on('error', () => {
+        const fallback = spawnFn(
+          'powershell',
+          ['-NoProfile', '-Command', `Start-Process ${JSON.stringify(url)}`],
+          { ...detached, windowsHide: true }
+        );
+        if (fallback && typeof fallback.unref === 'function') fallback.unref();
+      });
+    }
+  } else {
+    child = spawnFn('xdg-open', [url], detached);
+  }
+  if (child && typeof child.unref === 'function') child.unref();
+  return child;
+}
+
+function restoreStdin(stdin, previous) {
+  try {
+    if (stdin.setRawMode && previous && typeof previous.rawMode === 'boolean') {
+      stdin.setRawMode(previous.rawMode);
+    }
+  } catch {
+    // Leave the stream as-is if the TTY rejects the restore.
+  }
+  try {
+    if (previous && previous.paused && typeof stdin.pause === 'function') {
+      stdin.pause();
+    }
+  } catch {
+    // ignore
+  }
+}
+
+function classifyWelcomeKey(chunk) {
+  const key = Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk);
+  if (key.includes('\u0003')) {
+    return 'cancel';
+  }
+  if (key === '\r' || key === '\n' || key === '\r\n') {
+    return 'open';
+  }
+  const trimmed = key.replace(/\r/g, '').replace(/\n/g, '');
+  if (trimmed.toLowerCase() === 'q') {
+    return 'skip';
+  }
+  if (trimmed === '' && /[\r\n]/.test(key)) {
+    return 'open';
+  }
+  return null;
+}
+
+function waitForWelcomeKey({ stdin = process.stdin, timeoutMs = WELCOME_TIMEOUT_MS } = {}) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const previous = {
+      rawMode: typeof stdin.isRaw === 'boolean' ? stdin.isRaw : false,
+      paused: typeof stdin.isPaused === 'function' ? stdin.isPaused() : true,
+    };
+
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      stdin.removeListener('data', onData);
+      restoreStdin(stdin, previous);
+      resolve(result);
+    };
+
+    const onData = (chunk) => {
+      const action = classifyWelcomeKey(chunk);
+      if (action) finish(action);
+    };
+
+    try {
+      if (typeof stdin.setRawMode === 'function') {
+        stdin.setRawMode(true);
+      }
+    } catch {
+      // Line-buffered stdin still works: Enter and `q` classify the same.
+    }
+
+    if (typeof stdin.setEncoding === 'function') {
+      stdin.setEncoding('utf8');
+    }
+    if (typeof stdin.resume === 'function') {
+      stdin.resume();
+    }
+    stdin.on('data', onData);
+
+    const timer = setTimeout(() => finish('timeout'), timeoutMs);
+  });
+}
+
+async function offerWelcome(options = {}) {
+  const {
+    env = process.env,
+    stdout = process.stdout,
+    stdin = process.stdin,
+    stdoutIsTTY = Boolean(stdout && stdout.isTTY),
+    stdinIsTTY = Boolean(stdin && stdin.isTTY),
+    timeoutMs = WELCOME_TIMEOUT_MS,
+    openUrl = openDestinationUrl,
+    write = (text) => {
+      if (stdout && typeof stdout.write === 'function') {
+        stdout.write(text);
+      }
+    },
+  } = options;
+
+  if (!shouldOfferWelcome({ env, stdoutIsTTY, stdinIsTTY })) {
+    return { offered: false, action: 'gated' };
+  }
+
+  write(`\n${WELCOME_BANNER}\n`);
+
+  const action = await waitForWelcomeKey({ stdin, timeoutMs });
+
+  if (action === 'open') {
+    try {
+      openUrl(VESTIGE_PRO_SCREEN_URL);
+      write('\nOpening the screen…\n');
+    } catch {
+      write(`\nCould not open the browser. Open this URL:\n${VESTIGE_PRO_SCREEN_URL}\n`);
+    }
+    return { offered: true, action };
+  }
+
+  if (action === 'timeout') {
+    write(`\nTimed out. Open the screen anytime:\n${VESTIGE_PRO_SCREEN_URL}\n`);
+    return { offered: true, action };
+  }
+
+  write('\n');
+  return { offered: true, action };
+}
+
+module.exports = {
+  VESTIGE_PRO_SCREEN_URL,
+  WELCOME_TIMEOUT_MS,
+  WELCOME_BANNER,
+  shouldOfferWelcome,
+  classifyWelcomeKey,
+  openDestinationUrl,
+  offerWelcome,
+};

--- a/packages/vestige-mcp-npm/scripts/welcome.js
+++ b/packages/vestige-mcp-npm/scripts/welcome.js
@@ -4,10 +4,9 @@ const { spawn } = require('child_process');
 
 /**
  * Destination opened when the user presses Enter on the Pro & Operator
- * welcome — the live Vestige Pro account site (sign up, email, pay).
- * Named so we can retarget later without hunting through install copy.
+ * welcome. Named so we can retarget later without hunting install copy.
  */
-const VESTIGE_PRO_SCREEN_URL = 'https://vestige-pro-production.fly.dev';
+const VESTIGE_PRO_SCREEN_URL = 'https://github.com/samvallad33/vestige#vestige-pro';
 const WELCOME_TIMEOUT_MS = 15_000;
 
 const WELCOME_BANNER = [

--- a/packages/vestige-mcp-npm/scripts/welcome.js
+++ b/packages/vestige-mcp-npm/scripts/welcome.js
@@ -6,7 +6,7 @@ const { spawn } = require('child_process');
  * Destination opened when the user presses Enter on the Pro & Operator
  * welcome. Named so we can retarget later without hunting install copy.
  */
-const VESTIGE_PRO_SCREEN_URL = 'https://github.com/samvallad33/vestige#vestige-pro';
+const VESTIGE_PRO_SCREEN_URL = 'https://vestige-pro-production.fly.dev';
 const WELCOME_TIMEOUT_MS = 15_000;
 
 const WELCOME_BANNER = [

--- a/packages/vestige-mcp-npm/tests/welcome.test.js
+++ b/packages/vestige-mcp-npm/tests/welcome.test.js
@@ -43,8 +43,8 @@ test('postinstall.js and welcome.js still parse', () => {
   }
 });
 
-test('destination URL is a named constant pointing at the Pro section', () => {
-  assert.equal(VESTIGE_PRO_SCREEN_URL, 'https://github.com/samvallad33/vestige#vestige-pro');
+test('destination URL is a named constant pointing at the Pro account site', () => {
+  assert.equal(VESTIGE_PRO_SCREEN_URL, 'https://vestige-pro-production.fly.dev');
   assert.equal(WELCOME_TIMEOUT_MS, 15_000);
 });
 

--- a/packages/vestige-mcp-npm/tests/welcome.test.js
+++ b/packages/vestige-mcp-npm/tests/welcome.test.js
@@ -43,8 +43,8 @@ test('postinstall.js and welcome.js still parse', () => {
   }
 });
 
-test('destination URL is a named constant pointing at the Pro account site', () => {
-  assert.equal(VESTIGE_PRO_SCREEN_URL, 'https://vestige-pro-production.fly.dev');
+test('destination URL is a named constant pointing at the Pro section', () => {
+  assert.equal(VESTIGE_PRO_SCREEN_URL, 'https://github.com/samvallad33/vestige#vestige-pro');
   assert.equal(WELCOME_TIMEOUT_MS, 15_000);
 });
 

--- a/packages/vestige-mcp-npm/tests/welcome.test.js
+++ b/packages/vestige-mcp-npm/tests/welcome.test.js
@@ -1,0 +1,189 @@
+'use strict';
+
+const assert = require('assert/strict');
+const { EventEmitter } = require('events');
+const { spawnSync } = require('child_process');
+const path = require('path');
+const test = require('node:test');
+
+const welcome = require('../scripts/welcome');
+
+const {
+  VESTIGE_PRO_SCREEN_URL,
+  WELCOME_BANNER,
+  WELCOME_TIMEOUT_MS,
+  shouldOfferWelcome,
+  classifyWelcomeKey,
+  openDestinationUrl,
+  offerWelcome,
+} = welcome;
+
+function fakeStdin() {
+  const stdin = new EventEmitter();
+  stdin.isTTY = true;
+  stdin.isRaw = false;
+  stdin.setRawMode = (value) => {
+    stdin.isRaw = Boolean(value);
+  };
+  stdin.setEncoding = () => {};
+  stdin.resume = () => {};
+  stdin.pause = () => {};
+  stdin.isPaused = () => true;
+  return stdin;
+}
+
+test('postinstall.js and welcome.js still parse', () => {
+  const scripts = [
+    path.join(__dirname, '..', 'scripts', 'postinstall.js'),
+    path.join(__dirname, '..', 'scripts', 'welcome.js'),
+  ];
+  for (const script of scripts) {
+    const result = spawnSync(process.execPath, ['--check', script], { encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  }
+});
+
+test('destination URL is a named constant pointing at the Pro account site', () => {
+  assert.equal(VESTIGE_PRO_SCREEN_URL, 'https://vestige-pro-production.fly.dev');
+  assert.equal(WELCOME_TIMEOUT_MS, 15_000);
+});
+
+test('banner copy is exact', () => {
+  assert.equal(
+    WELCOME_BANNER,
+    [
+      '✦  Vestige Pro & Operator — out now.',
+      '',
+      '   Continuity across every machine.',
+      '   Receipt → permit → effect. Fail closed.',
+      '',
+      '   Press Enter to open the screen · q to skip',
+    ].join('\n')
+  );
+  assert.doesNotMatch(WELCOME_BANNER, /\$19/);
+});
+
+test('TTY gate stays closed in CI, npm -y, and non-TTY installs', () => {
+  const tty = { stdoutIsTTY: true, stdinIsTTY: true };
+
+  assert.equal(shouldOfferWelcome({ ...tty, env: {} }), true);
+  assert.equal(shouldOfferWelcome({ ...tty, env: { CI: 'true' } }), false);
+  assert.equal(shouldOfferWelcome({ ...tty, env: { CI: '1' } }), false);
+  assert.equal(shouldOfferWelcome({ ...tty, env: { CONTINUOUS_INTEGRATION: 'true' } }), false);
+  assert.equal(shouldOfferWelcome({ ...tty, env: { npm_config_yes: 'true' } }), false);
+  assert.equal(shouldOfferWelcome({ ...tty, env: { npm_config_yes: '1' } }), false);
+  assert.equal(shouldOfferWelcome({ stdoutIsTTY: false, stdinIsTTY: true, env: {} }), false);
+  assert.equal(shouldOfferWelcome({ stdoutIsTTY: true, stdinIsTTY: false, env: {} }), false);
+  assert.equal(shouldOfferWelcome({ stdoutIsTTY: false, stdinIsTTY: false, env: {} }), false);
+});
+
+test('key classifier maps Enter, q, and Ctrl-C', () => {
+  assert.equal(classifyWelcomeKey('\r'), 'open');
+  assert.equal(classifyWelcomeKey('\n'), 'open');
+  assert.equal(classifyWelcomeKey('\r\n'), 'open');
+  assert.equal(classifyWelcomeKey('q'), 'skip');
+  assert.equal(classifyWelcomeKey('Q'), 'skip');
+  assert.equal(classifyWelcomeKey('q\n'), 'skip');
+  assert.equal(classifyWelcomeKey('\u0003'), 'cancel');
+  assert.equal(classifyWelcomeKey('x'), null);
+});
+
+test('openDestinationUrl uses the platform opener', () => {
+  const calls = [];
+  const spawnFn = (command, args, options) => {
+    calls.push({ command, args, options });
+    return { unref() {} };
+  };
+
+  openDestinationUrl(VESTIGE_PRO_SCREEN_URL, { spawnFn, platform: 'darwin' });
+  openDestinationUrl(VESTIGE_PRO_SCREEN_URL, { spawnFn, platform: 'linux' });
+  openDestinationUrl(VESTIGE_PRO_SCREEN_URL, { spawnFn, platform: 'win32' });
+
+  assert.deepEqual(calls[0], {
+    command: 'open',
+    args: [VESTIGE_PRO_SCREEN_URL],
+    options: { stdio: 'ignore', detached: true },
+  });
+  assert.deepEqual(calls[1], {
+    command: 'xdg-open',
+    args: [VESTIGE_PRO_SCREEN_URL],
+    options: { stdio: 'ignore', detached: true },
+  });
+  assert.equal(calls[2].command, 'cmd');
+  assert.deepEqual(calls[2].args, ['/c', 'start', '', VESTIGE_PRO_SCREEN_URL]);
+});
+
+test('offerWelcome is a no-op when the TTY gate is closed', async () => {
+  const chunks = [];
+  const result = await offerWelcome({
+    env: { CI: 'true' },
+    stdoutIsTTY: true,
+    stdinIsTTY: true,
+    write: (text) => chunks.push(text),
+  });
+  assert.deepEqual(result, { offered: false, action: 'gated' });
+  assert.deepEqual(chunks, []);
+});
+
+test('offerWelcome opens the screen on Enter', async () => {
+  const stdin = fakeStdin();
+  const chunks = [];
+  const opened = [];
+  const pending = offerWelcome({
+    env: {},
+    stdin,
+    stdoutIsTTY: true,
+    stdinIsTTY: true,
+    write: (text) => chunks.push(text),
+    openUrl: (url) => opened.push(url),
+    timeoutMs: 1_000,
+  });
+  stdin.emit('data', '\r');
+  const result = await pending;
+  assert.deepEqual(result, { offered: true, action: 'open' });
+  assert.deepEqual(opened, [VESTIGE_PRO_SCREEN_URL]);
+  assert.match(chunks.join(''), /Vestige Pro & Operator/);
+  assert.match(chunks.join(''), /Opening the screen/);
+});
+
+test('offerWelcome skips cleanly on q and Ctrl-C', async () => {
+  for (const [key, action] of [
+    ['q', 'skip'],
+    ['\u0003', 'cancel'],
+  ]) {
+    const stdin = fakeStdin();
+    const opened = [];
+    const pending = offerWelcome({
+      env: {},
+      stdin,
+      stdoutIsTTY: true,
+      stdinIsTTY: true,
+      write: () => {},
+      openUrl: (url) => opened.push(url),
+      timeoutMs: 1_000,
+    });
+    stdin.emit('data', key);
+    const result = await pending;
+    assert.deepEqual(result, { offered: true, action });
+    assert.deepEqual(opened, []);
+  }
+});
+
+test('offerWelcome times out with a URL fallback', async () => {
+  const stdin = fakeStdin();
+  const chunks = [];
+  const result = await offerWelcome({
+    env: {},
+    stdin,
+    stdoutIsTTY: true,
+    stdinIsTTY: true,
+    write: (text) => chunks.push(text),
+    openUrl: () => {
+      throw new Error('should not open on timeout');
+    },
+    timeoutMs: 20,
+  });
+  assert.deepEqual(result, { offered: true, action: 'timeout' });
+  assert.match(chunks.join(''), /Timed out/);
+  assert.ok(chunks.join('').includes(VESTIGE_PRO_SCREEN_URL));
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
After a successful binary install, a real TTY session announces Vestige Pro & Operator and waits for one key. Enter opens the live Pro account site. `q` or Ctrl-C skips. A 15s timeout prints the URL so installs never hang.

## What users see

```
✦  Vestige Pro & Operator — out now.

   Continuity across every machine.
   Receipt → permit → effect. Fail closed.

   Press Enter to open the screen · q to skip
```

Enter opens **https://vestige-pro-production.fly.dev** (`VESTIGE_PRO_SCREEN_URL`). Timeout fallback prints that same URL.

## Behavior

- Postinstall only offers this **after** a successful binary install
- Gate: stdout TTY **and** stdin TTY; skipped when `CI`, `CONTINUOUS_INTEGRATION`, or `npm_config_yes` is set
- CI, Docker builds, and `npm i` without a TTY never block
- Binary download / checksum path is unchanged
- `vestige` with no args shows the same short block plus the Enter prompt (TTY only)
- `vestige health` footer matches the announcement (no wait — scripts stay unblocked)
- `vestige-mcp` stdio is untouched
- Local memory stays free. Copy claims only “Pro & Operator — out now.”

## Tests

- `node --check` on postinstall + welcome
- Node unit tests for TTY gate, exact banner copy, Enter / `q` / Ctrl-C, timeout URL fallback, and platform openers
- CLI unit tests for the named URL and TTY gate

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02c03126-a1bf-41b6-91e1-eac2cafad541?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02c03126-a1bf-41b6-91e1-eac2cafad541&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

