### PR TITLE
test(core): env-gated test helpers pin a thread-local, not the process environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ starvation findings did not reproduce (every migration already runs inside one
 IMMEDIATE transaction with its own version bump, and `wal_autocheckpoint` is
 on), so those got regression tests and a checkpoint hook rather than rewrites.
 
+### Fixed — Test isolation
+
+- `cargo test -p vestige-core --lib vector` no longer fails three `peer_*`
+  tests on every run. `with_vector_search_disabled` set
+  `VESTIGE_DISABLE_VECTOR_SEARCH` in the process environment, so every other
+  test thread building a `Storage` in that window silently got no vector index;
+  the full suite passed only by scheduling luck. Both env-gated test helpers
+  (vector search and `VESTIGE_AUTO_CONSOLIDATE_MERGE`) now pin a thread-local
+  override that the gates read in test builds, `ENV_LOCK` is gone, and two
+  tests assert that a sibling thread never sees the override.
+- The vector-search gate and its "why is it off" report now parse the
+  variable the same way. `VESTIGE_DISABLE_VECTOR_SEARCH=0` leaves the index on
+  and is reported as on; before, any value made the report say disabled while
+  the index stayed on.
+
 ### Fixed — Vector index
 
 - A long-lived MCP server process now sees exactly the vectors its sibling

