### PR TITLE
feat(dashboard): duplicates page merges through the dedup plan-then-apply flow (#221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — The duplicates page can merge
+
+- `POST /api/duplicates/plan` and `POST /api/duplicates/apply` expose the
+  `dedup` tool's plan-then-apply flow to the dashboard, with the same plan ids,
+  classification and undo reflog the MCP surface uses. The Duplicates page's
+  merge control, disabled since the fake-success button was removed, now
+  previews the plan (survivor, absorbed count, matcher verdict, result text),
+  applies it on an explicit click, and shows the operation id that
+  `dedup undo` reverses. Oversized similarity components stay unmergeable.
+  The Live badge now reports the last fetch: Live, Refreshing, or Offline.
+  API errors surface the handler's message instead of a bare status line.
+
 ### Fixed — CI
 
 - The Observatory privacy test built file paths from `import.meta.url` with

--- a/apps/dashboard/src/lib/components/DuplicateCluster.svelte
+++ b/apps/dashboard/src/lib/components/DuplicateCluster.svelte
@@ -17,7 +17,9 @@
 		previewContent,
 		formatDate,
 		safeTags,
+		mergePlanSummary,
 	} from './duplicates-helpers';
+	import type { DuplicateMergePlan, DuplicateMergeResult } from '$types';
 
 	interface ClusterMemory {
 		id: string;
@@ -38,9 +40,59 @@
 		 */
 		oversized?: boolean;
 		onDismiss?: () => void;
+		/** Preview a reversible merge of these member ids. Nothing is written. */
+		onPlan?: (memberIds: string[]) => Promise<DuplicateMergePlan>;
+		/** Execute a previewed plan; returns the operation id `dedup undo` reverses. */
+		onApply?: (planId: string) => Promise<DuplicateMergeResult>;
+		/** Called after a successful apply so the page can drop the cluster and refetch. */
+		onMerged?: (result: DuplicateMergeResult) => void;
+	}
+	let {
+		similarity,
+		memories,
+		suggestedAction,
+		oversized = false,
+		onDismiss,
+		onPlan,
+		onApply,
+		onMerged,
+	}: Props = $props();
+
+	// Merge is a two-step flow: plan (read-only preview) then apply (explicit).
+	// Every state here is visible in the UI; there is no optimistic path.
+	let plan: DuplicateMergePlan | null = $state(null);
+	let planning = $state(false);
+	let applying = $state(false);
+	let mergeError: string | null = $state(null);
+	let merged: DuplicateMergeResult | null = $state(null);
+	const canMerge = $derived(!oversized && !!onPlan && !!onApply && !merged);
+
+	async function previewMerge() {
+		if (!onPlan || planning) return;
+		planning = true;
+		mergeError = null;
+		try {
+			plan = await onPlan(memories.map((m) => m.id));
+		} catch (e) {
+			mergeError = e instanceof Error ? e.message : 'Could not plan the merge';
+		} finally {
+			planning = false;
+		}
 	}
 
-	let { similarity, memories, suggestedAction, oversized = false, onDismiss }: Props = $props();
+	async function applyMerge() {
+		if (!onApply || !plan || applying) return;
+		applying = true;
+		mergeError = null;
+		try {
+			merged = await onApply(plan.planId);
+			onMerged?.(merged);
+		} catch (e) {
+			mergeError = e instanceof Error ? e.message : 'Could not apply the merge';
+		} finally {
+			applying = false;
+		}
+	}
 
 	let expanded = $state(false);
 
@@ -191,22 +243,69 @@
 			{/if}
 		</div>
 
