### PR TITLE
perf(mcp): tools/list from 35,019 to 28,731 bytes, with a pinned ceiling (#212, partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — tools/list is 18 percent smaller
+
+- 126 schema and tool descriptions were rewritten to say the same thing in
+  fewer words, and the batch item schema of `smart_ingest` no longer repeats
+  the descriptions of the single-mode fields it mirrors. Measured on the built
+  binary: 35,019 bytes to 28,731 (38,474 before 2.8.0). The e2e suite now pins
+  a 30,000 byte ceiling so the payload cannot creep back unnoticed. The 20 KB
+  target in #212 needs fewer parameters, not shorter prose; the issue stays
+  open with the numbers.
+
 ### Fixed — CI
 
 - The Observatory privacy test built file paths from `import.meta.url` with

--- a/crates/vestige-mcp/src/server.rs
+++ b/crates/vestige-mcp/src/server.rs
@@ -399,7 +399,7 @@ description: Some("Retrieve from memory. mode 'lookup' (default): fast hybrid ke
                     idempotent_hint: true,
                     open_world_hint: false,
                 }),
-description: Some("Inspect a persisted retrieval receipt ('get') or run a controlled ablation of its frozen evidence pack ('replay', which withholds named slots without rerunning search, calling a model, or claiming causality).".to_string()),
+description: Some("Inspect a persisted retrieval receipt ('get') or ablate its frozen evidence pack ('replay'): named slots withheld, no rerun, no model, no causal claim.".to_string()),
                 input_schema: tools::receipt::schema(),
                 ..Default::default()
             },
@@ -415,7 +415,7 @@ description: Some("Inspect a persisted retrieval receipt ('get') or run a contro
                     idempotent_hint: false,
                     open_world_hint: false,
                 }),
-description: Some("Manage one memory. Actions: 'get', 'get_batch' (ids), 'state' (accessibility), 'promote' and 'demote' (adjust retrieval strength; demote never deletes), 'edit' (replace content, keep FSRS state), 'purge' (remove content and embeddings for good; confirm=true). 'delete' is an alias for purge.".to_string()),
+description: Some("Manage one memory: 'get', 'get_batch', 'state', 'promote' / 'demote' (demote never deletes), 'edit' (keeps FSRS state), 'purge' (for good; confirm=true). 'delete' aliases purge.".to_string()),
                 input_schema: tools::memory_unified::schema(),
                 ..Default::default()
             },
@@ -428,7 +428,7 @@ description: Some("Manage one memory. Actions: 'get', 'get_batch' (ids), 'state'
                     idempotent_hint: false,
                     open_world_hint: false,
                 }),
-description: Some("Code memory. Actions: 'remember_pattern', 'remember_decision', 'get_context' (patterns and decisions, each marked current or stale), 'verify' (re-check anchored code memories against the working tree).".to_string()),
+description: Some("Code memory: 'remember_pattern', 'remember_decision', 'get_context' (marked current or stale), 'verify' (re-check anchors against the tree).".to_string()),
                 input_schema: tools::codebase_unified::schema(),
                 ..Default::default()
             },
@@ -457,7 +457,7 @@ description: Some("Intentions. Actions: 'set', 'check' (find triggered), 'update
                     idempotent_hint: false,
                     open_world_hint: false,
                 }),
-description: Some("Save to memory with Prediction Error Gating: 'content' is created, merged into a similar memory, or supersedes an outdated one. Batch mode: 'items' (max 20) for session-end saves, each through the full pipeline.".to_string()),
+description: Some("Save to memory through Prediction Error Gating: 'content' is created, merged into a similar memory, or supersedes an outdated one. Batch: 'items' (max 20).".to_string()),
                 input_schema: tools::smart_ingest::schema(),
                 ..Default::default()
             },
@@ -473,7 +473,7 @@ description: Some("Save to memory with Prediction Error Gating: 'content' is cre
                     idempotent_hint: true,
                     open_world_hint: true,
                 }),
-description: Some("Index an external system into local, searchable memories that cite the canonical record. source='github' (repo='owner/name', GITHUB_TOKEN env) or 'redmine' (project, REDMINE_URL and REDMINE_API_KEY env). Re-runs update changed items; reconcile=true tombstones items removed upstream.".to_string()),
+description: Some("Index an external system into local memories that cite the source. source='github' (repo, GITHUB_TOKEN) or 'redmine' (project, REDMINE_URL, REDMINE_API_KEY). Re-runs update; reconcile=true tombstones removals.".to_string()),
                 input_schema: tools::source_sync::schema(),
                 ..Default::default()
             },
@@ -492,7 +492,7 @@ description: Some("Index an external system into local, searchable memories that
                     idempotent_hint: true,
                     open_world_hint: false,
                 }),
-description: Some("Store status. view 'health' (default: stats, decay preview, module health, warnings), 'retention' (average, distribution, trend), 'timeline' (memories by day), 'changelog' (state-change audit trail), 'stats' (hygiene counts by type, tag, age, retention, lifecycle).".to_string()),
+description: Some("Store status: view 'health' (default), 'retention', 'timeline', 'changelog', 'stats'.".to_string()),
                 input_schema: tools::memory_status::schema(),
                 ..Default::default()
             },
@@ -510,7 +510,7 @@ description: Some("Store status. view 'health' (default: stats, decay preview, m
                     idempotent_hint: false,
                     open_world_hint: false,
                 }),
-description: Some("Lifecycle maintenance. Actions: 'consolidate' (decay and embedding cycle), 'dream' (replay memories into insights and connections), 'gc' (collect stale memories; dry_run=true by default), 'importance_score' (score 'content'), 'backup', 'export' (JSON or JSONL with filters), 'restore' (from 'path').".to_string()),
+description: Some("Lifecycle: 'consolidate', 'dream', 'gc' (dry_run default true), 'importance_score', 'backup', 'export', 'restore'.".to_string()),
                 input_schema: tools::maintain::schema(),
                 ..Default::default()
             },
@@ -529,7 +529,7 @@ description: Some("Lifecycle maintenance. Actions: 'consolidate' (decay and embe
                     idempotent_hint: false,
                     open_world_hint: false,
                 }),
