### PR TITLE
deps: usearch 2.26, and compile Windows MSVC on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,39 @@ jobs:
           name: vestige-mcp-${{ matrix.target }}
           path: vestige-mcp-${{ matrix.target }}.tar.gz
 
+  # Windows is otherwise compiled only by release.yml when a tag is cut, so an
+  # MSVC-only break (usearch 2.24.0 referencing POSIX MAP_FAILED, #93 before it)
+  # surfaces after the release exists. This compiles the default feature set on
+  # MSVC on every pull request, so a dependency bump proves itself first.
+  windows-msvc-build:
+    name: Windows MSVC build (x86_64-pc-windows-msvc)
+    runs-on: windows-latest
+    needs: [test]
+    if: |
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-x86_64-pc-windows-msvc-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build release
+        run: cargo build --release -p vestige-mcp
+
+      - name: Smoke the binary
+        run: ./target/release/vestige-mcp.exe --version
+
   # Linux-gnu is built in Ubuntu 22.04 (glibc 2.35), not ubuntu-latest.
   # ubuntu-latest is 24.04+/glibc 2.39, which is why the published 2.3.0
   # asset dies on 22.04 and Debian 12 with GLIBC_2.38 not found (#174, #175).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ starvation findings did not reproduce (every migration already runs inside one
 IMMEDIATE transaction with its own version bump, and `wal_autocheckpoint` is
 on), so those got regression tests and a checkpoint hook rather than rewrites.
 