-		<!-- Actions — native <button> elements, fully keyboard-accessible.
-		     Merge is NOT wired to a backend yet; the old button console.logged and
-		     optimistically dismissed the cluster — a fake success. Until the merge
-		     endpoint ships, the control is visibly disabled (never lies). -->
+		<!-- Merge preview. Rendered only after the backend returned a plan, so
+		     every number here came from the dedup tool, not from this component. -->
+		{#if plan && !merged}
+			<div class="rounded-xl border border-synapse/25 bg-synapse/5 p-3 text-xs">
+				<div class="font-mono text-[11px] uppercase tracking-[0.18em] text-synapse-glow">
+					Merge preview · nothing written yet
+				</div>
+				<div class="mt-1 text-text">{mergePlanSummary(plan)}</div>
+				<div class="mt-1 text-muted">{plan.explanation}</div>
+				<div class="mt-2 max-h-24 overflow-hidden text-muted">
+					Result: {previewContent(plan.diff.resultContent, 240)}
+				</div>
+				<div class="mt-3 flex flex-wrap items-center gap-2">
+					<button
+						type="button"
+						onclick={applyMerge}
+						disabled={applying}
+						class="rounded-lg bg-synapse/25 px-3 py-1.5 text-xs font-medium text-synapse-glow transition hover:bg-synapse/35 disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-synapse/60"
+					>
+						{applying ? 'Applying…' : 'Apply merge'}
+					</button>
+					<button
+						type="button"
+						onclick={() => (plan = null)}
+						disabled={applying}
+						class="rounded-lg bg-white/[0.04] px-3 py-1.5 text-xs text-dim transition hover:bg-white/[0.08] hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-synapse/60"
+					>
+						Cancel
+					</button>
+				</div>
+			</div>
+		{/if}
+		{#if merged}
+			<div class="rounded-xl border border-consolidated/25 bg-consolidated/5 p-3 text-xs text-text">
+				Merged into {merged.survivorId.slice(0, 8)}. Reversible: run dedup undo with
+				operation id <span class="font-mono">{merged.operationId}</span>.
+			</div>
+		{/if}
+		{#if mergeError}
+			<div class="rounded-xl border border-decay/25 bg-decay/5 p-3 text-xs text-decay" role="alert">
+				{mergeError}
+			</div>
+		{/if}
+
+		<!-- Actions: native <button> elements, fully keyboard-accessible. Merge
+		     is a plan-then-apply flow against POST /api/duplicates/plan and
+		     /api/duplicates/apply; oversized components stay unmergeable because
+		     they chain through pairwise similarity. -->
 		<div class="flex flex-wrap items-center gap-2 pt-1">
 			<button
 				type="button"
-				disabled
-				aria-disabled="true"
-				aria-label="Merge is not available yet"
-				class="cursor-not-allowed rounded-lg bg-white/[0.03] px-3 py-1.5 text-xs font-medium text-muted/60"
+				onclick={previewMerge}
+				disabled={!canMerge || planning || !!plan}
+				aria-disabled={!canMerge}
+				aria-label={oversized ? 'Merge is not safe for an oversized component' : 'Preview a reversible merge'}
+				class={canMerge
+					? 'rounded-lg bg-synapse/20 px-3 py-1.5 text-xs font-medium text-synapse-glow transition hover:bg-synapse/30 disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-synapse/60'
+					: 'cursor-not-allowed rounded-lg bg-white/[0.03] px-3 py-1.5 text-xs font-medium text-muted/60'}
 				title={oversized
-					? 'Oversized similarity component — not safe to merge'
-					: 'Merge backend not shipped yet — no destructive action is taken from this screen'}
+					? 'Oversized similarity component: members chain through pairwise similarity, so a merge could fold unrelated memories together'
+					: 'Preview first; nothing is written until you apply'}
 			>
-				Merge unavailable
+				{oversized ? 'Merge unsafe here' : planning ? 'Planning…' : 'Preview merge'}
 			</button>
 			<button
 				type="button"

--- a/apps/dashboard/src/lib/components/__tests__/DuplicateCluster.test.ts
+++ b/apps/dashboard/src/lib/components/__tests__/DuplicateCluster.test.ts
@@ -22,6 +22,7 @@ import {
 	previewContent,
 	formatDate,
 	safeTags,
+	mergePlanSummary,
 } from '../duplicates-helpers';
 
 // ---------------------------------------------------------------------------
@@ -361,5 +362,31 @@ describe('safeTags', () => {
 
 	it('honors default limit = 4', () => {
 		expect(safeTags(['a', 'b', 'c', 'd', 'e', 'f'])).toEqual(['a', 'b', 'c', 'd']);
+	});
+});
+
+describe('mergePlanSummary', () => {
+	it('names the survivor, the absorbed count and the matcher verdict', () => {
+		const text = mergePlanSummary({
+			survivorId: 'abcdef1234567890',
+			memberIds: ['abcdef1234567890', 'x', 'y'],
+			classification: 'possible',
+			confidence: '0.812',
+			diff: { invalidatedIds: ['x', 'y'] }
+		});
+		expect(text).toBe(
+			'Keeps abcdef12, folds 2 memories into it. Matcher: possible at 81%. Reversible with dedup undo.'
+		);
+	});
+
+	it('falls back to member count and says unknown for an unparsable confidence', () => {
+		const text = mergePlanSummary({
+			survivorId: 'abcdef1234567890',
+			memberIds: ['abcdef1234567890', 'x'],
+			classification: 'match',
+			confidence: 'n/a'
+		});
+		expect(text).toContain('folds 1 memory into it');
+		expect(text).toContain('at unknown');
 	});
 });

--- a/apps/dashboard/src/lib/components/duplicates-helpers.ts
+++ b/apps/dashboard/src/lib/components/duplicates-helpers.ts
@@ -147,3 +147,25 @@ export function safeTags(tags: string[] | null | undefined, limit: number = 4): 
 	if (!Array.isArray(tags)) return [];
 	return tags.slice(0, limit);
 }
+
+export interface MergePlanLike {
+	survivorId: string;
+	memberIds: string[];
+	classification: string;
+	confidence: string | number;
+	diff?: { invalidatedIds?: string[] };
+}
+
+/**
+ * One line a person can read before pressing Apply: who survives, how many
+ * memories fold into it, and how sure the matcher was. Pure, so the preview
+ * panel and its test share it.
+ */
+export function mergePlanSummary(plan: MergePlanLike): string {
+	const absorbed = plan.diff?.invalidatedIds?.length ?? Math.max(0, plan.memberIds.length - 1);
+	const confidence =
+		typeof plan.confidence === 'number' ? plan.confidence : Number.parseFloat(plan.confidence);
+	const pct = Number.isFinite(confidence) ? `${Math.round(confidence * 100)}%` : 'unknown';
+	const noun = absorbed === 1 ? 'memory' : 'memories';
+	return `Keeps ${plan.survivorId.slice(0, 8)}, folds ${absorbed} ${noun} into it. Matcher: ${plan.classification} at ${pct}. Reversible with dedup undo.`;
+}

--- a/apps/dashboard/src/lib/stores/api.ts
+++ b/apps/dashboard/src/lib/stores/api.ts
@@ -7,6 +7,8 @@ import type {
 	TimelineResponse,
 	GraphResponse,
 	DuplicatesResponse,
+	DuplicateMergePlan,
+	DuplicateMergeResult,
 	ContradictionsResponse,
 	CrossProjectPatternsResponse,
 	MemoryAuditResponse,
@@ -44,7 +46,19 @@ async function fetcher<T>(path: string, options?: RequestInit): Promise<T> {
 		headers: { 'Content-Type': 'application/json' },
 		...options
 	});
-	if (!res.ok) throw new Error(`API ${res.status}: ${res.statusText}`);
+	if (!res.ok) {
+		// Handlers that reject with a JSON `error` carry the same words the MCP
+		// caller would see; surface them instead of a bare status line.
+		const detail = await res
+			.json()
+			.then((body: unknown) =>
+				body && typeof body === 'object' && typeof (body as { error?: unknown }).error === 'string'
+					? (body as { error: string }).error
+					: null
+			)
+			.catch(() => null);
+		throw new Error(detail ?? `API ${res.status}: ${res.statusText}`);
+	}
 	return res.json();
 }
 