-description: Some("Duplicates, merges, supersession, and exact tag maintenance. Actions: 'scan' (default, read-only: duplicate clusters and merge candidates), 'plan_merge' (member_ids to plan_id), 'plan_supersede' (old_id, new_id to plan_id), 'apply' (run a plan_id; weak matches need confirm=true), 'undo' (reverse an operation_id, or omit to list the reflog), 'tag_rename' and 'tag_merge' (preview-token gated), 'protect' (pin against auto-merge), 'policy' (get or set match thresholds). Merged memories are invalidated, never deleted.".to_string()),
+description: Some("Duplicates and merges: 'scan' (read-only), 'plan_merge' / 'plan_supersede' (preview), 'apply' (plan_id; weak matches need confirm), 'undo' (reflog), 'tag_rename' / 'tag_merge' (preview-token gated), 'protect', 'policy'. Merged memories are invalidated, never deleted.".to_string()),
                 input_schema: tools::dedup::unified_schema(),
                 ..Default::default()
             },
@@ -552,7 +552,7 @@ description: Some("Duplicates, merges, supersession, and exact tag maintenance. 
                     idempotent_hint: false,
                     open_world_hint: false,
                 }),
-description: Some("Memory graph. Actions: 'chain' (path from, to), 'associations' (spreading activation from 'from'), 'bridges' (connectors between from and to), 'predict' (what you will need next, from 'context'), 'memory_graph' (subgraph around center_id or query), 'recent', 'get', 'memory', 'neighbors', 'never_composed', 'bounty_mode' (composition topology), 'label' (record an outcome; the only write).".to_string()),
+description: Some("Memory graph: 'chain', 'associations', 'bridges', 'predict', 'memory_graph', composition topology ('recent', 'get', 'memory', 'neighbors', 'never_composed', 'bounty_mode'), 'label' (the only write).".to_string()),
                 input_schema: tools::graph_unified::schema(),
                 ..Default::default()
             },
@@ -572,7 +572,7 @@ description: Some("Memory graph. Actions: 'chain' (path from, to), 'associations
                     idempotent_hint: true,
                     open_world_hint: false,
                 }),
-description: Some("Start-of-session context in one call: relevant memories, open intentions, store status, predictions, and codebase context under one token budget. Replaces separate recall, intention, memory_status, and codebase calls.".to_string()),
+description: Some("Start-of-session context in one call: relevant memories, open intentions, status, predictions, codebase context, under one token budget.".to_string()),
                 input_schema: tools::session_context::schema(),
                 ..Default::default()
             },
@@ -599,7 +599,7 @@ description: Some("Start-of-session context in one call: relevant memories, open
                     idempotent_hint: true,
                     open_world_hint: false,
                 }),
-description: Some("Inhibit a memory without deleting it (top-down suppression, Anderson 2025 and Davis Rac1): it drops out of retrieval and decays faster, each call compounds, and a background worker spreads accelerated decay to co-activated neighbours. reverse=true undoes it within 24 hours.".to_string()),
+description: Some("Inhibit a memory without deleting it: out of retrieval, faster decay, compounding per call, neighbours affected over 72 hours. reverse=true undoes it within 24 hours.".to_string()),
                 input_schema: tools::suppress::schema(),
                 ..Default::default()
             },
@@ -619,7 +619,7 @@ description: Some("Inhibit a memory without deleting it (top-down suppression, A
                     idempotent_hint: false,
                     open_world_hint: false,
                 }),
-description: Some("Memory with hindsight. After a failure is recorded, reach backward in time and promote the quiet earlier memory that caused it (same file, env var, or service), which similarity search cannot surface because a root cause rarely resembles the bug. Backward-only by construction (Cai 2024). Pass failure_id (defaults to the latest failure), manual=true to force, promote=false for a dry run.".to_string()),
+description: Some("Memory with hindsight: after a failure is recorded, reach backward and promote the quiet earlier memory that caused it (same file, env var or service), which similarity search cannot surface. failure_id (default: latest failure), manual=true to force, promote=false for a dry run.".to_string()),
                 input_schema: tools::backfill::schema(),
                 ..Default::default()
             },