+### Changed — Dependencies
+
+- usearch `=2.23.0` is unpinned to `2.26`. The MSVC compile break that forced
+  the pin (2.24.0 referenced the POSIX `MAP_FAILED` macro, unum-cloud/usearch#746)
+  was fixed upstream in April 2026, and the `fp16lib` feature that 2.23.0 needed
+  no longer exists: 2.26 carries its own scalar fp16 conversion and its headers
+  have no `#warning` directive, so the MSVC fatal-error path that made `fp16lib`
+  load-bearing is gone. Default features stay off so release binaries do not
+  ship NumKong's AVX2/FMA dispatch kernels (#71). No re-embedding is needed.
+- CI now compiles the default feature set on Windows MSVC (`windows-msvc-build`)
+  on every pull request and on `main`. Until now Windows was compiled only when a
+  release tag was cut, which is how an MSVC-only break could ship (#93).
+
 ### Fixed — Vector index
 
 - A long-lived MCP server process now sees exactly the vectors its sibling

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5011,9 +5011,9 @@ dependencies = [
 
 [[package]]
 name = "usearch"
-version = "2.23.0"
+version = "2.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a03c05af8d678ec19f014c734ab667c20ea54128b4f9a1472cb470246a9b341"
+checksum = "b43f3a7c8d3b100d53c1a34e9ce4cd76cc83627bdb4fcd035d4e82102778aeee"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/crates/vestige-core/Cargo.toml
+++ b/crates/vestige-core/Cargo.toml
@@ -148,26 +148,18 @@ tokenizers = { version = "0.22.2", default-features = false, features = ["onig"]
 # ============================================================================
 # OPTIONAL: Vector Search (USearch - HNSW, 20x faster than FAISS)
 # ============================================================================
-# Pinned to 2.23.0 — 2.24.0 introduced a Windows MSVC compile break because
-# its memory_mapping_allocator_gt template references the POSIX MAP_FAILED
-# macro from <sys/mman.h>, which doesn't exist on MSVC. Tracked upstream in
-# unum-cloud/usearch#746. Unpin when the upstream fix lands.
+# usearch 2.26. The MSVC compile break that forced the 2.23.0 pin (2.24.0
+# referenced the POSIX MAP_FAILED macro, unum-cloud/usearch#746) was fixed
+# upstream in April 2026. The `fp16lib` feature that 2.23.0 needed no longer
+# exists: 2.26 carries its own scalar fp16 conversion and its headers have no
+# `#warning` directive, so the MSVC fatal-error C1021 path that made fp16lib
+# load-bearing is gone. The Windows MSVC job in ci.yml compiles this crate on
+# every pull request so that claim stays proven rather than remembered.
 #
-# Disable default features so release binaries do not include SimSIMD's
-# Haswell+/AVX2/FMA dispatch targets. Those kernels can trigger illegal
-# instructions on older x86_64 CPUs that Vestige otherwise supports (#71).
-#
-# But re-enable `fp16lib` explicitly. usearch's defaults are
-# ["simsimd", "fp16lib"]; with BOTH off, build.rs sets USEARCH_USE_FP16LIB=0
-# and USEARCH_USE_SIMSIMD=0, which selects the bare half-precision `#else`
-# branch in include/usearch/index_plugins.hpp. That branch carries a
-# `#warning` directive, which MSVC's cl.exe treats as fatal error C1021,
-# breaking the Windows build (GCC/Clang only warn). `fp16lib` is a scalar,
-# self-contained fp16<->fp32 conversion library with NO SIMD intrinsics, so
-# re-enabling it sets USEARCH_USE_FP16LIB=1 (taking the non-warning branch)
-# WITHOUT reintroducing the SimSIMD illegal-instruction risk from #71. Do not
-# drop this feature.
-usearch = { version = "=2.23.0", default-features = false, features = ["fp16lib"], optional = true }
+# Default features stay OFF so release binaries do not include NumKong (the
+# SimSIMD successor) and its Haswell+/AVX2/FMA dispatch kernels, which can
+# raise illegal instructions on older x86_64 CPUs that Vestige supports (#71).
+usearch = { version = "2.26", default-features = false, optional = true }
 
 # LRU cache for query embeddings
 lru = "0.16"


### PR DESCRIPTION
## Summary

Lifts the `usearch = "=2.23.0"` pin to `2.26` and adds the CI job that proves it on Windows.

**Why the pin can go.** The pin existed because 2.24.0 referenced the POSIX `MAP_FAILED` macro and broke MSVC (unum-cloud/usearch#746). That issue was closed upstream on April 18, 2026. The second reason the old line was load-bearing, `features = ["fp16lib"]`, is gone too: the 2.26 crate exposes only `numkong`, `openmp`, and `simsimd` (an alias for `numkong`), it carries its own scalar fp16 conversion, and none of `index.hpp`, `index_dense.hpp`, or `index_plugins.hpp` at v2.26.2 contains a `#warning` directive. That `#warning` was what MSVC turned into fatal error C1021 when fp16lib was off (#93). Default features stay off so NumKong's AVX2/FMA dispatch kernels stay out of release binaries (#71).

**Why the job exists.** Windows was compiled only by release.yml when a tag was cut, which is exactly how an MSVC-only break reaches users. `windows-msvc-build` compiles the default feature set on `windows-latest` for every pull request and on `main`, then runs the binary with `--version`. This PR is its first run.

## Gates

| Gate | Result |
|---|---|
| `cargo check -p vestige-core -p vestige-mcp --all-targets` against 2.26.2 | clean, no API changes needed |
| `cargo test -p vestige-core --lib peer_` (cross-process index refresh) | 4 passed |
| `cargo test -p vestige-mcp --lib search` | 61 passed |
| `windows-msvc-build` | this PR's CI run |

## A pre-existing test race, found on the way

`cargo test -p vestige-core --lib vector` fails three `peer_*` tests deterministically on this branch **and on `main` with 2.23.0** (two of two runs each), while `--lib peer_` alone passes. The cause is `with_vector_search_disabled`, which sets `VESTIGE_DISABLE_VECTOR_SEARCH=1` process-wide under `ENV_LOCK` while the `peer_*` tests, which never take that lock, build storage and get no vector index. The full suite passes by scheduling luck. It is not a usearch behaviour change; #229 fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
