### PR TITLE
feat(mcp): purge is its own tool, flagged for user interaction (#219, part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `purge` is its own tool
+
+- The one irreversible call used to sit inside `memory`, which is mostly reads,
+  so a client could not treat it differently. `purge` is now advertised on its
+  own with `destructiveHint: true` and `_meta["anthropic/requiresUserInteraction"]`,
+  which Claude Code honours with a prompt on every call, even under bypass
+  permissions. It runs the same code path as `memory(action='purge')`: the same
+  pre-execution review gate, the same content-free tombstone. `memory(action='purge')`
+  keeps working for one release; the unit test pins that `purge` is the only
+  tool with the interaction flag.
+
 ### Fixed — CI
 
 - The Observatory privacy test built file paths from `import.meta.url` with

--- a/crates/vestige-mcp/src/server.rs
+++ b/crates/vestige-mcp/src/server.rs
@@ -419,6 +419,26 @@ description: Some("Manage one memory. Actions: 'get', 'get_batch' (ids), 'state'
                 input_schema: tools::memory_unified::schema(),
                 ..Default::default()
             },
+            // ================================================================
+            // PURGE: the one irreversible call, on its own so a client can
+            // gate it without gating the reads that share `memory`. Claude
+            // Code honours `anthropic/requiresUserInteraction` with a prompt
+            // on every call, even under bypass. memory(action='purge') keeps
+            // working for one release.
+            // ================================================================
+            ToolDescription {
+                name: "purge".to_string(),
+                title: Some("Purge".to_string()),
+                annotations: Some(ToolAnnotations {
+                    read_only_hint: false,
+                    destructive_hint: true,
+                    idempotent_hint: false,
+                    open_world_hint: false,
+                }),
+                description: Some("Remove one memory's content and embeddings for good. Irreversible: confirm=true is required and the client asks before running it. Legacy audit and sync rows keep opaque markers, so this is not verified unlearning. Same path and review gate as memory(action='purge').".to_string()),
+                input_schema: tools::memory_unified::purge_schema(),
+                meta: Some(serde_json::json!({ "anthropic/requiresUserInteraction": true })),
+            },
             ToolDescription {
                 name: "codebase".to_string(),
                 title: Some("Codebase".to_string()),
@@ -832,6 +852,14 @@ description: Some("Memory with hindsight. After a failure is recorded, reach bac
             "memory" => {
                 tools::memory_unified::execute(&self.storage, &self.cognitive, request.arguments)
                     .await
+            }
+            "purge" => {
+                tools::memory_unified::execute_purge_tool(
+                    &self.storage,
+                    &self.cognitive,
+                    request.arguments,
+                )
+                .await
             }
             "codebase" => {
                 tools::codebase_unified::execute(
@@ -1935,13 +1963,15 @@ description: Some("Memory with hindsight. After a failure is recorded, reach bac
             }
 
             // -- memory: get/delete/promote/demote --
-            "memory" | "promote_memory" | "demote_memory" | "delete_knowledge"
+            "memory" | "purge" | "promote_memory" | "demote_memory" | "delete_knowledge"
             | "get_memory_state" => {
                 let action = args
                     .as_ref()
                     .and_then(|a| a.get("action"))
                     .and_then(|a| a.as_str())
-                    .unwrap_or(if tool_name == "promote_memory" {
+                    .unwrap_or(if tool_name == "purge" {
+                        "purge"
+                    } else if tool_name == "promote_memory" {
                         "promote"
                     } else if tool_name == "demote_memory" {
                         "demote"
@@ -2987,7 +3017,7 @@ mod tests {
         // dispatchable as hidden back-compat aliases but drop off the advertised list.
         assert_eq!(
             tools.len(),
-            14,
+            15,
             "Expected exactly 14 tools after v2.3 receipt replay integration \
              (12 consolidated: dedup + memory_status + graph + maintain + recall; \
              session_context renamed) plus `receipt` and the flagship `backfill`"
@@ -3036,7 +3066,17 @@ mod tests {
             read_only,
             ["memory_status", "recall", "receipt", "session_start"]
         );
-        assert_eq!(destructive, ["dedup", "intention", "maintain", "memory"]);
+        assert_eq!(
+            destructive,
+            ["dedup", "intention", "maintain", "memory", "purge"]
+        );
+        // The one irreversible call asks the user first, and only it does.
+        let interactive: Vec<&str> = tools
+            .iter()
+            .filter(|t| t["_meta"]["anthropic/requiresUserInteraction"] == true)
+            .map(|t| t["name"].as_str().unwrap())
+            .collect();
+        assert_eq!(interactive, ["purge"]);
         assert_eq!(
             open_world,
             ["source_sync"],

--- a/crates/vestige-mcp/src/tools/memory_unified.rs
+++ b/crates/vestige-mcp/src/tools/memory_unified.rs
@@ -73,6 +73,42 @@ pub fn schema() -> Value {
     })
 }
 
+/// Input schema for the standalone `purge` tool: the fields of
+/// `memory(action='purge')` without the action, so a client can gate the one
+/// irreversible call without gating the reads that share `memory`.
+pub fn purge_schema() -> Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "id": { "type": "string", "description": "Memory id to purge." },
+            "confirm": {
+                "type": "boolean",
+                "default": false,
+                "description": "Must be true. Removes canonical content and embeddings for good; legacy audit and sync rows keep opaque markers, so this is not verified unlearning."
+            },
+            "reason": { "type": "string", "description": "Why (optional, logged)." }
+        },
+        "required": ["id", "confirm"]
+    })
+}
+
+/// `purge` as its own tool: the same code path as `memory(action='purge')`,
+/// including the review gate and the content-free tombstone.
+pub async fn execute_purge_tool(
+    storage: &Arc<Storage>,
+    cognitive: &Arc<Mutex<CognitiveEngine>>,
+    args: Option<Value>,
+) -> Result<Value, String> {
+    let mut args = args.unwrap_or_else(|| serde_json::json!({}));
+    match args.as_object_mut() {
+        Some(object) => {
+            object.insert("action".to_string(), serde_json::json!("purge"));
+        }
+        None => return Err("Invalid arguments: expected an object".to_string()),
+    }
+    execute(storage, cognitive, Some(args)).await
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct MemoryArgs {

--- a/crates/vestige-mcp/src/trace_recorder.rs
+++ b/crates/vestige-mcp/src/trace_recorder.rs
@@ -57,7 +57,7 @@ const RECEIPT_ATTESTATION_ALGORITHM_V1: &str = "mcp-retrieval-receipt-v1";
 fn is_write_tool(tool: &str) -> bool {
     matches!(
         tool,
-        "smart_ingest" | "ingest" | "session_checkpoint" | "memory" | "codebase"
+        "smart_ingest" | "ingest" | "session_checkpoint" | "memory" | "purge" | "codebase"
     )
 }
 
@@ -467,6 +467,25 @@ fn pending_memory_mutation(
             }
             Some(PendingMemoryMutation {
                 action,
+                id: args.get("id")?.as_str()?.to_string(),
+                reason: args
+                    .get("reason")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string),
+            })
+        }
+        // The standalone tool is `memory(action='purge')` under another name;
+        // it meets the same pre-execution gate.
+        "purge" => {
+            if !args
+                .get("confirm")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                return None;
+            }
+            Some(PendingMemoryMutation {
+                action: "purge".to_string(),
                 id: args.get("id")?.as_str()?.to_string(),
                 reason: args
                     .get("reason")
@@ -2628,6 +2647,7 @@ mod tests {
     #[test]
     fn write_tool_set_includes_codebase_b2() {
         assert!(is_write_tool("codebase"));
+        assert!(is_write_tool("purge"));
         assert!(is_write_tool("memory"));
         assert!(!is_write_tool("search"));
         assert!(!is_write_tool("deep_reference"));

--- a/crates/vestige-mcp/tests/e2e_real_binary.rs
+++ b/crates/vestige-mcp/tests/e2e_real_binary.rs
@@ -1607,6 +1607,48 @@ fn approved_purge_removes_content_and_leaves_a_content_free_tombstone() {
     assert_store_is_healthy(dir.path());
 }
 
+/// `purge` as its own tool: the one irreversible call carries its own
+/// annotations and `requiresUserInteraction`, so a client can gate it without
+/// gating the reads that share the `memory` tool. Same code path, same gate,
+/// same content-free tombstone.
+#[test]
+fn standalone_purge_tool_needs_confirm_and_takes_the_same_path() {
+    let dir = data_dir();
+    disable_review_gate(dir.path());
+    let mut server = Server::spawn(dir.path());
+    server.handshake();
+
+    let subject = server.ingest_keyword_only(
+        "Purge target: the badge number for the Oslo contractor",
+        &["hr"],
+    );
+    let refused = server.call_tool("purge", json!({ "id": &subject }));
+    assert!(
+        refused["error"].as_str().is_some_and(|e| e.contains("confirm")),
+        "purge without confirm must refuse and say so: {refused}"
+    );
+    assert!(server.memory_found(&subject), "a refused purge must change nothing");
+
+    let purged = server.call_tool_ok(
+        "purge",
+        json!({ "id": &subject, "confirm": true, "reason": "contractor offboarded" }),
+    );
+    assert_eq!(purged["action"], json!("purge"));
+    assert_eq!(purged["success"], json!(true), "{purged}");
+    assert!(!server.memory_found(&subject), "purged memory is still readable");
+
+    let list = server.result("tools/list", None);
+    let purge = list["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t["name"] == json!("purge"))
+        .expect("purge is advertised");
+    assert_eq!(purge["_meta"]["anthropic/requiresUserInteraction"], json!(true));
+    assert_eq!(purge["annotations"]["destructiveHint"], json!(true));
+    server.shutdown();
+}
+
 /// Suppression must persist and compound across a restart.
 ///
 /// Active forgetting is not deletion: the memory stays, inhibited. Catches the


### PR DESCRIPTION
## Summary

First half of #219. The one irreversible call lived inside `memory`, a tool that is mostly reads, so a client could not treat it differently from `get`.

- **`purge` is its own advertised tool** with `destructiveHint: true` and `_meta["anthropic/requiresUserInteraction"]: true`, which Claude Code honours with a permission prompt on every call, even under bypass permissions. Schema: `id`, `confirm` (required), `reason`.
- **Same path, same gate.** It injects `action: "purge"` and runs the memory tool, so the pre-execution review gate (`gate_pending_memory_mutation`), the content-free tombstone and the `MemoryDeleted` event are identical. `is_write_tool` and `pending_memory_mutation` know the new name.
- `memory(action='purge')` keeps working for one release.
- Unit test pins that `purge` is the only tool with the interaction flag and is in the destructive set; an e2e test drives the new tool over stdio (refuses without confirm, tombstones with it, advertised with the flag).

`outputSchema`, the other half of #219, is deferred: on the four hot tools it would add about 1.5 KB to `tools/list`, which #237 just pinned under 30,000 bytes; it needs its own byte budget decision.

## Gates

| Gate | Result |
|---|---|
| `cargo test -p vestige-mcp --lib tools_list`, `is_write_tool`, `purge` | tools_list pins 15 tools, the destructive set and the single interaction flag; 8 purge tests pass including the pre-gate on the real MCP path |
| `cargo clippy -p vestige-mcp --all-targets -- -D warnings` | clean |
| e2e `standalone_purge_tool...`, existing purge tests, `tools_list_is_deterministic...` | 4 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