--- a/crates/vestige-mcp/src/tools/backfill.rs
+++ b/crates/vestige-mcp/src/tools/backfill.rs
@@ -29,11 +29,11 @@ pub fn schema() -> Value {
         "properties": {
             "failure_id": {
                 "type": "string",
-                "description": "ID of the failure/'aversive event' memory to backfill from. If omitted, the most recent memory that looks like a failure is used."
+                "description": "Failure memory to backfill from. Omitted: the most recent failure-like memory."
             },
             "manual": {
                 "type": "boolean",
-                "description": "Force the backfill even if the event isn't auto-detected as salient (manual override). Default false.",
+                "description": "Force the backfill when the event is not auto-detected as salient. Default false.",
                 "default": false
             },
             "lookback_days": {
@@ -45,7 +45,7 @@ pub fn schema() -> Value {
             },
             "promote": {
                 "type": "boolean",
-                "description": "Whether to actually promote (boost) the surfaced cause(s) in storage. Default true. Set false for a dry-run preview.",
+                "description": "Promote the surfaced causes in storage. Default true; false for a dry run.",
                 "default": true
             },
             "scan_limit": {

--- a/crates/vestige-mcp/src/tools/codebase_unified.rs
+++ b/crates/vestige-mcp/src/tools/codebase_unified.rs
@@ -25,47 +25,47 @@ pub fn schema() -> Value {
             "action": {
                 "type": "string",
                 "enum": ["remember_pattern", "remember_decision", "get_context", "verify"],
-                "description": "'remember_pattern' stores a code pattern, 'remember_decision' an architectural decision, 'get_context' returns both with a current-or-stale mark, 'verify' re-checks every anchored code memory against the working tree"
+                "description": "'remember_pattern', 'remember_decision', 'get_context' (both, marked current or stale), 'verify' (re-check anchored memories against the tree)"
             },
             // remember_pattern fields
             "name": {
                 "type": "string",
-                "description": "Name/title for the pattern (required for remember_pattern)"
+                "description": "Pattern name (remember_pattern)."
             },
             "description": {
                 "type": "string",
-                "description": "Detailed description of the pattern (required for remember_pattern)"
+                "description": "Pattern description (remember_pattern)."
             },
             // remember_decision fields
             "decision": {
                 "type": "string",
-                "description": "The architectural or design decision made (required for remember_decision)"
+                "description": "The decision made (remember_decision)."
             },
             "rationale": {
                 "type": "string",
-                "description": "Why this decision was made (required for remember_decision)"
+                "description": "Why it was made (remember_decision)."
             },
             "alternatives": {
                 "type": "array",
                 "items": { "type": "string" },
-                "description": "Alternatives that were considered (optional for remember_decision)"
+                "description": "Alternatives considered (optional)."
             },
             // Shared fields
             "files": {
                 "type": "array",
                 "items": { "type": "string" },
-                "description": "Files this pattern or decision touches: a path ('src/state.py'), path plus symbol ('src/state.py#load_config'), or path plus lines ('src/state.py:552-580'). Anything beyond a plain path is content-hashed so the memory can report when the code changed."
+                "description": "Files touched: 'src/a.py', 'src/a.py#symbol', or 'src/a.py:10-20'. Anything beyond a bare path is content-hashed so staleness is detectable."
             },
             "anchors": {
                 "type": "array",
-                "description": "Structured form of 'files' for callers that know the symbol. Each anchor is content-hashed at save time so staleness is detectable.",
+                "description": "Structured form of 'files'; each anchor is content-hashed at save time.",
                 "items": {
                     "type": "object",
                     "properties": {
-                        "path": { "type": "string", "description": "Repository-relative path to the anchored file" },
-                        "symbol": { "type": "string", "description": "Function/type/class this memory is about. Strongly preferred over a line number: line numbers rot within a week." },
+                        "path": { "type": "string", "description": "Repository-relative file path." },
+                        "symbol": { "type": "string", "description": "Function, type or class this is about. Prefer over line numbers, which rot." },
                         "symbolKind": { "type": "string", "description": "Optional display kind, e.g. 'fn', 'class'" },
-                        "startLine": { "type": "integer", "description": "1-based start line, when the exact span is known" },
+                        "startLine": { "type": "integer", "description": "1-based start line, when known." },
                         "endLine": { "type": "integer", "description": "1-based inclusive end line" }
                     },
                     "required": ["path"]
@@ -73,21 +73,21 @@ pub fn schema() -> Value {
             },
             "repoPath": {
                 "type": "string",
-                "description": "Repository root used to resolve anchor paths (default: the server's working directory)"
+                "description": "Repository root for anchor paths (default: server working directory)."
             },
             "verify": {
                 "type": "boolean",
-                "description": "Check returned code memories against the current source and flag the ones that no longer match (default: true)",
+                "description": "Re-check returned code memories against the source and flag stale ones (default true).",
                 "default": true
             },
             "codebase": {
                 "type": "string",
-                "description": "Codebase/project identifier (e.g., 'vestige-tauri')"
+                "description": "Codebase or project identifier."
             },
             // get_context fields
             "limit": {
                 "type": "integer",
-                "description": "Maximum items per category (default: 10, for get_context)",
+                "description": "Max items per category (default 10, get_context).",
                 "default": 10
             }
         },

--- a/crates/vestige-mcp/src/tools/dedup.rs
+++ b/crates/vestige-mcp/src/tools/dedup.rs
@@ -299,44 +299,44 @@ pub fn unified_schema() -> Value {
                 "type": "string",
                 "enum": ["scan", "plan_merge", "plan_supersede", "apply", "undo", "tag_rename", "tag_merge", "protect", "policy"],
                 "default": "scan",
-                "description": "What to do. 'scan' (default): surface duplicate clusters (cosine) AND merge candidates (Fellegi-Sunter), read-only. 'plan_merge'/'plan_supersede': preview a reversible memory plan. 'apply': execute a plan_id. 'undo': reverse a prior memory or tag operation (omit operation_id to list the mixed reflog plus tagOperations). 'tag_rename'/'tag_merge': exact, scoped, preview-token-gated tag maintenance. 'protect': pin a memory. 'policy': get/set Fellegi-Sunter thresholds."
+                "description": "'scan' (default, read-only): duplicate clusters and merge candidates. 'plan_merge' / 'plan_supersede': preview a reversible plan. 'apply': run a plan_id. 'undo': reverse an operation_id, or list the reflog. 'tag_rename' / 'tag_merge': preview-token gated. 'protect': pin a memory. 'policy': thresholds."
             },
             "similarity_threshold": {
                 "type": "number",
-                "description": "[scan] Minimum cosine similarity for duplicate clusters (0.5-1.0, default 0.80).",
+                "description": "[scan] Minimum cosine similarity for clusters (0.5 to 1, default 0.80).",
                 "minimum": 0.5, "maximum": 1.0
             },
             "limit": {
                 "type": "integer",
-                "description": "[scan] Max clusters/candidates to return (default 20).",
+                "description": "[scan] Max clusters and candidates (default 20).",
                 "minimum": 1, "maximum": 100
             },
             "tags": {
                 "type": "array", "items": { "type": "string" },
-                "description": "[scan] Optional: only consider memories with these tags (ANY match)."
+                "description": "[scan] Only memories with any of these tags."
             },
             "member_ids": {
                 "type": "array", "items": { "type": "string" },
-                "description": "[plan_merge] IDs of memories to merge (>= 2). Survivor kept; rest bitemporally invalidated."
+                "description": "[plan_merge] Two or more memory ids; the survivor is kept, the rest invalidated."
             },
-            "survivor_id": { "type": "string", "description": "[plan_merge] Optional: which member to keep (defaults to highest-retention)." },
+            "survivor_id": { "type": "string", "description": "[plan_merge] Member to keep (default: highest retention)." },
             "old_id": { "type": "string", "description": "[plan_supersede] Memory being superseded (kept, marked invalid)." },
-            "new_id": { "type": "string", "description": "[plan_supersede] Memory that supersedes the old one." },
-            "plan_id": { "type": "string", "description": "[apply] ID of a plan produced by plan_merge/plan_supersede." },
-            "confirm": { "type": "boolean", "default": false, "description": "[apply/tag_*] Explicit mutation confirmation. Tag actions always preview when false and require the returned preview_token when true." },
-            "operation_id": { "type": "string", "description": "[undo] Operation to reverse. Omit to list recent merge/supersede operations plus a dedicated tagOperations array that cannot be buried by merge activity." },
+            "new_id": { "type": "string", "description": "[plan_supersede] Memory that supersedes it." },
+            "plan_id": { "type": "string", "description": "[apply] Plan id from plan_merge or plan_supersede." },
+            "confirm": { "type": "boolean", "default": false, "description": "[apply, tag_*] Explicit confirmation. Tag actions preview when false and need preview_token when true." },
+            "operation_id": { "type": "string", "description": "[undo] Operation to reverse. Omit to list recent operations plus tagOperations." },
             "source_tag": { "type": "string", "description": "[tag_rename] Exact source tag to rename." },
-            "source_tags": { "type": "array", "items": { "type": "string" }, "minItems": 2, "maxItems": 50, "description": "[tag_merge] Two or more exact source tags to merge." },
+            "source_tags": { "type": "array", "items": { "type": "string" }, "minItems": 2, "maxItems": 50, "description": "[tag_merge] Two or more exact source tags." },
             "target_tag": { "type": "string", "description": "[tag_rename/tag_merge] Exact destination tag." },
-            "scope": { "type": "string", "default": "user", "description": "[tag_rename/tag_merge] Project scope. Defaults to the isolated 'user' scope." },
-            "all_scopes": { "type": "boolean", "default": false, "description": "[tag_rename/tag_merge] Explicitly operate across every scope. Default false." },
-            "preview_token": { "type": "string", "description": "[tag_rename/tag_merge confirm=true] Token returned by the immediately preceding matching preview." },
-            "reason": { "type": "string", "minLength": 1, "maxLength": 1000, "description": "[tag_rename/tag_merge confirm=true] Required durable audit reason." },
+            "scope": { "type": "string", "default": "user", "description": "[tag_*] Project scope (default 'user')." },
+            "all_scopes": { "type": "boolean", "default": false, "description": "[tag_*] Operate across every scope. Default false." },
+            "preview_token": { "type": "string", "description": "[tag_* confirm=true] Token from the matching preview." },
+            "reason": { "type": "string", "minLength": 1, "maxLength": 1000, "description": "[tag_* confirm=true] Audit reason, required." },
             "id": { "type": "string", "description": "[protect] Memory id to protect/unprotect." },
             "protected": { "type": "boolean", "default": true, "description": "[protect] true to pin, false to unpin." },
             "match_threshold": { "type": "number", "minimum": 0.0, "maximum": 1.0, "description": "[policy] Score >= this => 'match'." },
             "possible_threshold": { "type": "number", "minimum": 0.0, "maximum": 1.0, "description": "[policy] Score in [possible, match) => review." },
-            "auto_apply": { "type": "boolean", "description": "[policy] Allow 'match' plans to apply without confirm. Default false." }
+            "auto_apply": { "type": "boolean", "description": "[policy] Apply 'match' plans without confirm. Default false." }
         }
     })
 }

--- a/crates/vestige-mcp/src/tools/graph_unified.rs
+++ b/crates/vestige-mcp/src/tools/graph_unified.rs
@@ -40,13 +40,13 @@ pub fn schema() -> Value {
                     "recent", "get", "memory", "neighbors",
                     "never_composed", "bounty_mode", "label"
                 ],
-                "description": "Reasoning: 'chain' (from, to), 'associations' (spreading activation from 'from'), 'bridges' (connectors between from and to), 'predict' (next needs, from 'context'), 'memory_graph' (subgraph around 'center_id' or 'query'). Composition topology: 'recent', 'get' (event_id), 'memory' and 'neighbors' (memory_id), 'never_composed', 'bounty_mode', 'label' (record an outcome; the only write)."
+                "description": "Reasoning: 'chain' (from, to), 'associations' (from), 'bridges' (from, to), 'predict' (context), 'memory_graph' (center_id or query). Composition: 'recent', 'get' (event_id), 'memory', 'neighbors' (memory_id), 'never_composed', 'bounty_mode', 'label' (records an outcome; the only write)."
             },
             // --- explore (chain/associations/bridges) ---
             "from": { "type": "string", "description": "[chain/associations/bridges] Source memory ID." },
             "to": { "type": "string", "description": "[chain/bridges] Target memory ID." },
             // --- predict ---
-            "context": { "type": "object", "description": "[predict] Current context (current_file, current_topics, codebase)." },
+            "context": { "type": "object", "description": "[predict] Context: current_file, current_topics, codebase." },
             // --- memory_graph (viz subgraph) ---
             "center_id": { "type": "string", "description": "[memory_graph] Center node id (or use 'query')." },
             "query": { "type": "string", "description": "[memory_graph] Pick a center node by search query." },
@@ -59,10 +59,10 @@ pub fn schema() -> Value {
             "outcome_type": {
                 "type": "string",
                 "enum": OUTCOME_TYPES,
-                "description": "[label] Outcome to record for the composition (the only mutating action)."
+                "description": "[label] Outcome to record (the only write)."
             },
             // --- shared ---
-            "limit": { "type": "integer", "description": "Max results (per-action defaults; clamped internally).", "minimum": 1, "maximum": 100 }
+            "limit": { "type": "integer", "description": "Max results (per-action defaults, clamped).", "minimum": 1, "maximum": 100 }
         },
         "required": ["action"]
     })