--- a/crates/vestige-core/src/storage/sqlite.rs
+++ b/crates/vestige-core/src/storage/sqlite.rs
@@ -647,6 +647,40 @@ pub(crate) struct PurgeCleanup {
 const DATA_DIR_ENV: &str = "VESTIGE_DATA_DIR";
 const DATABASE_FILE: &str = "vestige.db";
 const VESTIGE_DISABLE_VECTOR_SEARCH: &str = "VESTIGE_DISABLE_VECTOR_SEARCH";
+
+// Test-only override for the runtime vector-search gate, scoped to the
+// current thread. Tests run in parallel inside one process, so a test that
+// wants the index disabled must not touch the process environment: every
+// other test thread building a `Storage` at that moment would silently get
+// no index. This cell is what `with_vector_search_disabled` flips instead.
+#[cfg(all(test, feature = "vector-search"))]
+thread_local! {
+    static VECTOR_SEARCH_DISABLED_FOR_TEST: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
+}
+
+// Test-only override for `VESTIGE_AUTO_CONSOLIDATE_MERGE`, scoped to the
+// current thread for the same reason as the vector-search override: this
+// gate decides whether consolidation hard-deletes near-duplicates, so a
+// process-wide flag would reach every consolidation test running at once.
+// `Some(None)` pins the variable unset; `Some(Some(v))` pins a value.
+#[cfg(all(test, feature = "embeddings", feature = "vector-search"))]
+thread_local! {
+    static AUTO_CONSOLIDATE_MERGE_FOR_TEST: std::cell::RefCell<Option<Option<String>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Whether an environment value asks for vector search to be turned off.
+/// Only affirmative values count, so `VESTIGE_DISABLE_VECTOR_SEARCH=0` leaves
+/// the index on and reports it as on.
+#[cfg(feature = "vector-search")]
+fn env_value_disables_vector_search(value: &std::ffi::OsStr) -> bool {
+    let value = value.to_ascii_lowercase();
+    matches!(
+        value.to_str(),
+        Some("1" | "true" | "yes" | "on" | "enable" | "enabled")
+    )
+}
 /// Immutable compatibility identity for vectors written before Embedding
 /// Profiles existed. It is deliberately explicit: raw-text vectors must never
 /// be confused with the corrected Nomic retrieval encoding contract.
@@ -778,29 +812,24 @@ impl SqliteMemoryStore {
         #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
         let has_required_features = true;
 
-        let disabled_by_env = std::env::var_os(VESTIGE_DISABLE_VECTOR_SEARCH)
-            .and_then(|v| {
-                let value = v.to_ascii_lowercase();
-                if value == "1"
-                    || value == "true"
-                    || value == "yes"
-                    || value == "on"
-                    || value == "enable"
-                    || value == "enabled"
-                {
-                    Some(())
-                } else {
-                    None
-                }
-            })
-            .is_some();
+        has_required_features && !Self::vector_search_disable_requested()
+    }
 
-        has_required_features && !disabled_by_env
+    /// The runtime opt-out, read the same way by the gate and by the
+    /// "why is it off" report so the two can never disagree.
+    #[cfg(feature = "vector-search")]
+    fn vector_search_disable_requested() -> bool {
+        #[cfg(test)]
+        if VECTOR_SEARCH_DISABLED_FOR_TEST.with(|cell| cell.get()) {
+            return true;
+        }
+        std::env::var_os(VESTIGE_DISABLE_VECTOR_SEARCH)
+            .is_some_and(|value| env_value_disables_vector_search(&value))
     }
 
     #[cfg(feature = "vector-search")]
     fn vector_search_unavailable_reason() -> Option<&'static str> {
-        if std::env::var_os(VESTIGE_DISABLE_VECTOR_SEARCH).is_some() {
+        if Self::vector_search_disable_requested() {
             return Some("disabled by VESTIGE_DISABLE_VECTOR_SEARCH");
         }
 
@@ -8162,6 +8191,18 @@ impl SqliteMemoryStore {
         })
     }
 
+    /// The raw `VESTIGE_AUTO_CONSOLIDATE_MERGE` value, or a test's pinned
+    /// value for this thread. Parsing stays in the caller so the fail-closed
+    /// rule is read next to the destructive pass it guards.
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    fn auto_consolidate_merge_value() -> Option<String> {
+        #[cfg(test)]
+        if let Some(pinned) = AUTO_CONSOLIDATE_MERGE_FOR_TEST.with(|cell| cell.borrow().clone()) {
+            return pinned;
+        }
+        std::env::var("VESTIGE_AUTO_CONSOLIDATE_MERGE").ok()
+    }
+
     /// Auto-deduplicate similar memories during consolidation (episodic → semantic merge)
     ///
     /// Finds clusters with cosine similarity >= 0.85, keeps the strongest node,
@@ -8181,7 +8222,7 @@ impl SqliteMemoryStore {
         // unaffected by this gate. Gate here (not the caller) so it stays
         // with the pin filter and self-protects against a future second
         // caller.
-        let auto_merge = std::env::var("VESTIGE_AUTO_CONSOLIDATE_MERGE")
+        let auto_merge = Self::auto_consolidate_merge_value()
             .map(|v| {
                 let v = v.trim();
                 v.eq_ignore_ascii_case("true")
@@ -15244,9 +15285,6 @@ mod tests {
     // alias keeps all existing tests compiling without modification.
     use SqliteMemoryStore as Storage;
 
-    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
     fn create_test_storage() -> Storage {
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("test.db");
@@ -16379,31 +16417,83 @@ mod tests {
         assert_eq!(res2.node_id, created.node_id);
     }
 
+    /// Run `f` with vector search disabled for this thread only. It used to
+    /// set `VESTIGE_DISABLE_VECTOR_SEARCH` in the process environment under
+    /// `ENV_LOCK`, but every other test thread building a `Storage` during
+    /// that window got no vector index: `cargo test --lib vector` failed the
+    /// three `peer_*` tests on every run, and the full suite passed only by
+    /// scheduling luck.
     #[cfg(all(feature = "embeddings", feature = "vector-search"))]
     fn with_vector_search_disabled<T>(f: impl FnOnce() -> T) -> T {
-        let _guard = ENV_LOCK.lock().unwrap();
-        let previous = std::env::var_os(VESTIGE_DISABLE_VECTOR_SEARCH);
-
-        // Tests serialize access with ENV_LOCK because process environment
-        // mutation is global and unsafe under Rust 2024.
-        unsafe {
-            std::env::set_var(VESTIGE_DISABLE_VECTOR_SEARCH, "1");
-        }
-
+        VECTOR_SEARCH_DISABLED_FOR_TEST.with(|cell| cell.set(true));
         let result = catch_unwind(AssertUnwindSafe(f));
-
-        unsafe {
-            if let Some(value) = previous {
-                std::env::set_var(VESTIGE_DISABLE_VECTOR_SEARCH, value);
-            } else {
-                std::env::remove_var(VESTIGE_DISABLE_VECTOR_SEARCH);
-            }
-        }
+        VECTOR_SEARCH_DISABLED_FOR_TEST.with(|cell| cell.set(false));
 
         match result {
             Ok(value) => value,
             Err(payload) => resume_unwind(payload),
         }
+    }
+
+    #[cfg(feature = "vector-search")]
+    #[test]
+    fn vector_search_env_value_parsing() {
+        use std::ffi::OsStr;
+        for on in ["1", "true", "TRUE", "yes", "On", "enable", "enabled"] {
+            assert!(
+                env_value_disables_vector_search(OsStr::new(on)),
+                "{on} must disable"
+            );
+        }
+        for off in ["", "0", "false", "no", "off", "disabled", "banana"] {
+            assert!(
+                !env_value_disables_vector_search(OsStr::new(off)),
+                "{off:?} must not disable"
+            );
+        }
+    }
+
+    /// The regression guard for the test race itself: disabling vector search
+    /// in one test must be invisible to a storage built on another thread.
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    #[test]
+    fn disabling_vector_search_in_one_test_does_not_leak_to_other_threads() {
+        with_vector_search_disabled(|| {
+            assert!(!Storage::vector_search_enabled_by_cpu());
+            let sibling = std::thread::spawn(|| {
+                let dir = tempdir().unwrap();
+                let storage = create_test_storage_at(&dir, "sibling-thread.db");
+                (
+                    Storage::vector_search_enabled_by_cpu(),
+                    storage.vector_index.is_some(),
+                )
+            })
+            .join()
+            .unwrap();
+            assert_eq!(
+                sibling,
+                (true, true),
+                "a sibling thread saw this test's vector-search override"
+            );
+        });
+        assert!(Storage::vector_search_enabled_by_cpu());
+    }
+
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    #[test]
+    fn pinning_auto_merge_in_one_test_does_not_leak_to_other_threads() {
+        let real = std::env::var("VESTIGE_AUTO_CONSOLIDATE_MERGE").ok();
+        with_auto_merge_env(Some("1"), || {
+            assert_eq!(
+                Storage::auto_consolidate_merge_value().as_deref(),
+                Some("1")
+            );
+            let sibling = std::thread::spawn(Storage::auto_consolidate_merge_value)
+                .join()
+                .unwrap();
+            assert_eq!(sibling, real, "a sibling thread saw this test's pin");
+        });
+        assert_eq!(Storage::auto_consolidate_merge_value(), real);
     }
 
     #[cfg(all(feature = "embeddings", feature = "vector-search"))]
@@ -21266,31 +21356,17 @@ mod tests {
             .unwrap();
     }
 
-    /// Run `f` with VESTIGE_AUTO_CONSOLIDATE_MERGE pinned to `value`
-    /// (None = pinned-unset, i.e. the documented ON default), serialized via
-    /// ENV_LOCK and restored afterward (process env is global + unsafe under
-    /// Rust 2024). Sibling of `with_vector_search_disabled`.
+    /// Run `f` with VESTIGE_AUTO_CONSOLIDATE_MERGE pinned to `value` for this
+    /// thread (None = pinned-unset, the documented fail-closed default).
+    /// Sibling of `with_vector_search_disabled`; like it, this no longer
+    /// touches the process environment, so consolidation tests on other
+    /// threads keep reading the real one.
     #[cfg(all(feature = "embeddings", feature = "vector-search"))]
     fn with_auto_merge_env<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
-        const KEY: &str = "VESTIGE_AUTO_CONSOLIDATE_MERGE";
-        let _guard = ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let previous = std::env::var_os(KEY);
-        unsafe {
-            match value {
-                Some(v) => std::env::set_var(KEY, v),
-                None => std::env::remove_var(KEY),
-            }
-        }
+        AUTO_CONSOLIDATE_MERGE_FOR_TEST
+            .with(|cell| *cell.borrow_mut() = Some(value.map(str::to_string)));
         let result = catch_unwind(AssertUnwindSafe(f));
-        unsafe {
-            if let Some(prev) = previous {
-                std::env::set_var(KEY, prev);
-            } else {
-                std::env::remove_var(KEY);
-            }
-        }
+        AUTO_CONSOLIDATE_MERGE_FOR_TEST.with(|cell| *cell.borrow_mut() = None);
         match result {
             Ok(value) => value,
             Err(payload) => resume_unwind(payload),


### PR DESCRIPTION
## Summary

A deterministic red on `main` that nobody saw because the full suite hides it.

`cargo test -p vestige-core --lib vector` fails `peer_process_write_is_visible_to_the_vector_index_without_restart`, `peer_reembedding_replaces_the_stale_vector_here`, and `peer_purge_removes_the_vector_here` on every run (three of three on this machine, on `main`), while `--lib peer_` passes. `with_vector_search_disabled` sets `VESTIGE_DISABLE_VECTOR_SEARCH=1` in the process environment under `ENV_LOCK`; the `peer_*` tests never take that lock, build a `Storage` during the window, and get no vector index. The workspace suite passes only because the two groups rarely overlap there.

**Fix.** Environment-gated test helpers no longer touch the process environment. `with_vector_search_disabled` and `with_auto_merge_env` (the `VESTIGE_AUTO_CONSOLIDATE_MERGE` sibling, same hazard, destructive gate) each pin a thread-local override that the gate reads in test builds. `ENV_LOCK` is removed. Two new tests spawn a sibling thread inside the override and assert it sees the real environment.

**One behaviour fix that fell out.** `vector_search_enabled_by_cpu` parsed the variable (only `1`, `true`, `yes`, `on`, `enable`, `enabled` disable), but `vector_search_unavailable_reason` treated any value as disabled. `VESTIGE_DISABLE_VECTOR_SEARCH=0` therefore kept the index on while the report said it was off. Both now read one function, and the parser has its own test.

## Gates

| Gate | Result |
|---|---|
| `cargo test -p vestige-core --lib vector`, three consecutive runs | 23 passed each (was 3 failed each on `main`) |
| Negative test: helper mutates the process env again | `disabling_vector_search_in_one_test_does_not_leak_to_other_threads` fails, file restored (md5 checked) |
| `cargo test -p vestige-core --lib auto_dedup` | 8 passed |
| `cargo clippy -p vestige-core --all-targets -- -D warnings` | clean |
| `cargo test -p vestige-core --lib` | 796 passed, 1 ignored (pre-existing) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
