### PR TITLE
fix(deps): libgit2-sys 0.18.8+1.9.7, four-plus libgit2 CVEs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2558,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.8+1.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "7f7c568b25d7489bc3fb2988ed69ab111d2944d2f5fec3d5c987fe545ea97b50"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
One lock-file update. The bundled libgit2 1.9.2 predates v1.9.5 (2026-07-18), which fixed CVE-2026-53584 (submodule path escaping), CVE-2026-53585 (unbounded allocation via the delta object result-size header), CVE-2026-53586 (auth callback host) and CVE-2026-53587, and v1.9.7 (2026-08-13). Vestige builds git2 with vendored OpenSSL, so the OpenSSL-backend fixes apply to shipped binaries. Same `^0.18` range as git2 0.20.4, so `Cargo.toml` is untouched.

| Check | Result |
| --- | --- |
| `cargo update -p libgit2-sys` | 0.18.3+1.9.2 to 0.18.8+1.9.7, one package, checksum updated |
| `cargo check --workspace --all-targets` | clean |
| `cargo test -p vestige-core --lib -- codebase` | 61 passed, 0 failed |

Sources: libgit2 releases v1.9.5 and v1.9.7 on GitHub, crates.io libgit2-sys 0.18.8+1.9.7 (2026-08-21). Found by the Sep 4 dependency audit; none of the existing upgrade plan items covered libgit2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)