--- a/crates/vestige-mcp/src/tools/intention_unified.rs
+++ b/crates/vestige-mcp/src/tools/intention_unified.rs
@@ -24,12 +24,12 @@ use vestige_core::neuroscience::prospective_memory::IntentionTrigger as Prospect
 pub fn schema() -> Value {
     serde_json::json!({
         "type": "object",
-        "description": "Unified intention management tool. Supports setting, checking, updating (complete/snooze/cancel), and listing intentions.",
+        "description": "Prospective memory: set, check, update (complete, snooze, cancel) and list intentions.",
         "properties": {
             "action": {
                 "type": "string",
                 "enum": ["set", "check", "update", "list"],
-                "description": "'set' creates, 'check' finds triggered intentions, 'update' changes status (complete, snooze, cancel), 'list' shows them"
+                "description": "'set' creates, 'check' finds triggered, 'update' changes status, 'list' shows."
             },
             // SET action parameters
             "description": {
@@ -43,7 +43,7 @@ pub fn schema() -> Value {
                     "type": {
                         "type": "string",
                         "enum": ["time", "context", "event"],
-                        "description": "Trigger type: time-based, context-based, or event-based"
+                        "description": "Trigger type: time, context or event."
                     },
                     "at": {
                         "type": "string",
@@ -89,12 +89,12 @@ pub fn schema() -> Value {
             "status": {
                 "type": "string",
                 "enum": ["complete", "snooze", "cancel"],
-                "description": "[update] New status: 'complete' marks as fulfilled, 'snooze' delays, 'cancel' cancels"
+                "description": "[update] 'complete', 'snooze' (delay) or 'cancel'."
             },
             "snooze_minutes": {
                 "type": "integer",
                 "default": 30,
-                "description": "[update] Minutes to snooze for (when status is 'snooze')"
+                "description": "[update] Minutes to snooze."
             },
             // CHECK action parameters
             "context": {

--- a/crates/vestige-mcp/src/tools/maintain.rs
+++ b/crates/vestige-mcp/src/tools/maintain.rs
@@ -35,7 +35,7 @@ pub fn schema() -> Value {
             "action": {
                 "type": "string",
                 "enum": ["consolidate", "dream", "gc", "importance_score", "backup", "export", "restore"],
-                "description": "'consolidate' (decay and embedding cycle), 'dream' (replay into insights and connections), 'gc' (stale memories; dry_run=true by default), 'importance_score' (score 'content'), 'backup', 'export' (JSON or JSONL with filters), 'restore' (JSON backup at 'path')."
+                "description": "'consolidate' (decay and embeddings), 'dream' (replay into insights), 'gc' (stale memories; dry_run default true), 'importance_score' ('content'), 'backup', 'export' (JSON or JSONL), 'restore' ('path')."
             },
             // --- gc ---
             "min_retention": { "type": "number", "minimum": 0.0, "maximum": 1.0, "description": "[gc] Collect memories below this retention (default 0.1)." },

--- a/crates/vestige-mcp/src/tools/memory_status.rs
+++ b/crates/vestige-mcp/src/tools/memory_status.rs
@@ -36,39 +36,39 @@ pub fn schema() -> Value {
                 "type": "string",
                 "enum": ["health", "retention", "timeline", "changelog", "stats"],
                 "default": "health",
-                "description": "'health' (default): system health, stats, decay preview, warnings, recommendations. 'retention': average, distribution, trend. 'timeline': memories by date. 'changelog': state-change audit trail. 'stats': hygiene counts by type, tag, age, retention, and lifecycle, with bounded detail lists and recent tag operations."
+                "description": "'health' (default): health, stats, decay preview, warnings. 'retention': average, distribution, trend. 'timeline': memories by date. 'changelog': state changes. 'stats': hygiene counts by type, tag, age, retention, lifecycle."
             },
             // --- [health view] ---
             "schema_introspection": {
                 "type": "boolean",
-                "description": "[health view] Include the response-schema description in the output."
+                "description": "[health] Include the response-schema description."
             },
             // --- [timeline view] ---
-            "start": { "type": "string", "description": "[timeline/changelog view] Start of range (ISO 8601 date or datetime)." },
-            "end": { "type": "string", "description": "[timeline/changelog view] End of range (ISO 8601 date or datetime)." },
-            "node_type": { "type": "string", "description": "[timeline view] Filter by node type (e.g. 'fact', 'decision')." },
+            "start": { "type": "string", "description": "[timeline, changelog] Range start (ISO 8601)." },
+            "end": { "type": "string", "description": "[timeline, changelog] Range end (ISO 8601)." },
+            "node_type": { "type": "string", "description": "[timeline] Filter by node type." },
             "tags": { "type": "array", "items": { "type": "string" }, "description": "[timeline view] Filter by tags (ANY match)." },
             "detail_level": {
                 "type": "string", "enum": ["brief", "summary", "full"],
-                "description": "[timeline view] Level of detail (default 'summary')."
+                "description": "[timeline] Detail level (default 'summary')."
             },
             // --- [changelog view] ---
-            "memory_id": { "type": "string", "description": "[changelog view] Per-memory mode: state transitions for this memory id." },
+            "memory_id": { "type": "string", "description": "[changelog] State transitions for this memory only." },
             // --- [stats view] ---
             "scope": {
                 "type": "string",
                 "default": "user",
-                "description": "[stats view] Exact normalized memory scope to aggregate (default 'user'). Ignored when all_scopes=true."
+                "description": "[stats] Scope to aggregate (default 'user'); ignored when all_scopes."
             },
             "all_scopes": {
                 "type": "boolean",
                 "default": false,
-                "description": "[stats view] Explicitly aggregate every stored scope. Default false preserves project isolation."
+                "description": "[stats] Aggregate every scope. Default false."
             },
             // --- shared: limit (per-view ranges differ; clamped internally) ---
             "limit": {
                 "type": "integer",
-                "description": "Max results. timeline: default 50, max 200. changelog: default 20, max 100. stats detail lists: default 50, max 200 (aggregate counts always cover the whole store). Ignored by health and retention.",
+                "description": "Max results: timeline 50 (max 200), changelog 20 (max 100), stats lists 50 (max 200). Ignored by health and retention.",
                 "minimum": 1, "maximum": 200
             }
         }

--- a/crates/vestige-mcp/src/tools/memory_unified.rs
+++ b/crates/vestige-mcp/src/tools/memory_unified.rs
@@ -44,29 +44,29 @@ pub fn schema() -> Value {
             "action": {
                 "type": "string",
                 "enum": ["get", "get_batch", "delete", "purge", "state", "promote", "demote", "edit"],
-                "description": "'get' (one node), 'get_batch' (by 'ids'), 'state' (accessibility), 'promote' and 'demote' (adjust retrieval strength; demote never deletes), 'edit' (replace content, keep FSRS state), 'purge' (remove content and embeddings for good; confirm=true). 'delete' is an alias for purge"
+                "description": "'get', 'get_batch' (ids), 'state', 'promote' / 'demote' (retrieval strength; demote never deletes), 'edit' (replace content, keep FSRS state), 'purge' (content and embeddings gone; confirm=true). 'delete' aliases purge"
             },
             "id": {
                 "type": "string",
-                "description": "The ID of the memory node (for single-memory actions)"
+                "description": "Memory id (single-memory actions)."
             },
             "ids": {
                 "type": "array",
                 "items": { "type": "string" },
-                "description": "Array of memory IDs (for get_batch action). Max 20 IDs per call."
+                "description": "[get_batch] Memory ids, max 20."
             },
             "reason": {
                 "type": "string",
-                "description": "Why this memory is being promoted/demoted/purged (optional, for logging)."
+                "description": "Why (optional, logged)."
             },
             "confirm": {
                 "type": "boolean",
-                "description": "Required for 'purge' and 'delete'. Purge removes canonical content and embeddings; legacy audit and sync records keep only opaque markers and limited metadata, so this is not verified machine unlearning.",
+                "description": "Required for purge and delete. Removes canonical content and embeddings; legacy audit and sync rows keep opaque markers, so this is not verified unlearning.",
                 "default": false
             },
             "content": {
                 "type": "string",
-                "description": "New content for edit action. Replaces existing content, regenerates embedding, preserves FSRS state."
+                "description": "[edit] New content; embedding regenerated, FSRS state kept."
             }
         },
         "required": ["action"]

--- a/crates/vestige-mcp/src/tools/receipt.rs
+++ b/crates/vestige-mcp/src/tools/receipt.rs
@@ -26,17 +26,17 @@ pub fn schema() -> Value {
             "action": {
                 "type": "string",
                 "enum": ["get", "replay"],
-                "description": "'get': one persisted receipt with its safe replay-capsule summary. 'replay': withhold named evidence slots from the frozen final context without rerunning retrieval."
+                "description": "'get': one receipt with its replay-capsule summary. 'replay': withhold named evidence slots from the frozen context without rerunning retrieval."
             },
             "receipt_id": {
                 "type": "string",
-                "description": "Source receipt id. For replay this must be a retrieval receipt that has a frozen replay capsule."
+                "description": "Receipt id; replay needs a retrieval receipt with a frozen capsule."
             },
             "withheld_slots": {
                 "type": "array",
                 "items": { "type": "string", "pattern": "^evidence_[1-9][0-9]*$" },
                 "uniqueItems": true,
-                "description": "[replay] Receipt-local slots to remove from the frozen final context. Search is never rerun and removed candidates are never backfilled."
+                "description": "[replay] Slots to remove from the frozen context; search is never rerun."
             }
         },
         "required": ["action", "receipt_id"],

--- a/crates/vestige-mcp/src/tools/search_unified.rs
+++ b/crates/vestige-mcp/src/tools/search_unified.rs
@@ -44,110 +44,110 @@ pub fn schema() -> Value {
             },
             "min_retention": {
                 "type": "number",
-                "description": "Minimum retention strength (0.0-1.0, default: 0.0)",
+                "description": "Minimum retention strength, 0 to 1 (default 0).",
                 "default": 0.0,
                 "minimum": 0.0,
                 "maximum": 1.0
             },
             "min_similarity": {
                 "type": "number",
-                "description": "Minimum similarity threshold (0.0-1.0, default: 0.5)",
+                "description": "Minimum similarity, 0 to 1 (default 0.5).",
                 "default": 0.5,
                 "minimum": 0.0,
                 "maximum": 1.0
             },
             "detail_level": {
                 "type": "string",
-                "description": "'brief': id, type, tags, score. 'summary' (default): the 8-field response. 'full': every field, including FSRS state and timestamps.",
+                "description": "'brief': id, type, tags, score. 'summary' (default): 8 fields. 'full': everything, including FSRS state.",
                 "enum": ["brief", "summary", "full"],
                 "default": "summary"
             },
             "context_topics": {
                 "type": "array",
                 "items": { "type": "string" },
-                "description": "Optional topics for context-dependent retrieval boosting"
+                "description": "Topics that boost context-dependent retrieval."
             },
             "exclude_types": {
                 "type": "array",
                 "items": { "type": "string" },
-                "description": "Node types to exclude. Reflections are excluded by default so they do not pollute factual queries."
+                "description": "Node types to exclude (reflections are excluded by default)."
             },
             "include_types": {
                 "type": "array",
                 "items": { "type": "string" },
-                "description": "If set, only return nodes of these types. Overrides exclude_types."
+                "description": "Only these node types; overrides exclude_types."
             },
             "token_budget": {
                 "type": "integer",
-                "description": "Max tokens for the response; content is truncated to fit. Fetch full content by id with memory(action='get').",
+                "description": "Max response tokens; content is truncated to fit. memory(action='get') has the full text.",
                 "minimum": 100,
                 "maximum": 100000
             },
             "retrieval_mode": {
                 "type": "string",
-                "description": "'precise': top results only, skips activation and competition. 'balanced' (default): the full cognitive pipeline. 'exhaustive': 5x overfetch, deep graph traversal, no competition.",
+                "description": "'precise': top hits, no activation or competition. 'balanced' (default): full pipeline. 'exhaustive': 5x overfetch, deep traversal.",
                 "enum": ["precise", "balanced", "exhaustive"],
                 "default": "balanced"
             },
             "concrete": {
                 "type": "boolean",
-                "description": "Literal search: no semantic expansion, reweighting, activation, or side effects. Auto-enabled for quoted strings, env vars, UUIDs, paths, and code identifiers.",
+                "description": "Literal search, no semantic expansion or side effects. Auto-on for quoted strings, env vars, UUIDs, paths, identifiers.",
                 "default": false
             },
             "rank_native_fusion": {
                 "type": "boolean",
-                "description": "Experimental: fuse the post-retrieval stages as ranked lists (weighted RRF) instead of score multipliers. Default off.",
+                "description": "Experimental: fuse post-retrieval stages by weighted RRF instead of multipliers.",
                 "default": false
             },
             "tag_prefix": {
                 "type": "string",
-                "description": "Keep only results with a tag starting with this prefix (case-insensitive), e.g. 'meeting:' matches 'meeting:standup'. Post-filter; raise 'limit' if it thins results heavily."
+                "description": "Only results with a tag starting with this prefix (case-insensitive). Post-filter; raise 'limit' if it thins results."
             },
             "scope": {
                 "type": "string",
-                "description": "Project namespace. Defaults to 'user', so project memories never bleed into an unscoped recall."
+                "description": "Project namespace (default 'user'); project memories never bleed into an unscoped recall."
             },
             "includeCrossScope": {
                 "type": "boolean",
-                "description": "Search across all project namespaces. Defaults to false; set only when cross-project retrieval is intentional.",
+                "description": "Search every project namespace. Only when cross-project retrieval is intended.",
                 "default": false
             },
             "validAt": {
                 "type": "string",
-                "description": "Only facts valid at this time: 'now', RFC3339, or YYYY-MM-DD. When omitted, expired and future facts stay auditable but are downranked."
+                "description": "Only facts valid at this time ('now', RFC3339, YYYY-MM-DD). Omitted: expired and future facts are downranked, not hidden."
             },
             "source_system": {
                 "type": "string",
-                "description": "Only memories ingested from this external system, e.g. 'github' or 'redmine'. Post-filter; raise 'limit' if it thins results heavily."
+                "description": "Only memories ingested from this external system ('github', 'redmine'). Post-filter."
             },
             "source_project": {
                 "type": "string",
-                "description": "Only memories from this source project or repo, exact match (GitHub 'owner/repo', Redmine project id)."
+                "description": "Only this source project or repo, exact match."
             },
             "source_id": {
                 "type": "string",
-                "description": "Only this source record id (issue number or ticket id). Pair with source_system."
+                "description": "Only this source record id; pair with source_system."
             },
             "source_type": {
                 "type": "string",
-                "description": "Investigation filter: source record type, e.g. 'issue', 'comment'."
+                "description": "Source record type, e.g. 'issue', 'comment'."
             },
             "source_author": {
                 "type": "string",
-                "description": "Investigation filter: the source author/reporter (not assignee)."
+                "description": "Source author or reporter (not assignee)."
             },
             "source_updated_after": {
                 "type": "string",
-                "description": "Investigation filter: only records whose source was updated at/after this RFC3339 timestamp (inclusive)."
+                "description": "Source updated at or after this RFC3339 time."
             },
             "source_updated_before": {
                 "type": "string",
-                "description": "Investigation filter: only records whose source was updated at/before this RFC3339 timestamp (inclusive)."
+                "description": "Source updated at or before this RFC3339 time."
             },
             "source_status": {
                 "type": "string",
                 "enum": ["any", "valid", "tombstoned"],
-                "description": "'any' (default), 'valid' (currently visible upstream), or 'tombstoned' (removed upstream, kept for audit).",
+                "description": "'any' (default), 'valid' (visible upstream), 'tombstoned' (removed upstream, kept for audit).",
                 "default": "any"
             }
         },

--- a/crates/vestige-mcp/src/tools/session_context.rs
+++ b/crates/vestige-mcp/src/tools/session_context.rs
@@ -27,7 +27,7 @@ pub fn schema() -> Value {
             },
             "token_budget": {
                 "type": "integer",
-                "description": "Max tokens for response (default: 1000). Server truncates content to fit budget. With 1M context models, budgets up to 100K are practical.",
+                "description": "Max response tokens (default 1000); content is truncated to fit.",
                 "default": 1000,
                 "minimum": 100,
                 "maximum": 100000

--- a/crates/vestige-mcp/src/tools/smart_ingest.rs
+++ b/crates/vestige-mcp/src/tools/smart_ingest.rs
@@ -39,17 +39,17 @@ pub fn schema() -> Value {
         "properties": {
             "content": {
                 "type": "string",
-                "description": "The content to remember. Will be compared against existing memories. (Single mode)"
+                "description": "What to remember; compared against existing memories (single mode)."
             },
             "node_type": {
                 "type": "string",
-                "description": "fact, concept, event, person, place, note, pattern, decision, or state. 'state' is a snapshot that rots (versions, progress, inventories): without validUntil it expires after VESTIGE_STATE_TTL_DAYS (default 30), then is downranked and marked currentlyValid=false, still auditable via validAt.",
+                "description": "fact, concept, event, person, place, note, pattern, decision, or state. 'state' snapshots expire after VESTIGE_STATE_TTL_DAYS (default 30) unless validUntil is set, then rank last with currentlyValid=false.",
                 "default": "fact"
             },
             "tags": {
                 "type": "array",
                 "items": { "type": "string" },
-                "description": "Tags for categorization. The response non-destructively suggests close existing tags in the same scope; suggestions are never auto-applied."
+                "description": "Tags. Close existing same-scope tags come back as suggestions, never auto-applied."
             },
             "source": {
                 "type": "string",
@@ -57,98 +57,87 @@ pub fn schema() -> Value {
             },
             "scope": {
                 "type": "string",
-                "description": "Project namespace for this memory. Defaults to 'user' for backward compatibility. Recall searches this namespace unless includeCrossScope=true."
+                "description": "Project namespace (default 'user'). Recall searches it unless includeCrossScope=true."
             },
             "validFrom": {
                 "type": "string",
-                "description": "When the fact becomes true (RFC3339 or YYYY-MM-DD). If omitted, one unambiguous 'as of YYYY-MM-DD' phrase in content is inferred and reported."
+                "description": "When the fact becomes true (RFC3339 or YYYY-MM-DD). Omitted: one unambiguous 'as of DATE' phrase is inferred."
             },
             "validUntil": {
                 "type": "string",
-                "description": "When this fact stops being true. Use RFC3339 or an exact YYYY-MM-DD date; must be after validFrom."
+                "description": "When the fact stops being true (RFC3339 or YYYY-MM-DD, after validFrom)."
             },
             "forceCreate": {
                 "type": "boolean",
-                "description": "Force creation of a new memory even if similar content exists",
+                "description": "Create even if similar content exists.",
                 "default": false
             },
             "allowSecrets": {
                 "type": "boolean",
-                "description": "Allow a detected credential to be stored for this single item. Dangerous: normally redact the value or store a secret-manager reference instead.",
+                "description": "Store a detected credential for this item. Dangerous; redact or store a reference instead.",
                 "default": false
             },
             "previewTagSuggestions": {
                 "type": "boolean",
-                "description": "Read-only preflight. Returns same-scope similar-tag suggestions and inferred validity without storing anything.",
+                "description": "Read-only preflight: tag suggestions and inferred validity, nothing stored.",
                 "default": false
             },
             "acceptedTagSuggestions": {
                 "type": "object",
                 "additionalProperties": { "type": "string" },
-                "description": "Accepted input-tag to existing-tag mappings from a preflight response, revalidated against current same-scope suggestions before ingest."
+                "description": "Accepted input-tag to existing-tag mappings from a preflight; revalidated before ingest."
             },
             "batchMergePolicy": {
                 "type": "string",
                 "enum": ["force_create", "smart"],
-                "description": "Batch only. 'force_create' (default) keeps caller-separated items separate; 'smart' allows Prediction Error Gating against existing memories.",
+                "description": "Batch only. 'force_create' (default) keeps items separate; 'smart' lets the gate merge.",
                 "default": "force_create"
             },
             "items": {
                 "type": "array",
-                "description": "Batch mode: up to 20 items to save, each force-created unless batchMergePolicy='smart'. Use at session end or before context compaction.",
+                "description": "Batch: up to 20 items with the same fields as single mode, each force-created unless batchMergePolicy='smart'. For session end or before compaction.",
                 "maxItems": 20,
                 "items": {
                     "type": "object",
                     "properties": {
                         "content": {
-                            "type": "string",
-                            "description": "The content to remember"
+                            "type": "string"
                         },
                         "tags": {
                             "type": "array",
-                            "items": { "type": "string" },
-                            "description": "Tags for categorization. Similar existing same-scope tags are returned as non-mutating suggestions."
+                            "items": { "type": "string" }
                         },
                         "node_type": {
                             "type": "string",
-                            "description": "Type: fact, concept, event, person, place, note, pattern, decision",
                             "default": "fact"
                         },
                         "source": {
-                            "type": "string",
-                            "description": "Source reference"
+                            "type": "string"
                         },
                         "scope": {
-                            "type": "string",
-                            "description": "Project namespace for this item. Overrides the batch scope when supplied."
+                            "type": "string"
                         },
                         "validFrom": {
-                            "type": "string",
-                            "description": "When this item becomes true (RFC3339 or YYYY-MM-DD). If omitted, one unambiguous 'as of YYYY-MM-DD' phrase is inferred."
+                            "type": "string"
                         },
                         "validUntil": {
-                            "type": "string",
-                            "description": "When this item stops being true (RFC3339 or YYYY-MM-DD; after validFrom)."
+                            "type": "string"
                         },
                         "forceCreate": {
                             "type": "boolean",
-                            "description": "Force creation of this item even if similar content exists",
                             "default": false
                         },
                         "allowSecrets": {
                             "type": "boolean",
-                            "description": "Allow a detected credential for this item only. Defaults to false; do not use for ordinary session summaries.",
                             "default": false
                         },
                         "previewTagSuggestions": {
                             "type": "boolean",
-                            "description": "Read-only per-item tag/validity preflight; this item is not stored.",
                             "default": false
                         },
                         "acceptedTagSuggestions": {
                             "type": "object",
-                            "additionalProperties": { "type": "string" },
-                            "description": "Explicitly accepted tag mappings from a prior preflight."
+                            "additionalProperties": { "type": "string" }
                         }
                     },
                     "required": ["content"]

--- a/crates/vestige-mcp/src/tools/source_sync.rs
+++ b/crates/vestige-mcp/src/tools/source_sync.rs
@@ -34,25 +34,25 @@ pub fn schema() -> Value {
             "source": {
                 "type": "string",
                 "enum": ["github", "redmine"],
-                "description": "External system to sync: 'github' (GitHub Issues) or 'redmine' (a Redmine project).",
+                "description": "'github' (issues) or 'redmine' (a project).",
                 "default": "github"
             },
             "repo": {
                 "type": "string",
-                "description": "GitHub only: repository as 'owner/name', e.g. 'samvallad33/vestige'."
+                "description": "GitHub: repository as 'owner/name'."
             },
             "project": {
                 "type": "string",
-                "description": "Redmine only: project identifier (slug or numeric id) to sync. The Redmine host comes from the REDMINE_URL env var."
+                "description": "Redmine: project slug or id. Host from REDMINE_URL."
             },
             "reconcile": {
                 "type": "boolean",
-                "description": "Also tombstone local memories for issues no longer visible upstream (an extra full enumeration pass). Default false on incremental syncs.",
+                "description": "Also tombstone local memories for issues gone upstream (full enumeration). Default false.",
                 "default": false
             },
             "max_pages": {
                 "type": "integer",
-                "description": "Max API pages to fetch this run (each page is up to 100 issues). Lets a first sync of a large project be resumed across calls. Default 10.",
+                "description": "Max API pages per run (100 issues each); resume a large first sync across calls. Default 10.",
                 "default": 10,
                 "minimum": 1,
                 "maximum": 1000

--- a/crates/vestige-mcp/src/tools/suppress.rs
+++ b/crates/vestige-mcp/src/tools/suppress.rs
@@ -25,7 +25,7 @@ use vestige_core::neuroscience::active_forgetting::{ActiveForgettingSystem, DEFA
 pub fn schema() -> Value {
     json!({
         "type": "object",
-        "description": "Top-down suppression (Anderson 2025 SIF, Davis Rac1): the memory persists but is inhibited from retrieval and decays faster. Each call compounds. A background worker spreads accelerated decay to co-activated neighbours over 72 hours. Reversible within 24 hours via reverse=true.",
+        "description": "Top-down suppression (Anderson 2025, Davis Rac1): the memory persists but is inhibited and decays faster; each call compounds; neighbours decay over 72 hours. Reversible within 24 hours via reverse=true.",
         "properties": {
             "id": {
                 "type": "string",
@@ -33,12 +33,12 @@ pub fn schema() -> Value {
             },
             "reason": {
                 "type": "string",
-                "description": "Optional free-form note explaining why this memory is being suppressed. Logged for audit."
+                "description": "Optional note on why; logged."
             },
             "reverse": {
                 "type": "boolean",
                 "default": false,
-                "description": "If true, reverse a previous suppression. Only works within the 24-hour labile window."
+                "description": "Reverse a previous suppression (within the 24-hour window)."
             }
         },
         "required": ["id"]

--- a/crates/vestige-mcp/tests/e2e_real_binary.rs
+++ b/crates/vestige-mcp/tests/e2e_real_binary.rs
@@ -762,6 +762,15 @@ fn tools_list_is_deterministic_across_restarts_and_carries_cache_hints() {
         "recall lost its result-size annotation: {recall}"
     );
 
+    // Every client pays this payload on every session start. Measured at
+    // 38,474 bytes before the description work, 28,731 after it; the ceiling
+    // stops it creeping back without anyone noticing. Raise it deliberately.
+    let bytes = serde_json::to_string(&a).unwrap().len();
+    assert!(
+        bytes <= 30_000,
+        "tools/list is {bytes} bytes, over the 30,000 byte ceiling; a schema or description grew"
+    );
+
     // Behaviour hints reach the client in MCP's camelCase shape, and the two
     // hints a client acts on (read-only, destructive) are set for every tool.
     for tool in a["tools"].as_array().unwrap() {


### PR DESCRIPTION
## Summary

Part of #212. Every MCP client receives `tools/list` at every session start, before the agent has said a word.

- 126 schema and tool descriptions rewritten to say the same thing in fewer words. Meaning preserved; examples and rationale dropped; enum values are already listed by the schema so the prose stops repeating them.
- The `smart_ingest` batch item schema mirrors the single-mode fields; it no longer repeats their descriptions (the `items` description says so).
- The two recall lines that #233 edits are left alone so the branches do not collide.
- The e2e `tools_list` test pins a 30,000 byte ceiling with the before and after numbers in its comment.

| Measurement (compact JSON, built binary) | bytes |
|---|---|
| before 2.8.0 | 38,474 |
| 2.8.0 (#209) | 35,019 |
| this PR | 28,731 |

**Why not 20 KB.** Property descriptions were 15.2 KB and are now about 10 KB; the rest of the payload is structure: 29 recall properties with enums, defaults and bounds, 23 for dedup, nested trigger and context objects for intention. Nesting the investigation filters under one object, as #212 proposed, moves bytes without removing them (measured). Reaching 20 KB means fewer parameters, for example a separate tool for the connector investigation filters, which is a surface change to decide on its own. The issue stays open with these numbers.

## Gates

| Gate | Result |
|---|---|
| `cargo build -p vestige-mcp` and a real `tools/list` call | 28,731 bytes |
| e2e `tools_list_is_deterministic_across_restarts_and_carries_cache_hints` | see CI (the ceiling assertion lives there) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)