### PR TITLE
docs: replace retired tool names and stale build recipes with the shipped ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Everything above is free forever and never metered. **Pro ($19/month)** is manag
 
 | | |
 |---|---|
-| Engine | Rust 2024, ~96k lines, single 25MB binary, 1,961 tests, clippy clean at `-D warnings` |
+| Engine | Rust 2024, ~96k lines, single 25MB binary, 1,990+ tests, clippy clean at `-D warnings` |
 | Retrieval | Nomic Embed v1.5 (Matryoshka 768d→256d) + USearch HNSW + SQLite FTS5, optional Qwen3 reranker |
 | Storage | SQLite, optional SQLCipher encryption ([docs/STORAGE.md](docs/STORAGE.md)) |
 | Offline | One 130MB model download on first run, then no network, ever |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -163,7 +163,7 @@ scores and timestamps are included:
 
 Resolved per call, highest to lowest:
 
-1. **Explicit MCP parameter** (e.g. `detail_level` / `limit` on a `search`
+1. **Explicit MCP parameter** (e.g. `detail_level` / `limit` on a `recall`
    call) — always wins.
 2. **`vestige.toml`** — the `[defaults]` keys and the selected profile.
 3. **Built-in default** — the `default` profile, identical to pre-v2.1.26
@@ -171,7 +171,7 @@ Resolved per call, highest to lowest:
 
 ### Affected tools
 
-`search`, `memory_timeline`, `codebase` (`get_context`), and `session_context`
+`recall`, `memory_status` (`timeline` view), `codebase` (`get_context`), and `session_start`
 resolve their default detail level and result limit through this config. Each of
 these tools also echoes the active `profile` in its response so you can confirm
 what was applied. Tools that take no `detail_level`/`limit` are unaffected.

--- a/docs/INSTALL-INTEL-MAC.md
+++ b/docs/INSTALL-INTEL-MAC.md
@@ -6,7 +6,7 @@ x86_64 macOS prebuilts after ONNX Runtime v1.23.0, so we use the
 `ort-dynamic` feature to runtime-link against the version you install locally.
 This keeps Vestige working on Intel Mac without waiting for a dead upstream.
 
-As of Vestige 2.3.0 this is still the Intel Mac path. Homebrew ONNX Runtime
+As of Vestige 2.7.1 this is still the Intel Mac path. Homebrew ONNX Runtime
 remains required; there is no pure-Rust Intel backend in the current release.
 
 ## Prerequisite
@@ -73,7 +73,7 @@ brew install onnxruntime
 git clone https://github.com/samvallad33/vestige && cd vestige
 cargo build --release -p vestige-mcp \
   --no-default-features \
-  --features ort-dynamic,vector-search
+  --features ort-dynamic,vector-search,cloud-sync,connectors
 export ORT_DYLIB_PATH="$(brew --prefix onnxruntime)/lib/libonnxruntime.dylib"
 ./target/release/vestige-mcp --version
 ```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,11 +3,12 @@
 > Public adoption roadmap for making Vestige easier to start, easier to trust,
 > and easier to configure.
 
-Last updated: June 7, 2026
+Last updated: September 4, 2026
 
-Vestige already has the core primitives for durable local memory: `search`,
-`session_context`, `smart_ingest`, `memory`, `intention`, `codebase`,
-`deep_reference`, suppression, portable storage, and the dashboard. The next
+Vestige already has the core primitives for durable local memory: `recall`
+(lookup, reason and contradictions modes), `session_start`, `smart_ingest`,
+`memory`, `intention`, `codebase`, suppression, portable storage, and the
+dashboard. The next
 product step is reducing first-user confusion so more people can get value from
 those primitives without inventing their own fragile memory vocabulary.
 
@@ -30,7 +31,7 @@ This roadmap turns early community feedback into a staged plan.
 
 | Area | Current State | Next Documentation Fix |
 |------|---------------|------------------------|
-| Session startup | `session_context` combines memories, intentions, status, predictions, and codebase context. | Update all agent setup templates to make `session_context` the default startup call. |
+| Session startup | `session_start` combines memories, intentions, status, predictions, and codebase context. | Update all agent setup templates to make `session_start` the default startup call. |
 | Batch memory saves | `smart_ingest` batch mode defaults to `batchMergePolicy="force_create"` so caller-separated items stay separate. | Document when to use batch force-create vs smart merge. |
 | Device migration | `portable-export`, `portable-import`, and `sync` preserve exact Vestige storage state. | Separate device migration from first-time document import so users do not confuse them. |
 | Supersede semantics | Supersede demotes the old memory and creates a new one; it does not purge the old memory. | Add plain-language vocabulary for create, update, supersede, suppress, demote, and purge. |
@@ -45,7 +46,7 @@ Target: make the first 30 minutes with Vestige hard to mess up.
 | Atomic memory guide | Clear examples for one fact, one preference, one decision, one bug fix, one source note, and one code pattern per memory. |
 | Default tag vocabulary | Recommended tags for source quality, confidence, project, type, urgency, and lifecycle without overloading words like `verified`. |
 | Smart vs force-create guide | Agents know when to use `forceCreate`, `batchMergePolicy="force_create"`, or normal PE gating. |
-| Updated agent templates | Claude, Codex, Cursor, VS Code, Xcode, OpenCode, JetBrains, and Windsurf templates start with `session_context` and use the same memory vocabulary. |
+| Updated agent templates | Claude, Codex, Cursor, VS Code, Xcode, OpenCode, JetBrains, and Windsurf templates start with `session_start` and use the same memory vocabulary. |
 
 Planned docs:
 
@@ -106,7 +107,7 @@ reminder.
 |------|---------|
 | Goal primitive | Non-fading, manually pivoted goals that survive normal memory decay. |
 | Milestone tracking | Goals can have milestones, status, evidence, and blockers. |
-| Goal-aware session context | `session_context` can include active goals when relevant. |
+| Goal-aware session context | `session_start` can include active goals when relevant. |
 | Manual pivot semantics | Agents can update goals only when the user explicitly pivots, completes, or cancels them. |
 | Dashboard surface | Users can inspect active, completed, paused, and cancelled goals. |
 


### PR DESCRIPTION
Docs only. Every item below was verified against the source tree and the CI workflow before editing.

| File | Was | Now |
| --- | --- | --- |
| docs/ROADMAP.md:6 | Last updated June 7, 2026 | September 4, 2026 |
| docs/ROADMAP.md:8-10 | core primitives `search`, `session_context`, `deep_reference` | `recall` (lookup, reason, contradictions), `session_start` |
| docs/ROADMAP.md:33, 48, 109 | `session_context` | `session_start` (renamed in v2.2; only server.rs recorded the rename) |
| docs/CONFIGURATION.md:166, 174 | `search`, `memory_timeline`, `session_context` | `recall`, `memory_status` timeline view, `session_start` |
| docs/INSTALL-INTEL-MAC.md:9 | "As of Vestige 2.3.0" | 2.7.1 |
| docs/INSTALL-INTEL-MAC.md:74-76 | build recipe without `cloud-sync`, `connectors` | matches the CI release flags for that target |
| README.md:143 | 1,961 tests | 1,990+ tests (1,991 pass on main today; the count moves every PR) |

Gate: `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)