### PR TITLE
feat(mcp): tool hints and titles, leaner descriptions, brief recall; stop quarantining incidental mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,39 @@ starvation findings did not reproduce (every migration already runs inside one
 IMMEDIATE transaction with its own version bump, and `wal_autocheckpoint` is
 on), so those got regression tests and a checkpoint hook rather than rewrites.
 
+### Changed — MCP surface
+
+- Every advertised tool now carries a `title` and all four MCP behaviour hints
+  (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`),
+  serialised explicitly so clients never fall back on the spec defaults that
+  assume the worst. `recall`, `receipt`, `memory_status`, and `session_start`
+  are read-only (they record receipts and access statistics, never memory
+  content); `memory`, `intention`, `maintain`, and `dedup` are destructive;
+  only `source_sync` reaches outside the local store. `graph` stays writable
+  because `label` records an outcome. A unit test pins the exact sets and the
+  e2e suite checks the wire shape.
+- 45 tool and property descriptions were rewritten to say the same thing in
+  fewer words (3,710 bytes removed), and `codebase` now advertises its
+  `verify` action. With the hints added, `tools/list` went from 38,474 to
+  35,019 bytes. The rest of the weight is schema structure and is tracked as
+  its own issue.
+- `recall` with `detail_level: "brief"` now returns `receiptId` without the
+  full receipt and without the `contextReinstatement` block. The receipt is
+  persisted and one `receipt` call away. Default and full responses are
+  unchanged.
+
+### Fixed — Memory PR gate
+
+- A single sensitive word deep inside a long note no longer quarantines the
+  write. The `sensitive_topic` signal fires when a tag names the topic, a
+  credential-shaped value sits in the content, the write is short (60 words
+  or fewer), the topic leads the text (first 12 words), or two distinct
+  topics appear. On the real store the incidental case produced most holds:
+  ordinary engineering notes that mentioned "token" or "identity" once were
+  held for review and their authors had to come back for them. Five tests
+  cover the branches, including a fake token fixture checked against the
+  secret scanner. `docs/CONFIGURATION.md` states the rule.
+
 ### Fixed — Vector index
 
 - A long-lived MCP server process now sees exactly the vectors its sibling

--- a/crates/vestige-core/src/trace/review.rs
+++ b/crates/vestige-core/src/trace/review.rs
@@ -304,11 +304,8 @@ fn collect_signals(ctx: &WriteContext) -> Vec<RiskSignal> {
             format!("Writes a sensitive node type: `{}`.", node_type_lc),
         ));
     }
-    if let Some(topic) = first_sensitive_topic(&ctx.content, &ctx.tags) {
-        signals.push(RiskSignal::new(
-            "sensitive_topic",
-            format!("Touches a sensitive topic: {topic}."),
-        ));
+    if let Some(reason) = sensitive_topic_reason(&ctx.content, &ctx.tags) {
+        signals.push(RiskSignal::new("sensitive_topic", reason));
     }
 
     // 4. Dream consolidation proposals.
@@ -358,34 +355,76 @@ fn collect_signals(ctx: &WriteContext) -> Vec<RiskSignal> {
     signals
 }
 
-/// Return the human label of the first sensitive topic found in content/tags.
+/// A write with at most this many words is short enough that any sensitive
+/// word in it is what the write is about.
+const SHORT_WRITE_WORDS: usize = 60;
+
+/// A sensitive word inside the leading run of this many words marks the topic
+/// of the write, however long the rest of it is.
+const LEADING_WORDS: usize = 12;
+
+/// Lowercase alphanumeric words of `text`, split on any other character.
+fn tokenize(text: &str) -> Vec<String> {
+    text.to_ascii_lowercase()
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|w| !w.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Decide whether a write is *about* a sensitive topic, and say why.
 ///
-/// B6: matches on WORD BOUNDARIES, not substrings — so "tokenizer" no longer
-/// trips "token", "author" no longer trips "auth", "secretary" no longer trips
-/// "secret". Multi-word needles (e.g. "api key") match a consecutive run of
-/// words. The text is lowercased and split on any non-alphanumeric char.
-fn first_sensitive_topic(content: &str, tags: &[String]) -> Option<&'static str> {
-    // Tokenize content + tags into lowercased alphanumeric words.
-    let mut words: Vec<String> = Vec::new();
-    let mut push_words = |s: &str| {
-        for w in s
-            .to_ascii_lowercase()
-            .split(|c: char| !c.is_ascii_alphanumeric())
-        {
-            if !w.is_empty() {
-                words.push(w.to_string());
-            }
-        }
-    };
-    push_words(content);
-    for t in tags {
-        push_words(t);
+/// B6 made matching whole-word ("tokenizer" no longer trips "token"). This
+/// adds the second half of the fix: a single sensitive word buried deep in a
+/// long engineering note is a mention, not a subject, and must not hold the
+/// write. On the real store that incidental case produced most quarantines,
+/// and every held write is one the agent has to come back for.
+///
+/// The write is held when any of these is true:
+/// - a tag names a sensitive topic (a tag is a deliberate label),
+/// - a sensitive word sits next to a credential-shaped value,
+/// - the write is short (`SHORT_WRITE_WORDS` or fewer words),
+/// - a sensitive word appears in the first `LEADING_WORDS` words,
+/// - two or more distinct sensitive topics appear anywhere.
+///
+/// Multi-word needles (e.g. "api key") match a consecutive run of words.
+fn sensitive_topic_reason(content: &str, tags: &[String]) -> Option<String> {
+    let tag_words: Vec<String> = tags.iter().flat_map(|t| tokenize(t)).collect();
+    if let Some((_, label)) = SENSITIVE_TOPICS
+        .iter()
+        .find(|(needle, _)| matches_word_sequence(&tag_words, needle))
+    {
+        return Some(format!("Tagged with a sensitive topic: {label}."));
     }
 
-    SENSITIVE_TOPICS
-        .iter()
-        .find(|(needle, _)| matches_word_sequence(&words, needle))
-        .map(|(_, label)| *label)
+    let words = tokenize(content);
+    let leading = &words[..words.len().min(LEADING_WORDS)];
+    let mut labels: Vec<&'static str> = Vec::new();
+    let mut leads_with_topic = false;
+    for (needle, label) in SENSITIVE_TOPICS {
+        if !matches_word_sequence(&words, needle) {
+            continue;
+        }
+        if !labels.contains(label) {
+            labels.push(label);
+        }
+        leads_with_topic |= matches_word_sequence(leading, needle);
+    }
+    let first = *labels.first()?;
+
+    if !crate::security::scan_secrets(content).is_empty() {
+        return Some(format!(
+            "Touches a sensitive topic ({first}) next to a credential-shaped value."
+        ));
+    }
+    if labels.len() >= 2 {
+        return Some(format!("Touches sensitive topics: {}.", labels.join(", ")));
+    }
+    if words.len() <= SHORT_WRITE_WORDS || leads_with_topic {
+        return Some(format!("Touches a sensitive topic: {first}."));
+    }
+    // One sensitive word deep inside a long note is incidental.
+    None
 }
 
 /// Whether `needle` (one or more space-separated words) appears as a consecutive
@@ -716,6 +755,97 @@ mod tests {
         }
     }
 
+    /// A long engineering note that mentions one sensitive word once, deep in
+    /// the text, is about the engineering, not the word.
+    fn long_note(tail: &str) -> String {
+        let body = "The vector journal is trigger fed from embedding_profile_vectors and \
+each reader applies rows past its watermark before answering a query. Reconcile \
+runs when the journal was pruned under a reader or when the same seq shows up \
+twice, which only happens after a restore from backup. The prune keeps the newest \
+ten thousand rows and everything from the last seven days so a reader that was \
+offline over a weekend still catches up incrementally instead of rebuilding.";
+        assert!(
+            tokenize(body).len() > SHORT_WRITE_WORDS,
+            "fixture must be a long write"
+        );
+        format!("{body} {tail}")
+    }
+
+    #[test]
+    fn incidental_mention_deep_in_long_note_does_not_gate() {
+        let mut ctx = ordinary();
+        ctx.node_type = "fact".into();
+        ctx.tags = vec![];
+        ctx.content = long_note("Each journal row costs about one token of context.");
+        let (class, signals) = classify_write(&ctx, ReviewMode::RiskGated);
+        assert_eq!(class, RiskClass::AutoCommit, "{signals:?}");
+    }
+
+    #[test]
+    fn long_note_that_leads_with_a_sensitive_topic_gates() {
+        let mut ctx = ordinary();
+        ctx.node_type = "fact".into();
+        ctx.tags = vec![];
+        ctx.content = format!("Security note. {}", long_note(""));
+        let (class, signals) = classify_write(&ctx, ReviewMode::RiskGated);
+        assert_eq!(class, RiskClass::Review);
+        assert!(signals.iter().any(|s| s.code == "sensitive_topic"));
+    }
+
+    #[test]
+    fn long_note_with_two_sensitive_topics_gates() {
+        let mut ctx = ordinary();
+        ctx.node_type = "fact".into();
+        ctx.tags = vec![];
+        ctx.content = long_note("The payment schedule is fixed by the contract.");
+        let (class, signals) = classify_write(&ctx, ReviewMode::RiskGated);
+        assert_eq!(class, RiskClass::Review);
+        let reason = &signals
+            .iter()
+            .find(|s| s.code == "sensitive_topic")
+            .expect("topic signal")
+            .detail;
+        assert!(reason.contains("financial fact"), "{reason}");
+        assert!(reason.contains("legal / contract fact"), "{reason}");
+    }
+
+    #[test]
+    fn sensitive_tag_gates_a_long_note() {
+        let mut ctx = ordinary();
+        ctx.node_type = "fact".into();
+        ctx.tags = vec!["security".into()];
+        ctx.content = long_note("");
+        let (class, signals) = classify_write(&ctx, ReviewMode::RiskGated);
+        assert_eq!(class, RiskClass::Review);
+        let reason = &signals
+            .iter()
+            .find(|s| s.code == "sensitive_topic")
+            .expect("topic signal")
+            .detail;
+        assert!(reason.starts_with("Tagged with"), "{reason}");
+    }
+
+    #[test]
+    fn credential_shaped_value_in_a_long_note_gates() {
+        let fake = format!("ghp_{}", "A".repeat(36));
+        assert!(
+            !crate::security::scan_secrets(&fake).is_empty(),
+            "fixture must look like a credential to the scanner"
+        );
+        let mut ctx = ordinary();
+        ctx.node_type = "fact".into();
+        ctx.tags = vec![];
+        ctx.content = long_note(&format!("The deploy token is {fake}."));
+        let (class, signals) = classify_write(&ctx, ReviewMode::RiskGated);
+        assert_eq!(class, RiskClass::Review);
+        let reason = &signals
+            .iter()
+            .find(|s| s.code == "sensitive_topic")
+            .expect("topic signal")
+            .detail;
+        assert!(reason.contains("credential-shaped value"), "{reason}");
+    }
+
     #[test]
     fn sensitive_node_type_gates() {
         let mut ctx = ordinary();
@@ -817,13 +947,23 @@ mod review_mode_labels {
     #[test]
     fn try_from_label_is_strict_and_from_label_is_lenient() {
         assert_eq!(ReviewMode::try_from_label("fast"), Some(ReviewMode::Fast));
-        assert_eq!(ReviewMode::try_from_label(" Risk-Gated "), Some(ReviewMode::RiskGated));
-        assert_eq!(ReviewMode::try_from_label("PARANOID"), Some(ReviewMode::Paranoid));
+        assert_eq!(
+            ReviewMode::try_from_label(" Risk-Gated "),
+            Some(ReviewMode::RiskGated)
+        );
+        assert_eq!(
+            ReviewMode::try_from_label("PARANOID"),
+            Some(ReviewMode::Paranoid)
+        );
         // A typo must be visible to the caller, not silently the default.
         assert_eq!(ReviewMode::try_from_label("fsat"), None);
         assert_eq!(ReviewMode::try_from_label(""), None);
         assert_eq!(ReviewMode::from_label("fsat"), ReviewMode::RiskGated);
-        for mode in [ReviewMode::Fast, ReviewMode::RiskGated, ReviewMode::Paranoid] {
+        for mode in [
+            ReviewMode::Fast,
+            ReviewMode::RiskGated,
+            ReviewMode::Paranoid,
+        ] {
             assert_eq!(ReviewMode::try_from_label(mode.as_str()), Some(mode));
         }
     }

--- a/crates/vestige-mcp/src/protocol/messages.rs
+++ b/crates/vestige-mcp/src/protocol/messages.rs
@@ -81,14 +81,42 @@ pub struct ServerCapabilities {
 // TOOLS
 // ============================================================================
 
+/// Behaviour hints for a tool, from the MCP `ToolAnnotations` schema.
+///
+/// Every hint is serialised explicitly, so a client that reads the list
+/// never has to fall back on the spec defaults (which assume the worst:
+/// writable, destructive, open-world). The hints describe the tool's effect
+/// on the user's memory store, which is the environment an agent cares
+/// about. `recall`, for example, records receipts and access statistics
+/// as it runs, but it never changes what a memory says, so it is read-only
+/// in the sense the hint exists to convey.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolAnnotations {
+    /// The tool does not modify memory content.
+    pub read_only_hint: bool,
+    /// The tool can delete, merge, or overwrite existing memories.
+    pub destructive_hint: bool,
+    /// Calling the tool twice with the same arguments has no extra effect.
+    pub idempotent_hint: bool,
+    /// The tool reaches outside the local store (network, external systems).
+    pub open_world_hint: bool,
+}
+
 /// Tool description for tools/list
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ToolDescription {
     pub name: String,
+    /// Human-readable display name; clients show it instead of `name`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub input_schema: Value,
+    /// Behaviour hints (read-only, destructive, idempotent, open-world).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<ToolAnnotations>,
     /// Per-tool `_meta` annotations from the MCP wire spec.
     ///
     /// Notable keys recognized by Claude Code (v2.1.91+):

--- a/crates/vestige-mcp/src/server.rs
+++ b/crates/vestige-mcp/src/server.rs
@@ -15,7 +15,7 @@ use crate::dashboard::events::VestigeEvent;
 use crate::protocol::messages::{
     CallToolRequest, CallToolResult, InitializeRequest, InitializeResult, ListResourcesResult,
     ListToolsResult, ReadResourceRequest, ReadResourceResult, ResourceDescription,
-    ServerCapabilities, ServerInfo, ToolDescription,
+    ServerCapabilities, ServerInfo, ToolAnnotations, ToolDescription,
 };
 use crate::protocol::types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, MCP_VERSION};
 use crate::resources;
@@ -379,13 +379,27 @@ impl McpServer {
             // ================================================================
             ToolDescription {
                 name: "recall".to_string(),
-                description: Some("Retrieve from memory. Modes: 'lookup' (default — fast hybrid search: keyword + semantic + convex fusion; retrieval is audit-only, and promote is the explicit usefulness signal), 'reason' (deep cognitive reasoning across memories with FSRS-6 trust scoring, spreading activation, supersession, and contradiction analysis; use when accuracy matters, needs 'query'), 'contradictions' (surface trust-weighted disagreement pairs for a 'topic'). Default mode is fast — only 'reason' pays the deep-analysis cost.".to_string()),
+                title: Some("Recall".to_string()),
+                annotations: Some(ToolAnnotations {
+                    read_only_hint: true,
+                    destructive_hint: false,
+                    idempotent_hint: true,
+                    open_world_hint: false,
+                }),
+description: Some("Retrieve from memory. mode 'lookup' (default): fast hybrid keyword and semantic search. 'reason': deep pass with trust scoring, spreading activation, supersession, and contradictions; needs 'query', use when accuracy matters. 'contradictions': disagreement pairs for a 'topic'. Reading never changes strength; promote what helped via memory.".to_string()),
                 input_schema: tools::recall::schema(),
                 ..Default::default()
             },
             ToolDescription {
                 name: "receipt".to_string(),
-                description: Some("Inspect a persisted memory receipt or run a controlled post-retrieval context ablation. Actions: 'get' returns the receipt and a privacy-safe frozen-capsule summary; 'replay' compares the exact final recorded evidence pack with the same pack minus specified receipt-local slots. Replay never reruns search, backfills candidates, expands the graph, calls a model, or establishes causality.".to_string()),
+                title: Some("Receipt".to_string()),
+                annotations: Some(ToolAnnotations {
+                    read_only_hint: true,
+                    destructive_hint: false,
+                    idempotent_hint: true,
+                    open_world_hint: false,
+                }),
+description: Some("Inspect a persisted retrieval receipt ('get') or run a controlled ablation of its frozen evidence pack ('replay', which withholds named slots without rerunning search, calling a model, or claiming causality).".to_string()),
                 input_schema: tools::receipt::schema(),
                 ..Default::default()
             },
@@ -394,19 +408,40 @@ impl McpServer {
             // ================================================================
             ToolDescription {
                 name: "memory".to_string(),
-                description: Some("Unified memory management tool. Actions: 'get' (retrieve full node), 'purge' (irreversibly remove content/embeddings with confirm=true), 'delete' (legacy alias for purge), 'state' (get accessibility state), 'promote' (thumbs up — increases retrieval strength), 'demote' (thumbs down — decreases retrieval strength, does NOT delete), 'edit' (update content in-place, preserves FSRS state).".to_string()),
+                title: Some("Memory".to_string()),
+                annotations: Some(ToolAnnotations {
+                    read_only_hint: false,
+                    destructive_hint: true,
+                    idempotent_hint: false,
+                    open_world_hint: false,
+                }),
+description: Some("Manage one memory. Actions: 'get', 'get_batch' (ids), 'state' (accessibility), 'promote' and 'demote' (adjust retrieval strength; demote never deletes), 'edit' (replace content, keep FSRS state), 'purge' (remove content and embeddings for good; confirm=true). 'delete' is an alias for purge.".to_string()),
                 input_schema: tools::memory_unified::schema(),
                 ..Default::default()
             },
             ToolDescription {
                 name: "codebase".to_string(),
-                description: Some("Unified codebase tool. Actions: 'remember_pattern' (store code pattern), 'remember_decision' (store architectural decision), 'get_context' (retrieve patterns and decisions).".to_string()),
+                title: Some("Codebase".to_string()),
+                annotations: Some(ToolAnnotations {
+                    read_only_hint: false,
+                    destructive_hint: false,
+                    idempotent_hint: false,
+                    open_world_hint: false,
+                }),
+description: Some("Code memory. Actions: 'remember_pattern', 'remember_decision', 'get_context' (patterns and decisions, each marked current or stale), 'verify' (re-check anchored code memories against the working tree).".to_string()),
                 input_schema: tools::codebase_unified::schema(),
                 ..Default::default()
             },
             ToolDescription {
                 name: "intention".to_string(),
-                description: Some("Unified intention management tool. Actions: 'set' (create), 'check' (find triggered), 'update' (complete/snooze/cancel), 'list' (show intentions).".to_string()),
+                title: Some("Intention".to_string()),
+                annotations: Some(ToolAnnotations {
+                    read_only_hint: false,
+                    destructive_hint: true,
+                    idempotent_hint: false,
+                    open_world_hint: false,
+                }),
+description: Some("Intentions. Actions: 'set', 'check' (find triggered), 'update' (complete, snooze, cancel), 'list'.".to_string()),
                 input_schema: tools::intention_unified::schema(),
                 ..Default::default()
             },
@@ -415,7 +450,14 @@ impl McpServer {
             // ================================================================
             ToolDescription {
                 name: "smart_ingest".to_string(),
-                description: Some("INTELLIGENT memory ingestion with Prediction Error Gating. Single mode: provide 'content' to auto-decide CREATE/UPDATE/SUPERSEDE. Batch mode: provide 'items' array (max 20) for session-end saves — each item runs the full cognitive pipeline (importance scoring, intent detection, synaptic tagging).".to_string()),
+                title: Some("Smart Ingest".to_string()),
+                annotations: Some(ToolAnnotations {
+                    read_only_hint: false,
+                    destructive_hint: false,
+                    idempotent_hint: false,
+                    open_world_hint: false,
+                }),
+description: Some("Save to memory with Prediction Error Gating: 'content' is created, merged into a similar memory, or supersedes an outdated one. Batch mode: 'items' (max 20) for session-end saves, each through the full pipeline.".to_string()),
                 input_schema: tools::smart_ingest::schema(),
                 ..Default::default()
             },
@@ -424,7 +466,14 @@ impl McpServer {
             // ================================================================
             ToolDescription {
                 name: "source_sync".to_string(),
-                description: Some("Index an external system into Vestige as a durable, offline, semantically-searchable index that cites back to the canonical record. GitHub: source='github', repo='owner/name' (auth via GITHUB_TOKEN env). Redmine: source='redmine', project='<id>' (host via REDMINE_URL, auth via REDMINE_API_KEY env). Idempotent: re-running updates changed issues without duplicating; set reconcile=true to tombstone issues removed upstream.".to_string()),
+                title: Some("Source Sync".to_string()),
+                annotations: Some(ToolAnnotations {
+                    read_only_hint: false,
+                    destructive_hint: false,
+                    idempotent_hint: true,
+                    open_world_hint: true,
+                }),
+description: Some("Index an external system into local, searchable memories that cite the canonical record. source='github' (repo='owner/name', GITHUB_TOKEN env) or 'redmine' (project, REDMINE_URL and REDMINE_API_KEY env). Re-runs update changed items; reconcile=true tombstones items removed upstream.".to_string()),
                 input_schema: tools::source_sync::schema(),
                 ..Default::default()
             },
@@ -436,7 +485,14 @@ impl McpServer {
             // ================================================================
             ToolDescription {
                 name: "memory_status".to_string(),
-                description: Some("Memory status & history. Views: 'health' (default — full system health + stats + FSRS preview + cognitive-module health + warnings + recommendations), 'retention' (lightweight retention dashboard: avg, distribution, trend), 'timeline' (browse memories chronologically, grouped by day), 'changelog' (audit trail of memory state changes — per-memory transitions or system-wide), 'stats' (full-store hygiene counts by type/tag/age/retention/lifecycle, bounded never-accessed and largest-node details, and recent tag-operation audit).".to_string()),
+                title: Some("Memory Status".to_string()),
+                annotations: Some(ToolAnnotations {
+                    read_only_hint: true,
+                    destructive_hint: false,
+                    idempotent_hint: true,
+                    open_world_hint: false,
+                }),
+description: Some("Store status. view 'health' (default: stats, decay preview, module health, warnings), 'retention' (average, distribution, trend), 'timeline' (memories by day), 'changelog' (state-change audit trail), 'stats' (hygiene counts by type, tag, age, retention, lifecycle).".to_string()),
                 input_schema: tools::memory_status::schema(),
                 ..Default::default()
             },
@@ -447,7 +503,14 @@ impl McpServer {
             // ================================================================
             ToolDescription {
                 name: "maintain".to_string(),
-                description: Some("Memory maintenance & lifecycle. Actions: 'consolidate' (run FSRS-6 decay/embedding cycle), 'dream' (replay memories → insights/connections + strengthen patterns), 'gc' (garbage-collect stale memories; dry_run=true by default for safety), 'importance_score' (4-channel neuroscience score for 'content'), 'backup' (SQLite DB backup), 'export' (memories as JSON/JSONL with tag/date filters), 'restore' (restore from a JSON backup at 'path').".to_string()),
+                title: Some("Maintain".to_string()),
+                annotations: Some(ToolAnnotations {
+                    read_only_hint: false,
+                    destructive_hint: true,
+                    idempotent_hint: false,
+                    open_world_hint: false,
+                }),
+description: Some("Lifecycle maintenance. Actions: 'consolidate' (decay and embedding cycle), 'dream' (replay memories into insights and connections), 'gc' (collect stale memories; dry_run=true by default), 'importance_score' (score 'content'), 'backup', 'export' (JSON or JSONL with filters), 'restore' (from 'path').".to_string()),
                 input_schema: tools::maintain::schema(),
                 ..Default::default()
             },
@@ -459,7 +522,14 @@ impl McpServer {
             // ================================================================
             ToolDescription {
                 name: "dedup".to_string(),
-                description: Some("Deduplication, merge/supersede, and exact tag maintenance. Actions: 'scan' (default — surface duplicate clusters via cosine + merge candidates via Fellegi-Sunter, read-only), 'plan_merge' (preview a reversible merge plan for 2+ member_ids → plan_id), 'plan_supersede' (preview superseding old_id with new_id → plan_id), 'apply' (execute a plan_id; 'possible'/'non_match' need confirm=true), 'undo' (reverse an operation_id, or omit to list the mixed reflog plus a dedicated tagOperations list that cannot be buried by merge activity), 'tag_rename'/'tag_merge' (exact, scoped, preview-token-gated tag maintenance), 'protect' (pin a memory against auto-merge/supersede/forget), 'policy' (get/set Fellegi-Sunter thresholds). Old memories are invalidated, never deleted.".to_string()),
+                title: Some("Dedup".to_string()),
+                annotations: Some(ToolAnnotations {
+                    read_only_hint: false,
+                    destructive_hint: true,
+                    idempotent_hint: false,
+                    open_world_hint: false,
+                }),
+description: Some("Duplicates, merges, supersession, and exact tag maintenance. Actions: 'scan' (default, read-only: duplicate clusters and merge candidates), 'plan_merge' (member_ids to plan_id), 'plan_supersede' (old_id, new_id to plan_id), 'apply' (run a plan_id; weak matches need confirm=true), 'undo' (reverse an operation_id, or omit to list the reflog), 'tag_rename' and 'tag_merge' (preview-token gated), 'protect' (pin against auto-merge), 'policy' (get or set match thresholds). Merged memories are invalidated, never deleted.".to_string()),
                 input_schema: tools::dedup::unified_schema(),
                 ..Default::default()
             },
@@ -473,7 +543,16 @@ impl McpServer {
             // ================================================================
             ToolDescription {
                 name: "graph".to_string(),
-                description: Some("Memory graph & associations. Actions: 'chain' (reasoning path from→to), 'associations' (related memories via spreading activation, needs 'from'), 'bridges' (connectors between from/to), 'predict' (what memories you'll need next, from 'context'), 'memory_graph' (force-directed subgraph for viz, from center_id or query), 'recent'/'get'/'memory'/'neighbors'/'never_composed'/'bounty_mode' (composition topology), 'label' (record a composition outcome — the only write).".to_string()),
+                title: Some("Graph".to_string()),
+                // Every graph action reads, except 'label', which records a
+                // composition outcome. One write makes the tool not read-only.
+                annotations: Some(ToolAnnotations {
+                    read_only_hint: false,
+                    destructive_hint: false,
+                    idempotent_hint: false,
+                    open_world_hint: false,
+                }),
+description: Some("Memory graph. Actions: 'chain' (path from, to), 'associations' (spreading activation from 'from'), 'bridges' (connectors between from and to), 'predict' (what you will need next, from 'context'), 'memory_graph' (subgraph around center_id or query), 'recent', 'get', 'memory', 'neighbors', 'never_composed', 'bounty_mode' (composition topology), 'label' (record an outcome; the only write).".to_string()),
                 input_schema: tools::graph_unified::schema(),
                 ..Default::default()
             },
@@ -486,7 +565,14 @@ impl McpServer {
             // ================================================================
             ToolDescription {
                 name: "session_start".to_string(),
-                description: Some("One-call session initialization. Combines search, intentions, status, predictions, and codebase context into a single token-budgeted response. Call this once at the start of a session instead of 5 separate calls. (Renamed from 'session_context' in v2.2.)".to_string()),
+                title: Some("Session Start".to_string()),
+                annotations: Some(ToolAnnotations {
+                    read_only_hint: true,
+                    destructive_hint: false,
+                    idempotent_hint: true,
+                    open_world_hint: false,
+                }),
+description: Some("Start-of-session context in one call: relevant memories, open intentions, store status, predictions, and codebase context under one token budget. Replaces separate recall, intention, memory_status, and codebase calls.".to_string()),
                 input_schema: tools::session_context::schema(),
                 ..Default::default()
             },
@@ -506,7 +592,14 @@ impl McpServer {
             // ================================================================
             ToolDescription {
                 name: "suppress".to_string(),
-                description: Some("Actively suppress a memory via top-down inhibitory control (Anderson 2025 SIF + Davis Rac1). Distinct from delete: the memory persists but is inhibited from retrieval and actively decays. Each call compounds. A background Rac1 worker cascades decay to co-activated neighbors. Reversible within 24 hours via reverse=true.".to_string()),
+                title: Some("Suppress".to_string()),
+                annotations: Some(ToolAnnotations {
+                    read_only_hint: false,
+                    destructive_hint: false,
+                    idempotent_hint: true,
+                    open_world_hint: false,
+                }),
+description: Some("Inhibit a memory without deleting it (top-down suppression, Anderson 2025 and Davis Rac1): it drops out of retrieval and decays faster, each call compounds, and a background worker spreads accelerated decay to co-activated neighbours. reverse=true undoes it within 24 hours.".to_string()),
                 input_schema: tools::suppress::schema(),
                 ..Default::default()
             },
@@ -519,7 +612,14 @@ impl McpServer {
             // ================================================================
             ToolDescription {
                 name: "backfill".to_string(),
-                description: Some("Memory with hindsight. When a FAILURE (bug/crash/regression) is recorded, reach BACKWARD in time and promote the quiet earlier memory that caused it — the root cause a vector search structurally cannot surface because it isn't similar to the failure, only causally upstream (shares an entity: same file/env-var/service). Faithful port of Cai 2024 Nature; backward-only by construction. Pass failure_id (or it auto-finds the latest failure), manual=true to force, promote=false for a dry run.".to_string()),
+                title: Some("Backfill".to_string()),
+                annotations: Some(ToolAnnotations {
+                    read_only_hint: false,
+                    destructive_hint: false,
+                    idempotent_hint: false,
+                    open_world_hint: false,
+                }),
+description: Some("Memory with hindsight. After a failure is recorded, reach backward in time and promote the quiet earlier memory that caused it (same file, env var, or service), which similarity search cannot surface because a root cause rarely resembles the bug. Backward-only by construction (Cai 2024). Pass failure_id (defaults to the latest failure), manual=true to force, promote=false for a dry run.".to_string()),
                 input_schema: tools::backfill::schema(),
                 ..Default::default()
             },
@@ -1417,7 +1517,13 @@ impl McpServer {
                     obj.entry("runId".to_string())
                         .or_insert_with(|| serde_json::json!(trace_run_id));
                     obj.insert("receiptId".to_string(), serde_json::json!(receipt_id));
-                    obj.insert("receipt".to_string(), receipt);
+                    // A caller that asked for `detail_level: "brief"` wants the
+                    // smallest useful answer. The full receipt is persisted and
+                    // one `receipt` call away by id, so only the id ships.
+                    let brief = obj.get("detailLevel").and_then(|v| v.as_str()) == Some("brief");
+                    if !brief {
+                        obj.insert("receipt".to_string(), receipt);
+                    }
                 }
 
                 // Memory PR gate: classify the writes this tool just made under
@@ -2617,7 +2723,10 @@ mod tests {
 
         assert_eq!(result["resultType"], "complete");
         assert_eq!(result["cacheScope"], "public");
-        assert!(result["ttlMs"].as_u64().is_some(), "ttlMs must be an integer");
+        assert!(
+            result["ttlMs"].as_u64().is_some(),
+            "ttlMs must be an integer"
+        );
         assert_eq!(
             result["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
             "vestige"
@@ -2885,6 +2994,54 @@ mod tests {
         );
 
         let tool_names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+
+        // Every advertised tool carries a display title and all four MCP
+        // behaviour hints, and the hints match what the tool actually does
+        // to the store. A missing hint reads as "assume the worst" to clients.
+        let mut read_only = Vec::new();
+        let mut destructive = Vec::new();
+        let mut open_world = Vec::new();
+        for tool in tools {
+            let name = tool["name"].as_str().unwrap();
+            assert!(
+                tool["title"].as_str().is_some_and(|t| !t.is_empty()),
+                "{name} has no title"
+            );
+            let ann = &tool["annotations"];
+            for hint in [
+                "readOnlyHint",
+                "destructiveHint",
+                "idempotentHint",
+                "openWorldHint",
+            ] {
+                assert!(ann[hint].is_boolean(), "{name} is missing {hint}: {ann}");
+            }
+            assert!(
+                !(ann["readOnlyHint"] == true && ann["destructiveHint"] == true),
+                "{name} cannot be both read-only and destructive"
+            );
+            if ann["readOnlyHint"] == true {
+                read_only.push(name);
+            }
+            if ann["destructiveHint"] == true {
+                destructive.push(name);
+            }
+            if ann["openWorldHint"] == true {
+                open_world.push(name);
+            }
+        }
+        read_only.sort();
+        destructive.sort();
+        assert_eq!(
+            read_only,
+            ["memory_status", "recall", "receipt", "session_start"]
+        );
+        assert_eq!(destructive, ["dedup", "intention", "maintain", "memory"]);
+        assert_eq!(
+            open_world,
+            ["source_sync"],
+            "only the connector sync leaves the local store"
+        );
 
         // Unified tools
         // (search folded into `recall` mode='lookup' in v2.2)

--- a/crates/vestige-mcp/src/tools/codebase_unified.rs
+++ b/crates/vestige-mcp/src/tools/codebase_unified.rs
@@ -25,7 +25,7 @@ pub fn schema() -> Value {
             "action": {
                 "type": "string",
                 "enum": ["remember_pattern", "remember_decision", "get_context", "verify"],
-                "description": "Action to perform: 'remember_pattern' stores a code pattern, 'remember_decision' stores an architectural decision, 'get_context' retrieves patterns and decisions (each annotated with whether the code it describes still matches), 'verify' re-checks every anchored code memory against the working tree and reports which ones have gone stale"
+                "description": "'remember_pattern' stores a code pattern, 'remember_decision' an architectural decision, 'get_context' returns both with a current-or-stale mark, 'verify' re-checks every anchored code memory against the working tree"
             },
             // remember_pattern fields
             "name": {
@@ -54,11 +54,11 @@ pub fn schema() -> Value {
             "files": {
                 "type": "array",
                 "items": { "type": "string" },
-                "description": "Files where this pattern is used or affected by this decision. Accepts a plain path ('src/state.py'), a path plus symbol ('src/state.py#load_config'), or a path plus line span ('src/state.py:552-580'). Anything more specific than a plain path is content-hashed at save time so the memory can later tell you itself whether the code it describes has changed."
+                "description": "Files this pattern or decision touches: a path ('src/state.py'), path plus symbol ('src/state.py#load_config'), or path plus lines ('src/state.py:552-580'). Anything beyond a plain path is content-hashed so the memory can report when the code changed."
             },
             "anchors": {
                 "type": "array",
-                "description": "Structured form of 'files', for callers that already know the symbol. Each anchor is content-hashed at save time so staleness becomes detectable instead of invisible.",
+                "description": "Structured form of 'files' for callers that know the symbol. Each anchor is content-hashed at save time so staleness is detectable.",
                 "items": {
                     "type": "object",
                     "properties": {
@@ -808,9 +808,8 @@ async fn execute_verify(storage: &Arc<Storage>, args: &CodebaseArgs) -> Result<V
     // Predict for the memories verification cannot reach. The predictor
     // refuses to fit without enough evidence, and a prediction is a
     // probability shown next to the memory, never an action taken on it.
-    let predictor = vestige_core::codebase::staleness::StalenessPredictor::fit(
-        &staleness_observations,
-    );
+    let predictor =
+        vestige_core::codebase::staleness::StalenessPredictor::fit(&staleness_observations);
     let unverifiable_memories: Vec<Value> = unanchored
         .iter()
         .map(|(id, age_days)| match &predictor {

--- a/crates/vestige-mcp/src/tools/graph_unified.rs
+++ b/crates/vestige-mcp/src/tools/graph_unified.rs
@@ -40,7 +40,7 @@ pub fn schema() -> Value {
                     "recent", "get", "memory", "neighbors",
                     "never_composed", "bounty_mode", "label"
                 ],
-                "description": "Graph operation. Reasoning paths: 'chain' (from→to), 'associations' (related via spreading activation, needs 'from'), 'bridges' (connectors between from/to). 'predict' (what memories you'll need next, from 'context'). 'memory_graph' (force-directed subgraph for viz, from 'center_id' or 'query'). Composition topology: 'recent', 'get' (event_id), 'memory' (memory_id), 'neighbors' (memory_id), 'never_composed', 'bounty_mode', 'label' (record an outcome — the only write)."
+                "description": "Reasoning: 'chain' (from, to), 'associations' (spreading activation from 'from'), 'bridges' (connectors between from and to), 'predict' (next needs, from 'context'), 'memory_graph' (subgraph around 'center_id' or 'query'). Composition topology: 'recent', 'get' (event_id), 'memory' and 'neighbors' (memory_id), 'never_composed', 'bounty_mode', 'label' (record an outcome; the only write)."
             },
             // --- explore (chain/associations/bridges) ---
             "from": { "type": "string", "description": "[chain/associations/bridges] Source memory ID." },

--- a/crates/vestige-mcp/src/tools/intention_unified.rs
+++ b/crates/vestige-mcp/src/tools/intention_unified.rs
@@ -29,7 +29,7 @@ pub fn schema() -> Value {
             "action": {
                 "type": "string",
                 "enum": ["set", "check", "update", "list"],
-                "description": "The action to perform: 'set' creates a new intention, 'check' finds triggered intentions, 'update' modifies status (complete/snooze/cancel), 'list' shows intentions"
+                "description": "'set' creates, 'check' finds triggered intentions, 'update' changes status (complete, snooze, cancel), 'list' shows them"
             },
             // SET action parameters
             "description": {

--- a/crates/vestige-mcp/src/tools/maintain.rs
+++ b/crates/vestige-mcp/src/tools/maintain.rs
@@ -35,7 +35,7 @@ pub fn schema() -> Value {
             "action": {
                 "type": "string",
                 "enum": ["consolidate", "dream", "gc", "importance_score", "backup", "export", "restore"],
-                "description": "Maintenance op. 'consolidate' (run FSRS-6 decay/embedding cycle), 'dream' (replay memories → insights/connections), 'gc' (garbage-collect stale memories; dry_run=true by default), 'importance_score' (4-channel neuroscience score for 'content'), 'backup' (SQLite DB backup), 'export' (memories as JSON/JSONL with filters), 'restore' (restore from a JSON backup at 'path')."
+                "description": "'consolidate' (decay and embedding cycle), 'dream' (replay into insights and connections), 'gc' (stale memories; dry_run=true by default), 'importance_score' (score 'content'), 'backup', 'export' (JSON or JSONL with filters), 'restore' (JSON backup at 'path')."
             },
             // --- gc ---
             "min_retention": { "type": "number", "minimum": 0.0, "maximum": 1.0, "description": "[gc] Collect memories below this retention (default 0.1)." },

--- a/crates/vestige-mcp/src/tools/memory_status.rs
+++ b/crates/vestige-mcp/src/tools/memory_status.rs
@@ -36,7 +36,7 @@ pub fn schema() -> Value {
                 "type": "string",
                 "enum": ["health", "retention", "timeline", "changelog", "stats"],
                 "default": "health",
-                "description": "Which status view. 'health' (default): full system health + stats + FSRS preview + warnings + recommendations. 'retention': lightweight retention dashboard (avg/distribution/trend). 'timeline': browse memories chronologically. 'changelog': audit trail of memory state changes. 'stats': complete hygiene counts by type/tag/age/retention/lifecycle plus bounded never-accessed and largest-node lists and recent tag-operation audit."
+                "description": "'health' (default): system health, stats, decay preview, warnings, recommendations. 'retention': average, distribution, trend. 'timeline': memories by date. 'changelog': state-change audit trail. 'stats': hygiene counts by type, tag, age, retention, and lifecycle, with bounded detail lists and recent tag operations."
             },
             // --- [health view] ---
             "schema_introspection": {
@@ -68,7 +68,7 @@ pub fn schema() -> Value {
             // --- shared: limit (per-view ranges differ; clamped internally) ---
             "limit": {
                 "type": "integer",
-                "description": "Max results. [timeline] default 50, max 200. [changelog] default 20, clamped to 100. [stats] detail lists default 50, clamped to 200; aggregate counts always cover the full selected store. Ignored by health/retention.",
+                "description": "Max results. timeline: default 50, max 200. changelog: default 20, max 100. stats detail lists: default 50, max 200 (aggregate counts always cover the whole store). Ignored by health and retention.",
                 "minimum": 1, "maximum": 200
             }
         }

--- a/crates/vestige-mcp/src/tools/memory_unified.rs
+++ b/crates/vestige-mcp/src/tools/memory_unified.rs
@@ -44,7 +44,7 @@ pub fn schema() -> Value {
             "action": {
                 "type": "string",
                 "enum": ["get", "get_batch", "delete", "purge", "state", "promote", "demote", "edit"],
-                "description": "Action to perform: 'get' retrieves full memory node, 'get_batch' retrieves multiple memories by IDs (use 'ids' array), 'purge' permanently removes memory content and embeddings after confirm=true, 'delete' is a backwards-compatible alias for purge and also requires confirm=true, 'state' returns accessibility state, 'promote' increases retrieval strength (thumbs up), 'demote' decreases retrieval strength (thumbs down), 'edit' updates content in-place (preserves FSRS state)"
+                "description": "'get' (one node), 'get_batch' (by 'ids'), 'state' (accessibility), 'promote' and 'demote' (adjust retrieval strength; demote never deletes), 'edit' (replace content, keep FSRS state), 'purge' (remove content and embeddings for good; confirm=true). 'delete' is an alias for purge"
             },
             "id": {
                 "type": "string",
@@ -61,7 +61,7 @@ pub fn schema() -> Value {
             },
             "confirm": {
                 "type": "boolean",
-                "description": "Required for action='purge' and action='delete'. Purge/delete removes canonical content and embeddings. Legacy audit/sync records retain only opaque markers and limited metadata, so this action is not verified-local machine unlearning.",
+                "description": "Required for 'purge' and 'delete'. Purge removes canonical content and embeddings; legacy audit and sync records keep only opaque markers and limited metadata, so this is not verified machine unlearning.",
                 "default": false
             },
             "content": {

--- a/crates/vestige-mcp/src/tools/recall.rs
+++ b/crates/vestige-mcp/src/tools/recall.rs
@@ -47,7 +47,7 @@ pub fn schema() -> Value {
                     "type": "string",
                     "enum": ["lookup", "reason", "contradictions"],
                     "default": "lookup",
-                    "description": "Retrieval mode. 'lookup' (default): fast hybrid search — use for plain recall. 'reason': deep cognitive reasoning across memories (FSRS-6 trust scoring, spreading activation, supersession, contradiction analysis) — use when accuracy matters; needs 'query'. 'contradictions': surface trust-weighted disagreement pairs for a 'topic' (or recent memories)."
+                    "description": "'lookup' (default): fast hybrid search. 'reason': deep pass with trust scoring, spreading activation, supersession, and contradiction analysis; needs 'query'. 'contradictions': trust-weighted disagreement pairs for a 'topic', or recent memories."
                 }),
             );
             // reason (deep_reference) extra field.

--- a/crates/vestige-mcp/src/tools/receipt.rs
+++ b/crates/vestige-mcp/src/tools/receipt.rs
@@ -26,7 +26,7 @@ pub fn schema() -> Value {
             "action": {
                 "type": "string",
                 "enum": ["get", "replay"],
-                "description": "get: inspect one persisted receipt and its safe replay-capsule summary. replay: withhold named receipt-local evidence slots from the exact frozen final context without rerunning retrieval."
+                "description": "'get': one persisted receipt with its safe replay-capsule summary. 'replay': withhold named evidence slots from the frozen final context without rerunning retrieval."
             },
             "receipt_id": {
                 "type": "string",

--- a/crates/vestige-mcp/src/tools/search_unified.rs
+++ b/crates/vestige-mcp/src/tools/search_unified.rs
@@ -58,7 +58,7 @@ pub fn schema() -> Value {
             },
             "detail_level": {
                 "type": "string",
-                "description": "Level of detail in results. 'brief' = id/type/tags/score only (saves tokens). 'summary' = default 8-field response. 'full' = all fields including FSRS state and timestamps.",
+                "description": "'brief': id, type, tags, score. 'summary' (default): the 8-field response. 'full': every field, including FSRS state and timestamps.",
                 "enum": ["brief", "summary", "full"],
                 "default": "summary"
             },
@@ -70,7 +70,7 @@ pub fn schema() -> Value {
             "exclude_types": {
                 "type": "array",
                 "items": { "type": "string" },
-                "description": "Node types to exclude from results (e.g., ['reflection']). Reflections are excluded by default to prevent polluting factual queries."
+                "description": "Node types to exclude. Reflections are excluded by default so they do not pollute factual queries."
             },
             "include_types": {
                 "type": "array",
@@ -79,33 +79,33 @@ pub fn schema() -> Value {
             },
             "token_budget": {
                 "type": "integer",
-                "description": "Max tokens for response. Server truncates content to fit budget. Use memory(action='get') for full content of specific IDs. With 1M context models, budgets up to 100K are practical.",
+                "description": "Max tokens for the response; content is truncated to fit. Fetch full content by id with memory(action='get').",
                 "minimum": 100,
                 "maximum": 100000
             },
             "retrieval_mode": {
                 "type": "string",
-                "description": "precise: top results only (fast, token-efficient, skips activation/competition). balanced: full 7-stage cognitive pipeline (default). exhaustive: maximum recall with 5x overfetch, deep graph traversal, no competition suppression.",
+                "description": "'precise': top results only, skips activation and competition. 'balanced' (default): the full cognitive pipeline. 'exhaustive': 5x overfetch, deep graph traversal, no competition.",
                 "enum": ["precise", "balanced", "exhaustive"],
                 "default": "balanced"
             },
             "concrete": {
                 "type": "boolean",
-                "description": "Force literal/concrete search. Skips semantic expansion, FSRS reweighting, spreading activation, and cognitive side effects. Auto-enabled for quoted strings, env vars, UUIDs, paths, and code identifiers.",
+                "description": "Literal search: no semantic expansion, reweighting, activation, or side effects. Auto-enabled for quoted strings, env vars, UUIDs, paths, and code identifiers.",
                 "default": false
             },
             "rank_native_fusion": {
                 "type": "boolean",
-                "description": "Join the post-retrieval stages (temporal, accessibility, context, utility) as ranked lists via weighted RRF instead of score multipliers. Experimental; default off pending benchmark validation.",
+                "description": "Experimental: fuse the post-retrieval stages as ranked lists (weighted RRF) instead of score multipliers. Default off.",
                 "default": false
             },
             "tag_prefix": {
                 "type": "string",
-                "description": "Optional tag-prefix filter. When set, only results carrying at least one tag whose value starts with this prefix are returned (case-insensitive). Example: tag_prefix=\"meeting:\" matches memories tagged 'meeting:standup', 'meeting:1-on-1', etc. Applied as a post-filter; combine with a larger 'limit' if you expect heavy thinning."
+                "description": "Keep only results with a tag starting with this prefix (case-insensitive), e.g. 'meeting:' matches 'meeting:standup'. Post-filter; raise 'limit' if it thins results heavily."
             },
             "scope": {
                 "type": "string",
-                "description": "Project namespace to search. Defaults to the legacy 'user' namespace, so project memories never bleed into an unscoped recall."
+                "description": "Project namespace. Defaults to 'user', so project memories never bleed into an unscoped recall."
             },
             "includeCrossScope": {
                 "type": "boolean",
@@ -114,19 +114,19 @@ pub fn schema() -> Value {
             },
             "validAt": {
                 "type": "string",
-                "description": "Return only facts valid at this time. Accepts 'now', RFC3339, or YYYY-MM-DD. When omitted, expired/future facts remain auditable but are conservatively downranked."
+                "description": "Only facts valid at this time: 'now', RFC3339, or YYYY-MM-DD. When omitted, expired and future facts stay auditable but are downranked."
             },
             "source_system": {
                 "type": "string",
-                "description": "Investigation filter (#57): only memories ingested from this external system, e.g. 'github' or 'redmine'. Post-filter — non-connector memories are excluded. Combine with a larger 'limit' if thinning is heavy."
+                "description": "Only memories ingested from this external system, e.g. 'github' or 'redmine'. Post-filter; raise 'limit' if it thins results heavily."
             },
             "source_project": {
                 "type": "string",
-                "description": "Investigation filter: only memories from this source project/repo, exact match (GitHub 'owner/repo', Redmine project id)."
+                "description": "Only memories from this source project or repo, exact match (GitHub 'owner/repo', Redmine project id)."
             },
             "source_id": {
                 "type": "string",
-                "description": "Investigation filter: a specific source record id (issue number / ticket id). Pair with source_system to disambiguate across systems."
+                "description": "Only this source record id (issue number or ticket id). Pair with source_system."
             },
             "source_type": {
                 "type": "string",
@@ -147,7 +147,7 @@ pub fn schema() -> Value {
             "source_status": {
                 "type": "string",
                 "enum": ["any", "valid", "tombstoned"],
-                "description": "Investigation filter: 'any' (default), 'valid' (currently-valid records only), or 'tombstoned' (records no longer visible upstream, kept for audit).",
+                "description": "'any' (default), 'valid' (currently visible upstream), or 'tombstoned' (removed upstream, kept for audit).",
                 "default": "any"
             }
         },
@@ -944,10 +944,7 @@ pub async fn execute(
         let fused = fuse_rank_native(
             &base,
             &[
-                (
-                    fusion_signals.iter().map(|s| s.temporal).collect(),
-                    0.15,
-                ),
+                (fusion_signals.iter().map(|s| s.temporal).collect(), 0.15),
                 (
                     fusion_signals.iter().map(|s| s.accessibility).collect(),
                     0.30,
@@ -1125,8 +1122,11 @@ pub async fn execute(
     if !associations.is_empty() {
         response["associations"] = serde_json::json!(associations);
     }
-    // Include context reinstatement if computed
-    if let Some(ri) = reinstatement_info {
+    // Include context reinstatement if computed. Brief callers asked for the
+    // smallest useful answer, so the diagnostic block stays out of theirs.
+    if let Some(ri) = reinstatement_info
+        && detail_level != "brief"
+    {
         response["contextReinstatement"] = ri;
     }
     // Include competition stats
@@ -2676,7 +2676,10 @@ mod tests {
             fused[5] > fused[1],
             "agreeing signals across a wide gap must be able to reorder"
         );
-        assert!(fused[0] > fused[5] || fused[0] > fused[1], "base still anchors the head");
+        assert!(
+            fused[0] > fused[5] || fused[0] > fused[1],
+            "base still anchors the head"
+        );
     }
 
     #[test]

--- a/crates/vestige-mcp/src/tools/smart_ingest.rs
+++ b/crates/vestige-mcp/src/tools/smart_ingest.rs
@@ -43,7 +43,7 @@ pub fn schema() -> Value {
             },
             "node_type": {
                 "type": "string",
-                "description": "Type of knowledge: fact, concept, event, person, place, note, pattern, decision, state. 'state' is for current-state snapshots (version numbers, progress, inventories) that rot: unless validUntil is given, it expires VESTIGE_STATE_TTL_DAYS (default 30) after ingest; expired memories are down-ranked to the bottom of recall and marked currentlyValid=false (still retrievable for audit via validAt).",
+                "description": "fact, concept, event, person, place, note, pattern, decision, or state. 'state' is a snapshot that rots (versions, progress, inventories): without validUntil it expires after VESTIGE_STATE_TTL_DAYS (default 30), then is downranked and marked currentlyValid=false, still auditable via validAt.",
                 "default": "fact"
             },
             "tags": {
@@ -61,7 +61,7 @@ pub fn schema() -> Value {
             },
             "validFrom": {
                 "type": "string",
-                "description": "When this fact becomes true. Use RFC3339 or an exact YYYY-MM-DD date. When omitted, one unambiguous 'as of YYYY-MM-DD' phrase in content is inferred as validFrom and reported in the response."
+                "description": "When the fact becomes true (RFC3339 or YYYY-MM-DD). If omitted, one unambiguous 'as of YYYY-MM-DD' phrase in content is inferred and reported."
             },
             "validUntil": {
                 "type": "string",
@@ -85,17 +85,17 @@ pub fn schema() -> Value {
             "acceptedTagSuggestions": {
                 "type": "object",
                 "additionalProperties": { "type": "string" },
-                "description": "Explicitly accepted input-tag to existing-tag mappings from a preflight response. Each mapping is revalidated against current same-scope suggestions before ingest."
+                "description": "Accepted input-tag to existing-tag mappings from a preflight response, revalidated against current same-scope suggestions before ingest."
             },
             "batchMergePolicy": {
                 "type": "string",
                 "enum": ["force_create", "smart"],
-                "description": "Batch mode only. Defaults to 'force_create' so caller-separated items stay separate. Use 'smart' to allow Prediction Error Gating against existing memories.",
+                "description": "Batch only. 'force_create' (default) keeps caller-separated items separate; 'smart' allows Prediction Error Gating against existing memories.",
                 "default": "force_create"
             },
             "items": {
                 "type": "array",
-                "description": "Batch mode: array of items to save (max 20). Defaults to force-creating each caller-separated item; set batchMergePolicy='smart' to allow Prediction Error Gating against existing memories. Use at session end or before context compaction.",
+                "description": "Batch mode: up to 20 items to save, each force-created unless batchMergePolicy='smart'. Use at session end or before context compaction.",
                 "maxItems": 20,
                 "items": {
                     "type": "object",

--- a/crates/vestige-mcp/src/tools/suppress.rs
+++ b/crates/vestige-mcp/src/tools/suppress.rs
@@ -25,7 +25,7 @@ use vestige_core::neuroscience::active_forgetting::{ActiveForgettingSystem, DEFA
 pub fn schema() -> Value {
     json!({
         "type": "object",
-        "description": "Actively suppress a memory via top-down inhibitory control (Anderson 2025 SIF + Davis Rac1). Distinct from delete: the memory persists but is inhibited from retrieval and actively decays. Each call compounds suppression strength. A background Rac1 worker cascades accelerated decay to co-activated neighbors over the next 72 hours. Reversible within 24 hours via reverse=true.",
+        "description": "Top-down suppression (Anderson 2025 SIF, Davis Rac1): the memory persists but is inhibited from retrieval and decays faster. Each call compounds. A background worker spreads accelerated decay to co-activated neighbours over 72 hours. Reversible within 24 hours via reverse=true.",
         "properties": {
             "id": {
                 "type": "string",

--- a/crates/vestige-mcp/tests/e2e_real_binary.rs
+++ b/crates/vestige-mcp/tests/e2e_real_binary.rs
@@ -668,12 +668,16 @@ fn list_methods_reject_unknown_cursors_and_templates_list_is_empty() {
             "{method} with an unknown cursor must be invalid params: {error}"
         );
         // Absent-equivalent cursors are not an error.
-        assert!(server
-            .result(method, Some(json!({ "cursor": null })))
-            .is_object());
-        assert!(server
-            .result(method, Some(json!({ "cursor": "" })))
-            .is_object());
+        assert!(
+            server
+                .result(method, Some(json!({ "cursor": null })))
+                .is_object()
+        );
+        assert!(
+            server
+                .result(method, Some(json!({ "cursor": "" })))
+                .is_object()
+        );
     }
 
     server.shutdown();
@@ -757,6 +761,26 @@ fn tools_list_is_deterministic_across_restarts_and_carries_cache_hints() {
         json!(300_000),
         "recall lost its result-size annotation: {recall}"
     );
+
+    // Behaviour hints reach the client in MCP's camelCase shape, and the two
+    // hints a client acts on (read-only, destructive) are set for every tool.
+    for tool in a["tools"].as_array().unwrap() {
+        let name = tool["name"].as_str().unwrap();
+        assert!(tool["title"].is_string(), "{name} has no title on the wire");
+        let ann = &tool["annotations"];
+        assert!(ann["readOnlyHint"].is_boolean(), "{name}: {ann}");
+        assert!(ann["destructiveHint"].is_boolean(), "{name}: {ann}");
+        assert!(ann["idempotentHint"].is_boolean(), "{name}: {ann}");
+        assert!(ann["openWorldHint"].is_boolean(), "{name}: {ann}");
+    }
+    assert_eq!(recall["annotations"]["readOnlyHint"], json!(true));
+    let memory = a["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t["name"] == json!("memory"))
+        .expect("memory tool");
+    assert_eq!(memory["annotations"]["destructiveHint"], json!(true));
 }
 
 /// Malformed, unknown, oversized and structurally wrong input must all produce

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -82,7 +82,7 @@ opens a **Memory PR** you decide in the dashboard (Memory PRs tab) or via
 | Mode | Behavior |
 |------|----------|
 | `fast` | Never gate. Every write auto-commits. |
-| `risk_gated` | **Default.** Ordinary writes auto-commit; risky ones (contradicting high-trust memories, destructive ops, sensitive topics) open a Memory PR. |
+| `risk_gated` | **Default.** Ordinary writes auto-commit; risky ones (contradicting high-trust memories, destructive ops, sensitive topics) open a Memory PR. A write counts as touching a sensitive topic when a tag names it, a credential-shaped value sits next to it, the write is short, the topic leads the text, or two distinct topics appear. One sensitive word buried in a long note is a mention, not a subject, and does not gate. |
 | `paranoid` | Gate every write. Nothing enters the brain without approval. |
 
 The mode is stored in `<data_dir>/review_mode.json` and set from the dashboard


### PR DESCRIPTION
## Summary

Three user-facing changes to the MCP surface and one fix to the Memory PR gate.

**Tool hints and titles.** Every advertised tool now carries a `title` and all four MCP behaviour hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`), serialised explicitly so a client never falls back on the spec defaults that assume the worst. The sets are pinned by a unit test:

| Hint | Tools |
|---|---|
| read-only | `recall`, `receipt`, `memory_status`, `session_start` (they record receipts and access statistics, never memory content) |
| destructive | `memory`, `intention`, `maintain`, `dedup` |
| open-world | `source_sync` only |

`graph` is not read-only because `label` writes a composition outcome. `suppress` and `backfill` write but never destroy.

**Leaner descriptions.** 45 tool and property descriptions were rewritten to say the same thing in fewer words (3,710 bytes removed), and `codebase` now advertises its `verify` action, which the old description left out. Measured on the built binary with a real `tools/list` call:

| | bytes |
|---|---|
| before | 38,474 |
| after, hints included | 35,019 |

The remaining weight is schema structure (recall alone has 29 properties). That is filed as its own issue rather than squeezed here.

**Brief recall is brief.** `recall` with `detail_level: "brief"` now returns `receiptId` without the full receipt and without `contextReinstatement`. The receipt is persisted and one `receipt` call away. Default and full responses are unchanged.

**Quarantine decides by subject, not by word.** The `sensitive_topic` signal used to fire on any whole-word match. On the real store that held ordinary engineering notes for review because they mentioned "token" or "identity" once, deep in a long paragraph. Today, while writing this PR, the running server quarantined two of four session notes for exactly that reason. The signal now fires when a tag names the topic, a credential-shaped value sits in the content, the write is short (60 words or fewer), the topic leads the text (first 12 words), or two distinct topics appear. One incidental word in a long note no longer holds the write. `docs/CONFIGURATION.md` states the rule.

## Gates

| Gate | Result |
|---|---|
| `cargo check -p vestige-mcp -p vestige-core --all-targets` | clean |
| `cargo test -p vestige-core --lib trace::review` | 23 passed (5 new) |
| `cargo test -p vestige-mcp --lib tools_list` | passed, pins the hint sets |
| `cargo test -p vestige-mcp --test e2e_real_binary tools_list` | passed, checks the wire shape |
| `git diff --check` | clean |

New tests: `incidental_mention_deep_in_long_note_does_not_gate`, `long_note_that_leads_with_a_sensitive_topic_gates`, `long_note_with_two_sensitive_topics_gates`, `sensitive_tag_gates_a_long_note`, `credential_shaped_value_in_a_long_note_gates` (the fixture is asserted against `scan_secrets` so a scanner change fails loudly).

## Notes for review

- `rustfmt` was run on the touched files only. The tree has pre-existing formatting drift in `contradiction.rs` and `retroactive_backfill.rs` that this PR leaves alone.
- No behaviour change for `risk_gated` mode beyond the incidental-mention case. `paranoid` still reviews everything and `fast` still reviews nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