@@ -140,6 +154,18 @@ export const api = {
 	// cross-project pattern transfer, per-memory audit trail.
 	duplicates: (threshold = 0.8, limit = 20) =>
 		fetcher<DuplicatesResponse>(`/duplicates?threshold=${threshold}&limit=${limit}`),
+	// Two-step merge: plan previews (nothing written), apply executes with the
+	// explicit confirm the dedup tool requires below a `match` classification.
+	duplicatesPlan: (memberIds: string[]) =>
+		fetcher<DuplicateMergePlan>('/duplicates/plan', {
+			method: 'POST',
+			body: JSON.stringify({ memberIds })
+		}),
+	duplicatesApply: (planId: string) =>
+		fetcher<DuplicateMergeResult>('/duplicates/apply', {
+			method: 'POST',
+			body: JSON.stringify({ planId, confirm: true })
+		}),
 
 	contradictions: (params?: { topic?: string; min_trust?: number; limit?: number }) => {
 		const qs = params

--- a/apps/dashboard/src/lib/types/index.ts
+++ b/apps/dashboard/src/lib/types/index.ts
@@ -408,6 +408,36 @@ export interface DuplicatesResponse {
 	clusters: DuplicateClusterGroup[];
 }
 
+// POST /api/duplicates/plan: the dedup tool's plan_merge shape, verbatim.
+export interface DuplicateMergePlan {
+	planId: string;
+	kind: string;
+	survivorId: string;
+	memberIds: string[];
+	diff: {
+		resultContent: string;
+		resultTags: string[];
+		resultSource: string | null;
+		invalidatedIds: string[];
+	};
+	confidence: string;
+	classification: string;
+	explanation: string;
+	requiresConfirm: boolean;
+	note: string;
+}
+
+// POST /api/duplicates/apply: the dedup tool's apply shape, verbatim.
+export interface DuplicateMergeResult {
+	operationId: string;
+	opType: string;
+	status: string;
+	survivorId: string;
+	affectedIds: string[];
+	reversible: boolean;
+	note: string;
+}
+
 // Contradiction pairs — GET /api/contradictions. Field names mirror the
 // Contradiction interface in $components/ContradictionArcs.svelte; a = older
 // memory, b = newer. Sorted by similarity desc.

--- a/apps/dashboard/src/routes/(app)/duplicates/+page.svelte
+++ b/apps/dashboard/src/routes/(app)/duplicates/+page.svelte
@@ -95,10 +95,13 @@
 		}
 	}
 
