### PR TITLE
fix(ci): dashboard test paths work on Windows; CI Windows job runs the dashboard suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,8 +287,10 @@ jobs:
 
   # Windows is otherwise compiled only by release.yml when a tag is cut, so an
   # MSVC-only break (usearch 2.24.0 referencing POSIX MAP_FAILED, #93 before it)
-  # surfaces after the release exists. This compiles the default feature set on
-  # MSVC on every pull request, so a dependency bump proves itself first.
+  # surfaces after the release exists. This job mirrors release.yml's Windows
+  # job: the dashboard check, test and build first (the v2.8.0 release build
+  # died on a dashboard test that had never run on Windows), then the default
+  # feature set compiled on MSVC, so both prove themselves on every pull request.
   windows-msvc-build:
     name: Windows MSVC build (x86_64-pc-windows-msvc)
     runs-on: windows-latest
@@ -298,6 +300,24 @@ jobs:
       github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Dashboard check, test and build on Windows
+        shell: bash
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter @vestige/dashboard check
+          pnpm --filter @vestige/dashboard test
+          pnpm --filter @vestige/dashboard build
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,8 +180,10 @@ jobs:
             target/
           key: ${{ runner.os }}-aarch64-linux-android-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      # ~/.cargo/bin is in the cache, so a warm cache already holds cargo-ndk
+      # and `cargo install` refuses to overwrite it (exit 101). Reuse it.
       - name: Install cargo-ndk
-        run: cargo install cargo-ndk --locked
+        run: command -v cargo-ndk >/dev/null || cargo install cargo-ndk --locked
 
       # openssl-src (git2's vendored OpenSSL) configures Android through the
       # NDK's clang wrappers, which it looks for on PATH under ANDROID_NDK_ROOT.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Windows job runs the dashboard check, test and build before the MSVC compile,
   the same steps as release.yml, so the next such break shows up on the pull
   request instead of on the release.
+- The Android CI job reuses a cached `cargo-ndk` instead of failing on
+  `cargo install` when the cargo cache is warm.
 
 ## [2.8.0] - 2026-09-05 — "Strong memories stay whole"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to Vestige will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed — CI
+
+- The Observatory privacy test built file paths from `import.meta.url` with
+  `.pathname`, which on Windows yields `/D:/...` and then `D:\D:\...` after
+  `join()`. It failed the v2.8.0 Windows release build, the first time the
+  dashboard suite had run on Windows. It now uses `fileURLToPath`, and the CI
+  Windows job runs the dashboard check, test and build before the MSVC compile,
+  the same steps as release.yml, so the next such break shows up on the pull
+  request instead of on the release.
+
 ## [2.8.0] - 2026-09-05 — "Strong memories stay whole"
 
 The release the Sep 4 deep audit asked for. The ingest gate stops merging new

--- a/apps/dashboard/src/lib/observatory/__tests__/stage-privacy.test.ts
+++ b/apps/dashboard/src/lib/observatory/__tests__/stage-privacy.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Privacy regression guard for the Observatory stage.
@@ -10,8 +11,10 @@ import { join } from 'node:path';
  * so the prop must default to `'none'` and no route may opt into `'full'`
  * without a deliberate change to this test.
  */
-const OBSERVATORY = new URL('..', import.meta.url).pathname;
-const ROUTES = new URL('../../../routes', import.meta.url).pathname;
+// fileURLToPath, not `.pathname`: on Windows the pathname of a file URL is
+// `/D:/a/...`, and join() turns that into `D:\D:\a\...` (ENOENT in CI).
+const OBSERVATORY = fileURLToPath(new URL('..', import.meta.url));
+const ROUTES = fileURLToPath(new URL('../../../routes', import.meta.url));
 
 function svelteFiles(dir: string): string[] {
 	const out: string[] = [];


### PR DESCRIPTION
## Summary

The v2.8.0 release build failed its Windows job in `pnpm --filter @vestige/dashboard test`: `stage-privacy.test.ts` built paths with `new URL('..', import.meta.url).pathname`, which on Windows is `/D:/a/...` and becomes `D:\D:\a\...` after `join()` (ENOENT, 2 tests failed, 832 passed). The other three targets uploaded; the Windows zip is missing from the release until this lands.

- The test uses `fileURLToPath` now. Passes locally (2 tests) and the Windows CI job on this PR is the real proof.
- The CI `windows-msvc-build` job now mirrors release.yml's Windows job: pnpm install, dashboard check, test and build, then the MSVC compile. Until tonight it only compiled Rust, so the dashboard suite had never run on Windows before a release.
- CHANGELOG has an Unreleased entry describing the fix.

## After merge

Dispatch release.yml on `main` with `tag=v2.8.0`. It overwrites the six existing assets with identical files (softprops/action-gh-release v2, `overwrite_files` defaults to true) and adds the Windows zip and checksum. No Rust or dashboard source changes since the tag, so the binaries are the same; the release notes will say the Windows asset was built from `main` after this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)