### PR TITLE
feat(mcp): first run announces its warm-up as MCP logging; responses say when the runtime is not ready (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — First run says what it is doing
+
+- A fresh install downloads about 130 MB of embedding model and about 150 MB
+  of reranker before the first answer, with progress only on stderr, which
+  stdio clients hide; the first minute read as a hang. The server now declares
+  the MCP `logging` capability and sends `notifications/message` from the
+  warm-up tasks: `model_download_started` (with the size) or `model_loading`,
+  `embedding_runtime_ready` or `embedding_runtime_unavailable`, and the same
+  for the reranker. `logging/setLevel` is accepted. Until the runtime is
+  ready, `recall` responses and vector-less `smart_ingest` responses carry a
+  `warming` block that names the effect (keyword-only retrieval, saves without
+  a vector until back-filled) and where to check readiness, so the agent can
+  tell the user instead of guessing. fastembed exposes no download progress
+  callback, so there is no byte-level progress; the notifications bracket the
+  download honestly.
+
 ### Fixed — CI
 
 - The Observatory privacy test built file paths from `import.meta.url` with

--- a/crates/vestige-core/src/embeddings/local.rs
+++ b/crates/vestige-core/src/embeddings/local.rs
@@ -69,6 +69,21 @@ impl EmbeddingBackend {
     }
 }
 
+/// Whether the local model cache already holds anything, so a caller can tell
+/// "loading a cached model" from "first run, downloading about 130 MB" before
+/// the download starts. Pure on the directory so it can be tested without
+/// touching the process environment.
+pub fn cache_populated(dir: &std::path::Path) -> bool {
+    std::fs::read_dir(dir)
+        .map(|mut entries| entries.next().is_some())
+        .unwrap_or(false)
+}
+
+/// [`cache_populated`] for the cache directory this process will use.
+pub fn embedding_model_cached() -> bool {
+    cache_populated(&get_cache_dir())
+}
+
 /// Get the default cache directory for fastembed models.
 ///
 /// Resolution order:
@@ -580,5 +595,17 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].0, 0); // First candidate should be most similar
         assert!((results[0].1 - 1.0).abs() < 0.0001);
+    }
+}
+
+#[cfg(test)]
+mod cache_tests {
+    #[test]
+    fn cache_populated_tells_a_fresh_cache_from_a_used_one() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!super::cache_populated(dir.path()));
+        assert!(!super::cache_populated(&dir.path().join("does-not-exist")));
+        std::fs::create_dir(dir.path().join("models--nomic-ai--nomic-embed-text-v1.5")).unwrap();
+        assert!(super::cache_populated(dir.path()));
     }
 }