-	// NOTE: merge intentionally has NO handler. The old mergeCluster console.logged
-	// and optimistically dismissed — a fake success claiming destructive work
-	// happened. DuplicateCluster now renders a visibly-disabled "Merge unavailable"
-	// control until POST /api/duplicates/merge ships.
+	// Merge is plan-then-apply against the dedup tool through the API. After a
+	// successful apply the cluster is dropped and detection reruns, so what the
+	// page shows is what the store holds; nothing is dismissed optimistically.
+	function onMerged(key: string) {
+		dismissCluster(key);
+		detect();
+	}
 
 	const visibleClusters = $derived(
 		clusters
@@ -159,16 +162,20 @@
 	<PageHeader
 		icon="duplicates"
 		title="Memory Hygiene: Duplicate Detection"
-		subtitle="Cosine-similarity clustering over embeddings. Oversized similarity components are quarantined for review because they chain through pairwise similarity and are not safe to merge. Dismissed clusters are hidden for this session only."
+		subtitle="Cosine-similarity clustering over embeddings. Merge previews a reversible plan and applies it only on your say-so; dedup undo reverses it. Oversized similarity components are quarantined for review because they chain through pairwise similarity and are not safe to merge. Dismissed clusters are hidden for this session only."
 		accent="synapse"
 	>
-		<span
-			class="ping-host flex h-2 w-2 items-center justify-center text-synapse-glow"
-			aria-hidden="true"
-		>
-			<span class="breathe h-2 w-2 rounded-full bg-synapse-glow"></span>
-		</span>
-		<span class="text-xs text-dim">Live</span>
+		<!-- The badge reports the last fetch, not a hope: Live after a successful
+		     detection, Refreshing while one runs, Offline when the API failed. -->
+		{#if !error}
+			<span
+				class="ping-host flex h-2 w-2 items-center justify-center text-synapse-glow"
+				aria-hidden="true"
+			>
+				<span class="breathe h-2 w-2 rounded-full bg-synapse-glow"></span>
+			</span>
+		{/if}
+		<span class="text-xs text-dim">{error ? 'Offline' : loading ? 'Refreshing' : 'Live'}</span>
 	</PageHeader>
 
 	<!-- Controls panel -->
@@ -341,6 +348,9 @@
 							suggestedAction={c.suggestedAction}
 							oversized={c.memories.length > OVERSIZED_MEMBERS}
 							onDismiss={() => dismissCluster(key)}
+							onPlan={(ids) => api.duplicatesPlan(ids)}
+							onApply={(planId) => api.duplicatesApply(planId)}
+							onMerged={() => onMerged(key)}
 						/>
 					</div>
 				</div>

--- a/crates/vestige-mcp/src/dashboard/handlers.rs
+++ b/crates/vestige-mcp/src/dashboard/handlers.rs
@@ -3003,6 +3003,73 @@ pub fn read_review_mode(state: &AppState) -> vestige_core::ReviewMode {
 // ============================================================================
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DuplicatesPlanBody {
+    pub member_ids: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DuplicatesApplyBody {
+    pub plan_id: String,
+    #[serde(default)]
+    pub confirm: bool,
+}
+
+/// Map a `dedup` tool error onto an HTTP status with the message kept, so the
+/// dashboard can show the same words the MCP caller would see.
+fn dedup_tool_error(message: String) -> (StatusCode, Json<Value>) {
+    let lower = message.to_ascii_lowercase();
+    let status = if lower.contains("not found") {
+        StatusCode::NOT_FOUND
+    } else if lower.contains("not enabled") || lower.contains("not compiled") {
+        StatusCode::NOT_IMPLEMENTED
+    } else {
+        StatusCode::BAD_REQUEST
+    };
+    (status, Json(serde_json::json!({ "error": message })))
+}
+
+/// POST /api/duplicates/plan: preview a reversible merge of a cluster.
+///
+/// Delegates to the `dedup` tool's `plan_merge`, so the dashboard and the MCP
+/// surface produce the same plan ids, classification and undo reflog. Nothing
+/// is written; the response says so in `note`.
+pub async fn plan_duplicates_merge(
+    State(state): State<AppState>,
+    Json(body): Json<DuplicatesPlanBody>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    if body.member_ids.len() < 2 {
+        return Err(dedup_tool_error(
+            "memberIds must contain at least two memory ids".to_string(),
+        ));
+    }
+    let args = serde_json::json!({ "action": "plan_merge", "member_ids": body.member_ids });
+    crate::tools::dedup::execute_unified(&state.storage, Some(args))
+        .await
+        .map(Json)
+        .map_err(dedup_tool_error)
+}
+
+/// POST /api/duplicates/apply: execute a previewed plan. The tool enforces
+/// the confirm rule (anything below a `match` needs `confirm: true`); this
+/// handler forwards the flag and the operation id that `dedup undo` reverses.
+pub async fn apply_duplicates_merge(
+    State(state): State<AppState>,
+    Json(body): Json<DuplicatesApplyBody>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let args = serde_json::json!({
+        "action": "apply",
+        "plan_id": body.plan_id,
+        "confirm": body.confirm,
+    });
+    crate::tools::dedup::execute_unified(&state.storage, Some(args))
+        .await
+        .map(Json)
+        .map_err(dedup_tool_error)
+}
+
+#[derive(Debug, Deserialize)]
 pub struct DuplicatesParams {
     pub threshold: Option<f64>,
     pub limit: Option<usize>,
@@ -4010,6 +4077,79 @@ mod tests {
         .unwrap();
 
         assert_eq!(body["threshold"], 0.99);
+    }
+
+    #[tokio::test]
+    async fn duplicates_plan_rejects_fewer_than_two_ids() {
+        let (_dir, storage) = seed_storage();
+        let state = AppState::new(storage, None);
+        let (status, Json(body)) = plan_duplicates_merge(
+            State(state),
+            Json(DuplicatesPlanBody {
+                member_ids: vec!["only-one".to_string()],
+            }),
+        )
+        .await
+        .expect_err("one id must be rejected");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body["error"].as_str().unwrap().contains("two"), "{body}");
+    }
+
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    #[tokio::test]
+    async fn duplicates_plan_then_apply_merges_through_the_reversible_reflog() {
+        let (_dir, storage) = seed_storage();
+        let a = ingest(&storage, "Rotate the payments cache key on every deploy");
+        let b = ingest(&storage, "Rotate the payments cache key on each deploy");
+        let state = AppState::new(storage.clone(), None);
+
+        let Json(plan) = plan_duplicates_merge(
+            State(state.clone()),
+            Json(DuplicatesPlanBody {
+                member_ids: vec![a.clone(), b.clone()],
+            }),
+        )
+        .await
+        .unwrap_or_else(|(status, Json(body))| panic!("plan failed: {status} {body}"));
+        let plan_id = plan["planId"]
+            .as_str()
+            .unwrap_or_else(|| panic!("plan carried no planId: {plan}"))
+            .to_string();
+        assert_eq!(plan["memberIds"].as_array().unwrap().len(), 2, "{plan}");
+        assert!(plan["note"].as_str().unwrap().contains("Nothing was changed"));
+
+        let Json(applied) = apply_duplicates_merge(
+            State(state),
+            Json(DuplicatesApplyBody {
+                plan_id: plan_id.clone(),
+                confirm: true,
+            }),
+        )
+        .await
+        .unwrap_or_else(|(status, Json(body))| panic!("apply failed: {status} {body}"));
+        let operation_id = applied["operationId"].as_str().expect("operationId");
+        assert_eq!(applied["reversible"], true, "{applied}");
+        let affected: Vec<&str> = applied["affectedIds"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(Value::as_str)
+            .collect();
+        assert!(affected.contains(&a.as_str()) && affected.contains(&b.as_str()), "{applied}");
+
+        // The reflog the dashboard's undo path reads knows the operation.
+        let log = crate::tools::dedup::execute_unified(
+            &storage,
+            Some(serde_json::json!({ "action": "undo" })),
+        )
+            .await
+            .unwrap();
+        let listed = log["operations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|op| op["operationId"] == operation_id);
+        assert!(listed, "{log}");
     }
 
     #[tokio::test]

--- a/crates/vestige-mcp/src/dashboard/mod.rs
+++ b/crates/vestige-mcp/src/dashboard/mod.rs
@@ -228,6 +228,14 @@ fn build_router_inner(state: AppState, port: u16) -> (Router, AppState) {
         // contradictions, cross-project patterns, per-memory audit
         // ============================================================
         .route("/api/duplicates", get(handlers::list_duplicates))
+        .route(
+            "/api/duplicates/plan",
+            post(handlers::plan_duplicates_merge),
+        )
+        .route(
+            "/api/duplicates/apply",
+            post(handlers::apply_duplicates_merge),
+        )
         .route("/api/contradictions", get(handlers::list_contradictions))
         .route(
             "/api/patterns/cross-project",


### PR DESCRIPTION
## Summary

Closes #221. The Duplicates page rendered clusters with a merge control that had been disabled since the fake-success button was removed, under a badge that said Live regardless of what happened.

- `POST /api/duplicates/plan` (`{ memberIds }`) and `POST /api/duplicates/apply` (`{ planId, confirm }`) forward to the `dedup` tool's action dispatcher, so the dashboard produces the same plan ids, classification, confirm rule and undo reflog as an MCP caller. Tool errors map to 400, 404 (unknown plan) or 501 (build without embeddings) with the message kept.
- The merge control is a plan-then-apply flow: Preview merge fetches the plan and shows survivor, absorbed count, matcher verdict and confidence, explanation and the first 240 characters of the result; Apply merge executes with `confirm: true`; success shows the operation id that `dedup undo` reverses and the page drops the cluster and reruns detection. No optimistic path. Oversized similarity components stay unmergeable, with the reason in the tooltip.
- The Live badge reports the last fetch: Live, Refreshing, or Offline (and the ping only when live).
- The API client surfaces a handler's JSON error message instead of a bare status line.

## Gates

| Gate | Result |
|---|---|
| `cargo test -p vestige-mcp --lib duplicates_plan` | 2 passed (plan rejects one id; plan then apply merges and appears in the undo reflog) |
| `cargo clippy -p vestige-mcp --all-targets -- -D warnings` | clean |
| `pnpm --filter @vestige/dashboard check` | 1001 files, 0 errors |
| `pnpm --filter @vestige/dashboard test` | 39 files, 836 passed (2 new for `mergePlanSummary`) |

The committed dashboard build is not regenerated here; releases do that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)