--- a/crates/vestige-core/src/embeddings/mod.rs
+++ b/crates/vestige-core/src/embeddings/mod.rs
@@ -29,6 +29,7 @@ pub use crate::embedding::{
 
 #[cfg(feature = "vector-search")]
 pub(crate) use local::get_cache_dir;
+pub use local::{cache_populated, embedding_model_cached};
 pub use local::{
     BATCH_SIZE, EMBEDDING_DIMENSIONS, Embedding, EmbeddingError, EmbeddingService, MAX_TEXT_LENGTH,
     cosine_similarity, dot_product, euclidean_distance, matryoshka_truncate,

--- a/crates/vestige-mcp/src/main.rs
+++ b/crates/vestige-mcp/src/main.rs
@@ -44,7 +44,7 @@ use tracing_subscriber::EnvFilter;
 // Use vestige-core for the cognitive science engine
 use vestige_core::Storage;
 
-use protocol::stdio::StdioTransport;
+use protocol::stdio::{Notifier, StdioTransport};
 use server::McpServer;
 
 const DATA_DIR_ENV: &str = "VESTIGE_DATA_DIR";
@@ -317,15 +317,46 @@ async fn main() {
     // finish their stdio handshake before a first-run model download. Optional
     // profiles reject this compatibility path: their artifact verification,
     // evaluation, migration, and activation remain explicit local operations.
+    // The stdio transport and the notifier that lets background work tell the
+    // client what it is doing. Created before the warm-up tasks so a first-run
+    // model download can announce itself as MCP logging instead of dying on
+    // stderr, which stdio clients hide.
+    let (transport, notifier) = StdioTransport::with_notifications();
+    // In builds without an embedding runtime nothing warms up, so the notifier
+    // has no sender beyond this scope; dropping it parks the channel.
+    let _notifier: Notifier = notifier.clone();
+
     #[cfg(feature = "embeddings")]
     {
         let storage_clone = Arc::clone(&storage);
+        let notifier = notifier.clone();
         tokio::task::spawn_blocking(move || {
+            let first_run = !vestige_core::embeddings::embedding_model_cached();
+            notifier.log(
+                "info",
+                "vestige.embeddings",
+                serde_json::json!({
+                    "event": if first_run { "model_download_started" } else { "model_loading" },
+                    "model": "nomic-ai/nomic-embed-text-v1.5",
+                    "approxBytes": if first_run { Some(130_000_000u64) } else { None },
+                    "effect": "recall answers by keyword and smart_ingest stores without a vector until the runtime is ready; those responses carry a `warming` block meanwhile",
+                }),
+            );
             if let Err(error) = storage_clone.init_embeddings() {
                 tracing::debug!(%error, "No legacy Nomic embedding runtime started");
+                notifier.log(
+                    "warning",
+                    "vestige.embeddings",
+                    serde_json::json!({ "event": "embedding_runtime_unavailable", "error": error.to_string() }),
+                );
                 return;
             }
             info!("Legacy Nomic embedding service initialized successfully");
+            notifier.log(
+                "info",
+                "vestige.embeddings",
+                serde_json::json!({ "event": "embedding_runtime_ready" }),
+            );
 
             #[cfg(feature = "vector-search")]
             match storage_clone.generate_embeddings(None, false) {
@@ -574,9 +605,18 @@ async fn main() {
     #[cfg(all(feature = "vector-search", feature = "embeddings"))]
     {
         let cog_clone = Arc::clone(&cognitive);
+        let notifier = notifier.clone();
         tokio::spawn(async move {
             // Small delay so we don't block the stdio handshake
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            notifier.log(
+                "info",
+                "vestige.reranker",
+                serde_json::json!({
+                    "event": "reranker_loading",
+                    "note": "a first run downloads about 150 MB; recall ranks by BM25 until it is ready",
+                }),
+            );
             // The model load is synchronous and downloads ~150MB on a fresh
             // install. Doing it under the CognitiveEngine mutex stalled every
             // tool that shares that lock (explore, predict, session_context,
@@ -592,9 +632,18 @@ async fn main() {
                 Ok(Some(model)) => {
                     let mut cog = cog_clone.lock().await;
                     cog.reranker.install_cross_encoder(model);
+                    notifier.log(
+                        "info",
+                        "vestige.reranker",
+                        serde_json::json!({ "event": "reranker_ready" }),
+                    );
                 }
                 // `None` already logged its reason; BM25 fallback stands.
-                Ok(None) => {}
+                Ok(None) => notifier.log(
+                    "warning",
+                    "vestige.reranker",
+                    serde_json::json!({ "event": "reranker_unavailable", "effect": "BM25 ranking stands" }),
+                ),
                 Err(e) => warn!("Cross-encoder load task failed: {e}"),
             }
         });
@@ -602,9 +651,6 @@ async fn main() {
 
     // Create MCP server with shared event channel for dashboard broadcasts
     let server = McpServer::new_with_events(storage, cognitive, event_tx);
-
-    // Create stdio transport
-    let transport = StdioTransport::new();
 
     info!("Starting MCP server on stdio...");
 

--- a/crates/vestige-mcp/src/protocol/messages.rs
+++ b/crates/vestige-mcp/src/protocol/messages.rs
@@ -75,6 +75,11 @@ pub struct ServerCapabilities {
     pub resources: Option<HashMap<String, Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompts: Option<HashMap<String, Value>>,
+    /// Declared so the server may send `notifications/message` (the MCP
+    /// logging channel) for out-of-band events such as a first-run model
+    /// download. Empty object per the spec.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logging: Option<HashMap<String, Value>>,
 }
 
 // ============================================================================

--- a/crates/vestige-mcp/src/protocol/stdio.rs
+++ b/crates/vestige-mcp/src/protocol/stdio.rs
@@ -76,25 +76,27 @@ impl StdioTransport {
         let stdin = tokio::io::stdin();
         let stdout = tokio::io::stdout();
 
-        let mut reader = BufReader::new(stdin);
+        // `Lines::next_line` is cancel safe (tokio docs); `read_line` is not.
+        // The select! below drops the pending read whenever a notification
+        // wins the race, and a cancelled `read_line` loses the bytes it had
+        // already pulled off stdin: the client's request vanishes and the
+        // client waits forever. `next_line` keeps its partial line across
+        // polls, so a notification can interleave at any moment.
+        let mut lines = BufReader::new(stdin).lines();
         let mut stdout = stdout;
         let mut consecutive_errors: u32 = 0;
-        let mut line_buf = String::new();
-
         loop {
-            line_buf.clear();
-
             tokio::select! {
-                result = reader.read_line(&mut line_buf) => {
+                result = lines.next_line() => {
                     match result {
-                        Ok(0) => {
+                        Ok(None) => {
                             // Clean EOF — stdin closed
                             info!("stdin closed (EOF), shutting down");
                             break;
                         }
-                        Ok(_) => {
+                        Ok(Some(line)) => {
                             consecutive_errors = 0;
-                            let line = line_buf.trim();
+                            let line = line.trim();
 
                             if line.is_empty() {
                                 continue;

--- a/crates/vestige-mcp/src/protocol/stdio.rs
+++ b/crates/vestige-mcp/src/protocol/stdio.rs
@@ -4,7 +4,9 @@
 //! v1.9.2: Async tokio I/O with error resilience.
 
 use std::io;
+use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
 use super::types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse};
@@ -13,16 +15,64 @@ use crate::server::McpServer;
 /// Maximum consecutive I/O errors before giving up
 const MAX_CONSECUTIVE_ERRORS: u32 = 5;
 
+/// Handle that background work (a first-run model download, a reranker load)
+/// uses to push server-initiated `notifications/message` lines onto stdout
+/// between responses. Clients that render MCP logging show them; others
+/// ignore them. Sending never blocks and never fails the sender.
+#[derive(Clone)]
+pub struct Notifier {
+    tx: mpsc::UnboundedSender<Value>,
+}
+
+impl Notifier {
+    /// Queue one logging notification. `level` is an MCP log level
+    /// (`info`, `warning`, ...), `logger` names the subsystem.
+    pub fn log(&self, level: &str, logger: &str, data: Value) {
+        let _ = self.tx.send(Self::message(level, logger, data));
+    }
+
+    /// The wire shape of a logging notification, kept pure for tests.
+    pub fn message(level: &str, logger: &str, data: Value) -> Value {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/message",
+            "params": { "level": level, "logger": logger, "data": data }
+        })
+    }
+}
+
+/// Resolve the next queued notification, or wait forever when the transport
+/// has no notification channel (or the channel closed and was dropped).
+async fn next_notification(rx: &mut Option<mpsc::UnboundedReceiver<Value>>) -> Option<Value> {
+    match rx {
+        Some(rx) => rx.recv().await,
+        None => std::future::pending().await,
+    }
+}
+
 /// stdio Transport for MCP server
-pub struct StdioTransport;
+pub struct StdioTransport {
+    notifications: Option<mpsc::UnboundedReceiver<Value>>,
+}
 
 impl StdioTransport {
     pub fn new() -> Self {
-        Self
+        Self { notifications: None }
+    }
+
+    /// A transport plus the [`Notifier`] that feeds it.
+    pub fn with_notifications() -> (Self, Notifier) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (
+            Self {
+                notifications: Some(rx),
+            },
+            Notifier { tx },
+        )
     }
 
     /// Run the MCP server over stdio with error resilience.
-    pub async fn run(self, mut server: McpServer) -> Result<(), io::Error> {
+    pub async fn run(mut self, mut server: McpServer) -> Result<(), io::Error> {
         let stdin = tokio::io::stdin();
         let stdout = tokio::io::stdout();
 
@@ -111,6 +161,24 @@ impl StdioTransport {
                         }
                     }
                 }
+                // Held until the handshake completes: a logging line before the
+                // initialize response would desync a client that reads the next
+                // line as its answer. The channel buffers meanwhile.
+                notification = next_notification(&mut self.notifications), if server.is_initialized() => {
+                    match notification {
+                        Some(notification) => match serde_json::to_string(&notification) {
+                            Ok(json) => {
+                                let out = format!("{}\n", json);
+                                stdout.write_all(out.as_bytes()).await?;
+                                stdout.flush().await?;
+                            }
+                            Err(e) => warn!("Failed to serialize notification: {}", e),
+                        },
+                        // Every sender is gone: park the branch instead of
+                        // spinning on a closed channel.
+                        None => self.notifications = None,
+                    }
+                }
             }
         }
 
@@ -121,5 +189,40 @@ impl StdioTransport {
 impl Default for StdioTransport {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Notifier;
+
+    #[test]
+    fn logging_notification_has_the_mcp_wire_shape() {
+        let message = Notifier::message(
+            "info",
+            "vestige.embeddings",
+            serde_json::json!({ "event": "model_download_started" }),
+        );
+        assert_eq!(message["jsonrpc"], "2.0");
+        assert_eq!(message["method"], "notifications/message");
+        assert_eq!(message["params"]["level"], "info");
+        assert_eq!(message["params"]["logger"], "vestige.embeddings");
+        assert_eq!(message["params"]["data"]["event"], "model_download_started");
+        assert!(message.get("id").is_none(), "notifications carry no id");
+    }
+
+    #[tokio::test]
+    async fn queued_notifications_are_delivered_in_order() {
+        let (mut transport, notifier) = super::StdioTransport::with_notifications();
+        notifier.log("info", "t", serde_json::json!({ "n": 1 }));
+        notifier.log("info", "t", serde_json::json!({ "n": 2 }));
+        let first = super::next_notification(&mut transport.notifications)
+            .await
+            .unwrap();
+        let second = super::next_notification(&mut transport.notifications)
+            .await
+            .unwrap();
+        assert_eq!(first["params"]["data"]["n"], 1);
+        assert_eq!(second["params"]["data"]["n"], 2);
     }
 }

--- a/crates/vestige-mcp/src/server.rs
+++ b/crates/vestige-mcp/src/server.rs
@@ -236,6 +236,9 @@ impl McpServer {
             "resources/read" => self.handle_resources_read(request.params).await,
             "server/discover" => self.handle_server_discover(),
             "ping" => Ok(serde_json::json!({})),
+            // The server only emits info and warning messages about its own
+            // startup (model downloads), so any requested level is accepted.
+            "logging/setLevel" => Ok(serde_json::json!({})),
             method => {
                 warn!("Unknown method: {}", method);
                 Err(JsonRpcError::method_not_found())
@@ -284,6 +287,7 @@ impl McpServer {
             "capabilities": {
                 "tools": { "listChanged": false },
                 "resources": { "listChanged": false },
+                "logging": {},
             },
             "instructions": build_instructions(),
             "ttlMs": DISCOVER_TTL_MS,
@@ -353,11 +357,19 @@ impl McpServer {
                     map
                 }),
                 prompts: None,
+                logging: Some(HashMap::new()),
             },
             instructions: Some(build_instructions()),
         };
 
         serde_json::to_value(result).map_err(|e| JsonRpcError::internal_error(&e.to_string()))
+    }
+
+    /// Whether the client has completed the `initialize` handshake. The stdio
+    /// transport holds server-initiated notifications until then, so nothing
+    /// precedes the initialize response on the wire.
+    pub fn is_initialized(&self) -> bool {
+        self.initialized
     }
 
     /// Handle tools/list request
@@ -2967,6 +2979,27 @@ mod tests {
     // ========================================================================
     // TOOLS/LIST TESTS
     // ========================================================================
+
+    #[tokio::test]
+    async fn logging_capability_is_declared_and_set_level_is_accepted() {
+        let (mut server, _dir) = test_server().await;
+        let init = server
+            .handle_request(make_request("initialize", Some(init_params())))
+            .await
+            .unwrap();
+        let caps = init.result.unwrap()["capabilities"].clone();
+        assert!(caps["logging"].is_object(), "{caps}");
+        let set = server
+            .handle_request(make_request(
+                "logging/setLevel",
+                Some(serde_json::json!({ "level": "info" })),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(set.result.unwrap(), serde_json::json!({}));
+        let discover = server.handle_request(make_request("server/discover", None)).await.unwrap();
+        assert!(discover.result.unwrap()["capabilities"]["logging"].is_object());
+    }
 
     #[tokio::test]
     async fn test_tools_list_returns_all_tools() {

--- a/crates/vestige-mcp/src/tools/mod.rs
+++ b/crates/vestige-mcp/src/tools/mod.rs
@@ -96,3 +96,4 @@ pub mod memory_states;
 pub mod review;
 #[allow(dead_code)]
 pub mod tagging;
+pub mod warming;

--- a/crates/vestige-mcp/src/tools/search_unified.rs
+++ b/crates/vestige-mcp/src/tools/search_unified.rs
@@ -421,6 +421,9 @@ pub async fn execute(
             response["tokenBudgetLimit"] = serde_json::json!(args.token_budget.unwrap());
         }
 
+        if let Some(warming) = super::warming::embedding_warming(storage) {
+            response["warming"] = warming;
+        }
         return Ok(response);
     }
 
@@ -1166,6 +1169,9 @@ pub async fn execute(
         response["tokensUsed"] = serde_json::json!(used);
     }
 
+    if let Some(warming) = super::warming::embedding_warming(storage) {
+        response["warming"] = warming;
+    }
     Ok(response)
 }
 

--- a/crates/vestige-mcp/src/tools/smart_ingest.rs
+++ b/crates/vestige-mcp/src/tools/smart_ingest.rs
@@ -924,6 +924,9 @@ pub async fn execute(
                 _ => "Memory processed successfully"
             }
         });
+        if !has_embedding && let Some(warming) = super::warming::embedding_warming(storage) {
+            response["warming"] = warming;
+        }
         attach_failure_hooks(&mut response, failure_hooks);
         Ok(response)
     }

--- a/crates/vestige-mcp/src/tools/warming.rs
+++ b/crates/vestige-mcp/src/tools/warming.rs
@@ -1,0 +1,48 @@
+//! First-run honesty. While the embedding runtime is still loading (or, on a
+//! fresh install, downloading about 130 MB), retrieval is keyword-only and
+//! saves have no vector yet. The responses say so, so the agent can tell the
+//! user why the first minute looks thin instead of guessing.
+
+use serde_json::{Value, json};
+use vestige_core::Storage;
+
+/// The `warming` block for a response, or `None` once the runtime is ready.
+/// Silent in builds without an embedding runtime: nothing is warming there.
+pub fn embedding_warming(storage: &Storage) -> Option<Value> {
+    if !crate::embeddings_compiled_in() || storage.is_embedding_ready() {
+        return None;
+    }
+    Some(json!({
+        "embeddingRuntime": "not ready",
+        "effect": "keyword-only retrieval and vector-less saves until the embedding model is loaded; a first run downloads about 130 MB",
+        "check": "memory_status view='health' reports embeddingReady; saves are back-filled with vectors once it is ready",
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use vestige_core::Storage;
+
+    fn storage_without_runtime() -> (Arc<Storage>, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new(Some(dir.path().join("test.db"))).unwrap();
+        (Arc::new(storage), dir)
+    }
+
+    #[cfg(all(feature = "embeddings", feature = "vector-search"))]
+    #[test]
+    fn warming_is_reported_until_the_runtime_is_ready() {
+        let (storage, _dir) = storage_without_runtime();
+        let block = super::embedding_warming(&storage).expect("runtime is not ready yet");
+        assert_eq!(block["embeddingRuntime"], "not ready");
+        assert!(block["effect"].as_str().unwrap().contains("130 MB"));
+    }
+
+    #[cfg(not(all(feature = "embeddings", feature = "vector-search")))]
+    #[test]
+    fn warming_is_silent_when_no_runtime_is_compiled_in() {
+        let (storage, _dir) = storage_without_runtime();
+        assert!(super::embedding_warming(&storage).is_none());
+    }
+}

--- a/crates/vestige-mcp/tests/e2e_real_binary.rs
+++ b/crates/vestige-mcp/tests/e2e_real_binary.rs
@@ -91,6 +91,10 @@ struct Server {
     stdout: Receiver<String>,
     stderr: Arc<Mutex<Vec<String>>>,
     next_id: u64,
+    /// Server-initiated notifications (`notifications/message` and friends)
+    /// seen while waiting for responses. A real MCP client must tolerate them
+    /// between any two lines; the harness stashes them here for assertions.
+    notifications: Vec<Value>,
 }
 
 impl Server {
@@ -157,6 +161,7 @@ impl Server {
             stdout,
             stderr,
             next_id: 0,
+            notifications: Vec::new(),
         }
     }
 
@@ -193,7 +198,26 @@ impl Server {
     }
 
     /// Read one line of output, failing the test rather than blocking forever.
+    /// Is this line a server-initiated notification (a method, no id)?
+    fn is_server_notification(line: &str) -> Option<Value> {
+        let value: Value = serde_json::from_str(line).ok()?;
+        (value.get("id").is_none() && value.get("method").is_some()).then_some(value)
+    }
+
+    /// Next response line. Server notifications are stashed, not returned:
+    /// the protocol allows them between any two lines once the handshake is
+    /// done, and a client reading "the next line" must skip them.
     fn read_line(&mut self) -> String {
+        loop {
+            let line = self.read_any_line();
+            match Self::is_server_notification(&line) {
+                Some(notification) => self.notifications.push(notification),
+                None => return line,
+            }
+        }
+    }
+
+    fn read_any_line(&mut self) -> String {
         match self.stdout.recv_timeout(RPC_TIMEOUT) {
             Ok(line) => line,
             Err(RecvTimeoutError::Timeout) => panic!(
@@ -210,8 +234,46 @@ impl Server {
     /// Assert that the server sends nothing at all within `window`. Used to
     /// prove that notifications and blank lines produce no response.
     fn expect_silence(&mut self, window: Duration) {
-        if let Ok(unexpected) = self.stdout.recv_timeout(window) {
-            panic!("expected no response, got: {unexpected}");
+        let deadline = Instant::now() + window;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return;
+            }
+            match self.stdout.recv_timeout(remaining) {
+                Ok(line) => match Self::is_server_notification(&line) {
+                    // Logging from the warm-up tasks is not a response.
+                    Some(notification) => self.notifications.push(notification),
+                    None => panic!("expected no response, got: {line}"),
+                },
+                Err(_) => return,
+            }
+        }
+    }
+
+    /// Wait until a `notifications/message` from `logger` has arrived, reading
+    /// and stashing lines until then.
+    fn wait_for_log_notification(&mut self, logger: &str, window: Duration) -> Value {
+        let deadline = Instant::now() + window;
+        loop {
+            if let Some(found) = self.notifications.iter().find(|n| {
+                n["method"] == json!("notifications/message") && n["params"]["logger"] == json!(logger)
+            }) {
+                return found.clone();
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "no notifications/message from {logger} within {window:?}; saw {:?}",
+                self.notifications
+            );
+            if let Ok(line) = self.stdout.recv_timeout(remaining) {
+                if let Some(notification) = Self::is_server_notification(&line) {
+                    self.notifications.push(notification);
+                } else {
+                    panic!("unexpected response while waiting for a notification: {line}");
+                }
+            }
         }
     }
 
@@ -640,6 +702,40 @@ fn uninitialized_requests_are_refused_but_discover_is_exempt() {
     server.handshake();
     assert!(server.result("tools/list", None)["tools"].is_array());
 
+    server.shutdown();
+}
+
+/// The first minute of a fresh install used to be silent: the model download
+/// printed to stderr, which stdio clients hide. The server now announces its
+/// warm-up as MCP logging, after the handshake and never before the initialize
+/// response (that ordering is what every other test in this file proves by
+/// reading responses line by line).
+#[test]
+fn warm_up_is_announced_as_mcp_logging_after_the_handshake() {
+    let dir = data_dir();
+    let mut server = Server::spawn(dir.path());
+    let init = server.handshake();
+    assert!(
+        init["capabilities"]["logging"].is_object(),
+        "logging capability must be declared: {init}"
+    );
+    assert!(
+        server.notifications.is_empty(),
+        "nothing may precede the initialize response: {:?}",
+        server.notifications
+    );
+
+    let note = server.wait_for_log_notification("vestige.embeddings", Duration::from_secs(20));
+    let event = note["params"]["data"]["event"].as_str().unwrap_or("");
+    assert!(
+        matches!(event, "model_loading" | "model_download_started" | "embedding_runtime_ready" | "embedding_runtime_unavailable"),
+        "unexpected warm-up event: {note}"
+    );
+    assert_eq!(note["params"]["level"].as_str().map(|l| l == "info" || l == "warning"), Some(true));
+
+    // Ordinary traffic keeps working with notifications interleaved.
+    let list = server.result("tools/list", None);
+    assert!(!list["tools"].as_array().unwrap().is_empty());
     server.shutdown();
 }
 


### PR DESCRIPTION
## Summary

Closes #222. A fresh install downloads about 130 MB of embedding model and about 150 MB of reranker before the first answer, with progress only on stderr, which stdio clients hide. The first minute read as a hang, and the first `recall` came back thin with no explanation.

- **The server declares the MCP `logging` capability** and sends `notifications/message` from its warm-up tasks: `model_download_started` (with the size) or `model_loading` depending on whether the model cache already holds anything, then `embedding_runtime_ready` or `embedding_runtime_unavailable`; the reranker does the same. `logging/setLevel` is accepted. Clients that render MCP logging show these lines; others ignore them.
- **A `Notifier` channel in the stdio transport.** Background tasks queue notifications; the transport's `select!` loop writes them between responses. A closed channel parks the branch instead of spinning.
- **A `warming` block on responses while the runtime is not ready**: `recall` (both paths) and vector-less `smart_ingest` saves say what the effect is (keyword-only retrieval, saves back-filled with vectors later) and where to check readiness, so the agent can tell the user instead of guessing. Silent in builds without an embedding runtime.
- `vestige_core::embeddings::embedding_model_cached()` reads the cache directory, pure on the path so it is tested without touching the environment.
- **Notifications wait for the handshake.** The transport holds them until `initialize` has been answered, so nothing precedes the initialize response on the wire. The e2e harness now skips server notifications the way a real client must and stashes them for assertions; the new e2e test proves the announcement arrives after the handshake and that ordinary traffic keeps working with notifications interleaved.

**Why no progress bar.** fastembed 5.13 exposes only a boolean `show_download_progress` (hf-hub's stderr bar); there is no callback for bytes. The notifications bracket the download honestly rather than fake a percentage.

## Gates

| Gate | Result |
|---|---|
| `cargo test -p vestige-mcp --lib warming`, `logging_capability`, `protocol::stdio` | 4 passed (all new) |
| `cargo test -p vestige-core --lib cache_populated` | passed (new) |
| `cargo clippy` default and no-embeddings variant | clean, both |
| e2e `discover_answers...`, `tools_list_is_deterministic...`, `uninitialized_requests...` | 6 passed, including the new `warm_up_is_announced_as_mcp_logging_after_the_handshake` |


## Follow-up fix in this PR

The first CI run hung for 120 s in `concurrent_server_startups_leave_an_intact_store` under the coverage job. Cause: with a second `select!` branch, a pending `read_line` is dropped whenever a notification wins the race, and the bytes it had already consumed from stdin are lost, so the client's request never reaches the handler. tokio documents `read_line` as not cancellation safe and `Lines::next_line` as cancel safe. The transport now reads with `next_line`. Locally: clippy clean, and three consecutive full e2e passes (18 passed, 7 ignored each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
