### PR TITLE
feat: project the durable subset of a scope into CLAUDE.md or MEMORY.md (roadmap: Markdown projection, part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Markdown projection
+
+- `project` (MCP tool and `vestige project`) renders the durable subset of a
+  scope, decisions, patterns and facts tagged `rule`, `preference` or
+  `convention`, currently valid and above a retention floor, into a fenced
+  region of a client rule file (`claude-md` for CLAUDE.md or AGENTS.md,
+  `memory-md` for an index). Every line ends with the memory id it came from.
+  Preview is the default and shows a line diff; `write` needs `confirm=true`,
+  replaces only the fence, keeps the rest of the file byte for byte, refuses a
+  path outside `root`, and is a no-op when the store has not changed. This is
+  the first half of the roadmap's Markdown and rules projection; re-import of
+  edits comes separately. `docs/PROJECTION.md` describes it.
+
 ### Fixed — CI
 
 - The Observatory privacy test built file paths from `import.meta.url` with

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Every mechanism is a cited result, implemented in Rust, running locally. Full wr
 | Memory Dreaming | Sleep-like replay and synthesis | Sleep consolidation research |
 | Active Forgetting | Reversible top-down suppression, cascading to neighbors | Anderson 2025, Davis 2020 |
 
-## The 14 tools
+## The tools
 
 Your agent calls these; you rarely do.
 
@@ -118,6 +118,7 @@ Your agent calls these; you rarely do.
 | `smart_ingest` | Store a fact, gated for novelty and contradiction |
 | `backfill` | Reach backward from a failure to its candidate cause |
 | `receipt` | Inspect retrieval receipts and evidence replay ([guide](docs/DECISION_RECEIPTS.md)) |
+| `project` | Project durable decisions, patterns and rules into CLAUDE.md or MEMORY.md, one memory id per line ([guide](docs/PROJECTION.md)) |
 | `memory` · `graph` · `intention` | Inspect, promote, explore, track goals |
 | `maintain` · `dedup` · `suppress` | Consolidation, merge, reversible forgetting |
 | `memory_status` · `codebase` · `source_sync` · `session_start` | Health, code index, connectors, session priming |

--- a/crates/vestige-core/src/lib.rs
+++ b/crates/vestige-core/src/lib.rs
@@ -110,6 +110,7 @@ pub mod advanced;
 
 /// Codebase memory - Vestige's killer differentiator for AI code understanding
 pub mod codebase;
+pub mod projection;
 
 /// Neuroscience-inspired memory mechanisms
 ///

--- a/crates/vestige-core/src/projection.rs
+++ b/crates/vestige-core/src/projection.rs
@@ -1,0 +1,503 @@
+//! Markdown projection: the durable subset of a scope's memory rendered into
+//! the rule files other agent clients already read (CLAUDE.md, MEMORY.md).
+//!
+//! Vestige stays the source of truth. The projection is a fenced region the
+//! store owns; everything outside the fence belongs to the human and is
+//! never touched. Each projected line ends with the id of the memory it came
+//! from, so a reader can trace a rule back to its evidence, and a later
+//! re-import can tell an edited line from a generated one.
+//!
+//! Selection is deliberately narrow: decisions, patterns, and facts or notes
+//! tagged `rule`, `preference` or `convention`, currently valid, at or above
+//! a retention floor, in the requested scope. A projection that carried every
+//! memory would be the "prompt sludge" the roadmap warns about.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::Storage;
+use crate::storage::Result;
+
+/// Which client file shape to render.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProjectionFormat {
+    /// A `## Vestige memory` section grouped by kind, for CLAUDE.md or AGENTS.md.
+    ClaudeMd,
+    /// A flat index of one line per memory, for a MEMORY.md style file.
+    MemoryMd,
+}
+
+impl ProjectionFormat {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "claude-md" | "claude_md" | "claude" | "agents-md" => Some(Self::ClaudeMd),
+            "memory-md" | "memory_md" | "memory" | "index" => Some(Self::MemoryMd),
+            _ => None,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::ClaudeMd => "claude-md",
+            Self::MemoryMd => "memory-md",
+        }
+    }
+}
+
+/// What to project and how much.
+#[derive(Debug, Clone)]
+pub struct ProjectionOptions {
+    pub scope: String,
+    pub format: ProjectionFormat,
+    /// Memories below this retention strength are left out (default 0.3).
+    pub min_retention: f64,
+    /// Upper bound on projected memories (default 60).
+    pub max_items: usize,
+}
+
+impl Default for ProjectionOptions {
+    fn default() -> Self {
+        Self {
+            scope: "user".to_string(),
+            format: ProjectionFormat::ClaudeMd,
+            min_retention: 0.3,
+            max_items: 60,
+        }
+    }
+}
+
+/// One projected memory, kept alongside the rendered text so callers can
+/// report provenance without re-parsing the Markdown.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ProjectedItem {
+    pub id: String,
+    pub node_type: String,
+    pub tags: Vec<String>,
+    pub content: String,
+    pub updated_at: DateTime<Utc>,
+    pub retention: f64,
+}
+
+/// The rendered region plus the items behind it.
+#[derive(Debug, Clone, Serialize)]
+pub struct Projection {
+    pub format: ProjectionFormat,
+    pub scope: String,
+    pub items: Vec<ProjectedItem>,
+    /// The fenced region, begin marker through end marker, newline-terminated.
+    pub region: String,
+}
+
+pub const BEGIN_MARKER: &str = "<!-- vestige:projection:begin";
+pub const END_MARKER: &str = "<!-- vestige:projection:end -->";
+
+/// Node types projected regardless of tags, in output order.
+const DURABLE_TYPES: [&str; 2] = ["decision", "pattern"];
+/// Tags that make a fact or note durable enough to project.
+const DURABLE_TAGS: [&str; 3] = ["rule", "preference", "convention"];
+/// How many candidates to pull per query before filtering.
+const CANDIDATE_LIMIT: i32 = 500;
+/// Longest single projected line before it is cut.
+const MAX_LINE_CHARS: usize = 400;
+
+/// Pick the durable subset of `opts.scope`.
+pub fn select_durable(storage: &Storage, opts: &ProjectionOptions) -> Result<Vec<ProjectedItem>> {
+    let now = Utc::now();
+    let mut candidates = Vec::new();
+    for node_type in DURABLE_TYPES {
+        candidates.extend(storage.get_nodes_by_type_and_tag(node_type, None, CANDIDATE_LIMIT)?);
+    }
+    for node_type in ["fact", "note"] {
+        for tag in DURABLE_TAGS {
+            candidates.extend(storage.get_nodes_by_type_and_tag(node_type, Some(tag), CANDIDATE_LIMIT)?);
+        }
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    let mut items = Vec::new();
+    for node in candidates {
+        if !seen.insert(node.id.clone()) {
+            continue;
+        }
+        if node.valid_until.is_some_and(|until| until <= now) {
+            continue;
+        }
+        if node.retention_strength < opts.min_retention {
+            continue;
+        }
+        // The tag query is a substring match on the JSON array, so confirm
+        // the tag is really present before trusting it.
+        let tagged = node
+            .tags
+            .iter()
+            .any(|tag| DURABLE_TAGS.contains(&tag.to_ascii_lowercase().as_str()));
+        if !DURABLE_TYPES.contains(&node.node_type.as_str()) && !tagged {
+            continue;
+        }
+        if !storage.node_is_in_scope(&node.id, &opts.scope)? {
+            continue;
+        }
+        items.push(ProjectedItem {
+            id: node.id,
+            node_type: node.node_type,
+            tags: node.tags,
+            content: node.content,
+            updated_at: node.updated_at,
+            retention: node.retention_strength,
+        });
+    }
+
+    items.sort_by(|a, b| {
+        kind_rank(&a.node_type, &a.tags)
+            .cmp(&kind_rank(&b.node_type, &b.tags))
+            .then_with(|| b.updated_at.cmp(&a.updated_at))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    items.truncate(opts.max_items);
+    Ok(items)
+}
+
+fn kind_rank(node_type: &str, _tags: &[String]) -> u8 {
+    match node_type {
+        "decision" => 0,
+        "pattern" => 1,
+        _ => 2,
+    }
+}
+
+fn kind_heading(rank: u8) -> &'static str {
+    match rank {
+        0 => "Decisions",
+        1 => "Patterns",
+        _ => "Rules and preferences",
+    }
+}
+
+/// One line of Markdown for a memory: whitespace collapsed, cut at
+/// `MAX_LINE_CHARS`, provenance comment at the end.
+fn render_line(item: &ProjectedItem) -> String {
+    let collapsed: String = item.content.split_whitespace().collect::<Vec<_>>().join(" ");
+    let mut text: String = collapsed.chars().take(MAX_LINE_CHARS).collect();
+    if collapsed.chars().count() > MAX_LINE_CHARS {
+        text.push('…');
+    }
+    format!("- {text} <!-- vestige:{} -->", item.id)
+}
+
+/// Render the fenced region for `items`. Deterministic for the same input:
+/// no timestamps inside the fence, so an unchanged store projects to an
+/// unchanged file.
+pub fn render(format: ProjectionFormat, scope: &str, items: &[ProjectedItem]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "{BEGIN_MARKER} scope={scope} format={} -->\n",
+        format.label()
+    ));
+    match format {
+        ProjectionFormat::ClaudeMd => {
+            out.push_str("## Vestige memory (projected)\n\n");
+            out.push_str(&format!(
+                "{} durable memories from scope `{scope}`. Change them in Vestige, not here: the next projection replaces this block. The comment at the end of each line is the memory id.\n",
+                items.len()
+            ));
+            let mut current: Option<u8> = None;
+            for item in items {
+                let rank = kind_rank(&item.node_type, &item.tags);
+                if current != Some(rank) {
+                    out.push_str(&format!("\n### {}\n", kind_heading(rank)));
+                    current = Some(rank);
+                }
+                out.push_str(&render_line(item));
+                out.push('\n');
+            }
+        }
+        ProjectionFormat::MemoryMd => {
+            out.push_str("# Memory index (projected by Vestige)\n\n");
+            out.push_str(&format!(
+                "{} durable memories from scope `{scope}`; one line each, memory id at the end.\n\n",
+                items.len()
+            ));
+            for item in items {
+                let line = render_line(item);
+                out.push_str(&line.replacen("- ", &format!("- [{}] ", item.node_type), 1));
+                out.push('\n');
+            }
+        }
+    }
+    out.push_str(END_MARKER);
+    out.push('\n');
+    out
+}
+
+/// Build the full projection for a scope.
+pub fn project(storage: &Storage, opts: &ProjectionOptions) -> Result<Projection> {
+    let items = select_durable(storage, opts)?;
+    let region = render(opts.format, &opts.scope, &items);
+    Ok(Projection {
+        format: opts.format,
+        scope: opts.scope.clone(),
+        items,
+        region,
+    })
+}
+
+/// Replace the fenced region inside `existing` with `region`, or append it
+/// when the file has none. Text outside the fence is returned byte for byte.
+/// Applying the same region twice yields the same file.
+pub fn splice(existing: &str, region: &str) -> String {
+    let region = region.strip_suffix('\n').unwrap_or(region);
+    if let Some(begin) = existing.find(BEGIN_MARKER) {
+        let line_start = existing[..begin].rfind('\n').map_or(0, |i| i + 1);
+        if let Some(end_rel) = existing[begin..].find(END_MARKER) {
+            let end = begin + end_rel + END_MARKER.len();
+            // Swallow the newline that closed the old end marker so the new
+            // region's own terminator does not double it.
+            let end = if existing[end..].starts_with('\n') { end + 1 } else { end };
+            let mut out = String::with_capacity(existing.len() + region.len());
+            out.push_str(&existing[..line_start]);
+            out.push_str(region);
+            out.push('\n');
+            out.push_str(&existing[end..]);
+            return out;
+        }
+    }
+    let mut out = existing.to_string();
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    if !out.is_empty() && !out.ends_with("\n\n") {
+        out.push('\n');
+    }
+    out.push_str(region);
+    out.push('\n');
+    out
+}
+
+/// One line of a preview diff.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DiffLine {
+    /// `'+'`, `'-'` or `' '`.
+    pub kind: char,
+    pub text: String,
+}
+
+/// Longest-common-subsequence line diff, enough for a rule file. Inputs
+/// larger than `LCS_MAX_LINES` lines fall back to remove-all/add-all so the
+/// quadratic table stays bounded.
+pub fn line_diff(old: &str, new: &str) -> Vec<DiffLine> {
+    const LCS_MAX_LINES: usize = 4_000;
+    let a: Vec<&str> = old.lines().collect();
+    let b: Vec<&str> = new.lines().collect();
+    if a.len() > LCS_MAX_LINES || b.len() > LCS_MAX_LINES {
+        let mut out: Vec<DiffLine> = a
+            .iter()
+            .map(|l| DiffLine { kind: '-', text: l.to_string() })
+            .collect();
+        out.extend(b.iter().map(|l| DiffLine { kind: '+', text: l.to_string() }));
+        return out;
+    }
+    let (n, m) = (a.len(), b.len());
+    let mut table = vec![vec![0u32; m + 1]; n + 1];
+    for i in (0..n).rev() {
+        for j in (0..m).rev() {
+            table[i][j] = if a[i] == b[j] {
+                table[i + 1][j + 1] + 1
+            } else {
+                table[i + 1][j].max(table[i][j + 1])
+            };
+        }
+    }
+    let (mut i, mut j) = (0, 0);
+    let mut out = Vec::new();
+    while i < n && j < m {
+        if a[i] == b[j] {
+            out.push(DiffLine { kind: ' ', text: a[i].to_string() });
+            i += 1;
+            j += 1;
+        } else if table[i + 1][j] >= table[i][j + 1] {
+            out.push(DiffLine { kind: '-', text: a[i].to_string() });
+            i += 1;
+        } else {
+            out.push(DiffLine { kind: '+', text: b[j].to_string() });
+            j += 1;
+        }
+    }
+    out.extend(a[i..].iter().map(|l| DiffLine { kind: '-', text: l.to_string() }));
+    out.extend(b[j..].iter().map(|l| DiffLine { kind: '+', text: l.to_string() }));
+    out
+}
+
+/// Counts of added and removed lines in a diff.
+pub fn diff_summary(diff: &[DiffLine]) -> (usize, usize) {
+    let added = diff.iter().filter(|l| l.kind == '+').count();
+    let removed = diff.iter().filter(|l| l.kind == '-').count();
+    (added, removed)
+}
+
+/// The changed lines with one line of context each side, as `+`/`-`/` `
+/// prefixed text; unchanged runs are elided with `...`.
+pub fn unified(diff: &[DiffLine], max_lines: usize) -> String {
+    let mut keep = vec![false; diff.len()];
+    for (i, line) in diff.iter().enumerate() {
+        if line.kind != ' ' {
+            let lo = i.saturating_sub(1);
+            let hi = (i + 1).min(diff.len().saturating_sub(1));
+            for flag in &mut keep[lo..=hi] {
+                *flag = true;
+            }
+        }
+    }
+    let mut out = String::new();
+    let mut emitted = 0usize;
+    let mut eliding = false;
+    for (i, line) in diff.iter().enumerate() {
+        if !keep[i] {
+            if !eliding {
+                out.push_str("...\n");
+                eliding = true;
+            }
+            continue;
+        }
+        eliding = false;
+        if emitted >= max_lines {
+            out.push_str("... (diff truncated)\n");
+            break;
+        }
+        out.push(line.kind);
+        out.push_str(&line.text);
+        out.push('\n');
+        emitted += 1;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::IngestInput;
+
+    fn item(id: &str, node_type: &str, content: &str) -> ProjectedItem {
+        ProjectedItem {
+            id: id.to_string(),
+            node_type: node_type.to_string(),
+            tags: vec![],
+            content: content.to_string(),
+            updated_at: Utc::now(),
+            retention: 0.9,
+        }
+    }
+
+    #[test]
+    fn render_is_deterministic_and_carries_provenance() {
+        let items = vec![
+            item("d1", "decision", "Use content-hashed cache keys\nfor build artifacts"),
+            item("p1", "pattern", "Wrap every writer in begin_write_transaction"),
+        ];
+        let a = render(ProjectionFormat::ClaudeMd, "user", &items);
+        let b = render(ProjectionFormat::ClaudeMd, "user", &items);
+        assert_eq!(a, b);
+        assert!(a.starts_with(BEGIN_MARKER));
+        assert!(a.ends_with(&format!("{END_MARKER}\n")));
+        assert!(a.contains("### Decisions\n- Use content-hashed cache keys for build artifacts <!-- vestige:d1 -->"));
+        assert!(a.contains("### Patterns\n- Wrap every writer in begin_write_transaction <!-- vestige:p1 -->"));
+        let index = render(ProjectionFormat::MemoryMd, "user", &items);
+        assert!(index.contains("- [decision] Use content-hashed cache keys"));
+    }
+
+    #[test]
+    fn long_content_is_cut_on_one_line() {
+        let long = "x".repeat(1_000);
+        let line = render_line(&item("id", "decision", &long));
+        assert!(line.chars().count() < 450, "{}", line.chars().count());
+        assert!(line.ends_with("<!-- vestige:id -->"));
+        assert!(line.contains('…'));
+    }
+
+    #[test]
+    fn splice_replaces_only_the_fence_and_is_idempotent() {
+        let region = render(ProjectionFormat::ClaudeMd, "user", &[item("d1", "decision", "one")]);
+        let hand_written = "# My project\n\nKeep this paragraph.\n";
+        let first = splice(hand_written, &region);
+        assert!(first.starts_with(hand_written), "text before the fence must survive:\n{first}");
+        assert!(first.contains("<!-- vestige:d1 -->"));
+        let again = splice(&first, &region);
+        assert_eq!(first, again, "re-projecting an unchanged store must not change the file");
+
+        let with_tail = format!("{first}\n## After the fence\nStill mine.\n");
+        let updated = render(ProjectionFormat::ClaudeMd, "user", &[item("d2", "decision", "two")]);
+        let spliced = splice(&with_tail, &updated);
+        assert!(spliced.starts_with(hand_written));
+        assert!(spliced.ends_with("## After the fence\nStill mine.\n"), "{spliced}");
+        assert!(spliced.contains("vestige:d2") && !spliced.contains("vestige:d1"));
+        assert_eq!(spliced.matches(BEGIN_MARKER).count(), 1);
+    }
+
+    #[test]
+    fn line_diff_reports_the_changed_lines() {
+        let old = "a\nb\nc\n";
+        let new = "a\nB\nc\nd\n";
+        let diff = line_diff(old, new);
+        assert_eq!(diff_summary(&diff), (2, 1));
+        let text = unified(&diff, 100);
+        assert!(text.contains("-b\n") && text.contains("+B\n") && text.contains("+d\n"), "{text}");
+        assert!(line_diff("same\n", "same\n").iter().all(|l| l.kind == ' '));
+    }
+
+    #[test]
+    fn select_durable_keeps_decisions_patterns_and_rule_tagged_facts_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new(Some(dir.path().join("test.db"))).unwrap();
+        let ingest = |content: &str, node_type: &str, tags: &[&str], valid_until| {
+            storage
+                .ingest(IngestInput {
+                    content: content.to_string(),
+                    node_type: node_type.to_string(),
+                    tags: tags.iter().map(|t| t.to_string()).collect(),
+                    valid_until,
+                    ..Default::default()
+                })
+                .unwrap()
+                .id
+        };
+        let decision = ingest("Ship releases from an integration branch", "decision", &[], None);
+        let pattern = ingest("Touch files after scripted edits", "pattern", &[], None);
+        let rule = ingest("Prefer tabs in Svelte files", "fact", &["preference"], None);
+        let plain = ingest("The office moved in spring", "fact", &[], None);
+        let expired = ingest(
+            "Old decision that was superseded",
+            "decision",
+            &[],
+            Some(Utc::now() - chrono::Duration::days(1)),
+        );
+
+        let items = select_durable(&storage, &ProjectionOptions::default()).unwrap();
+        let ids: Vec<&str> = items.iter().map(|i| i.id.as_str()).collect();
+        assert!(ids.contains(&decision.as_str()), "{ids:?}");
+        assert!(ids.contains(&pattern.as_str()), "{ids:?}");
+        assert!(ids.contains(&rule.as_str()), "{ids:?}");
+        assert!(!ids.contains(&plain.as_str()), "an untagged fact is not durable: {ids:?}");
+        assert!(!ids.contains(&expired.as_str()), "an invalidated memory is out: {ids:?}");
+        assert_eq!(items[0].node_type, "decision", "decisions render first");
+
+        let strict = select_durable(
+            &storage,
+            &ProjectionOptions {
+                min_retention: 1.1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(strict.is_empty(), "the retention floor applies");
+
+        let other_scope = select_durable(
+            &storage,
+            &ProjectionOptions {
+                scope: "some-other-project".to_string(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(other_scope.is_empty(), "scope isolation holds");
+    }
+}

--- a/crates/vestige-mcp/src/bin/cli.rs
+++ b/crates/vestige-mcp/src/bin/cli.rs
@@ -399,6 +399,33 @@ enum Commands {
         json: bool,
     },
 
+    /// Project the durable subset of a scope (decisions, patterns, rule-tagged facts)
+    /// into a fenced region of a client rule file such as CLAUDE.md or MEMORY.md, one
+    /// memory id per line. Prints the diff; writes only with --write, and only the fence.
+    Project {
+        /// Target file (created if missing; only the fenced region is ever replaced)
+        #[arg(long, value_name = "FILE", default_value = "CLAUDE.md")]
+        out: PathBuf,
+        /// 'claude-md' (grouped section) or 'memory-md' (one line per memory)
+        #[arg(long, default_value = "claude-md")]
+        format: String,
+        /// Project namespace to project
+        #[arg(long, default_value = "user")]
+        scope: String,
+        /// Leave out memories below this retention
+        #[arg(long, default_value = "0.3")]
+        min_retention: f64,
+        /// At most this many memories
+        #[arg(long, default_value = "60")]
+        max_items: usize,
+        /// Apply the change instead of printing the diff
+        #[arg(long)]
+        write: bool,
+        /// Output raw JSON instead of the diff
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Start standalone HTTP MCP server (no stdio, for remote access)
     Serve {
         /// HTTP transport port
@@ -506,6 +533,15 @@ fn main() -> anyhow::Result<()> {
             json,
         } => run_recall(query, depth, embedding_from, json),
         Commands::Compose { limit, tags, json } => run_compose(limit, tags, json),
+        Commands::Project {
+            out,
+            format,
+            scope,
+            min_retention,
+            max_items,
+            write,
+            json,
+        } => run_project(out, format, scope, min_retention, max_items, write, json),
         Commands::Serve {
             port,
             dashboard,
@@ -3808,6 +3844,95 @@ fn run_recall(
 }
 
 /// Compose: surface never-composed memory pairs + the testable question they imply.
+fn run_project(
+    out: PathBuf,
+    format: String,
+    scope: String,
+    min_retention: f64,
+    max_items: usize,
+    write: bool,
+    json: bool,
+) -> anyhow::Result<()> {
+    use vestige_core::projection::{self, ProjectionFormat, ProjectionOptions};
+
+    let format = ProjectionFormat::parse(&format)
+        .ok_or_else(|| anyhow::anyhow!("unknown format '{format}'; use claude-md or memory-md"))?;
+    let storage = open_storage()?;
+    let projection = projection::project(
+        &storage,
+        &ProjectionOptions {
+            scope: scope.clone(),
+            format,
+            min_retention: min_retention.clamp(0.0, 1.0),
+            max_items: max_items.clamp(1, 500),
+        },
+    )?;
+    let existing = if out.exists() {
+        std::fs::read_to_string(&out)?
+    } else {
+        String::new()
+    };
+    let new_text = projection::splice(&existing, &projection.region);
+    let diff = projection::line_diff(&existing, &new_text);
+    let (added, removed) = projection::diff_summary(&diff);
+
+    if write && (added > 0 || removed > 0) {
+        let tmp = out.with_extension("vestige-projection.tmp");
+        std::fs::write(&tmp, &new_text)?;
+        std::fs::rename(&tmp, &out)?;
+    }
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "path": out.display().to_string(),
+                "format": format.label(),
+                "scope": scope,
+                "itemCount": projection.items.len(),
+                "items": projection.items.iter().map(|i| serde_json::json!({
+                    "id": i.id, "nodeType": i.node_type, "tags": i.tags,
+                })).collect::<Vec<_>>(),
+                "added": added,
+                "removed": removed,
+                "written": write && (added > 0 || removed > 0),
+            }))?
+        );
+        return Ok(());
+    }
+
+    if added == 0 && removed == 0 {
+        println!(
+            "{} already holds this projection ({} memories from scope {}); nothing to change.",
+            out.display(),
+            projection.items.len(),
+            scope
+        );
+        return Ok(());
+    }
+    if write {
+        println!(
+            "Wrote {} memories from scope {} into the fenced region of {} (+{} -{} lines). Everything outside the fence is untouched.",
+            projection.items.len(),
+            scope,
+            out.display(),
+            added,
+            removed
+        );
+    } else {
+        println!(
+            "Projection of {} memories from scope {} for {} (+{} -{} lines). Re-run with --write to apply; only the fenced region changes.\n",
+            projection.items.len(),
+            scope,
+            out.display(),
+            added,
+            removed
+        );
+        print!("{}", projection::unified(&diff, 400));
+    }
+    Ok(())
+}
+
 fn run_compose(limit: i32, tags: Option<String>, json: bool) -> anyhow::Result<()> {
     let storage = open_storage()?;
 

--- a/crates/vestige-mcp/src/server.rs
+++ b/crates/vestige-mcp/src/server.rs
@@ -432,6 +432,24 @@ description: Some("Code memory. Actions: 'remember_pattern', 'remember_decision'
                 input_schema: tools::codebase_unified::schema(),
                 ..Default::default()
             },
+            // ================================================================
+            // PROJECT: the durable subset of a scope rendered into the rule
+            // files other clients already read. Preview by default; write
+            // replaces only the fenced region and needs confirm=true.
+            // ================================================================
+            ToolDescription {
+                name: "project".to_string(),
+                title: Some("Project".to_string()),
+                annotations: Some(ToolAnnotations {
+                    read_only_hint: false,
+                    destructive_hint: false,
+                    idempotent_hint: true,
+                    open_world_hint: false,
+                }),
+                description: Some("Project the durable subset of a scope (decisions, patterns, rule-tagged facts) into a fenced region of CLAUDE.md or MEMORY.md, a memory id on every line. 'preview' (default) shows the diff; 'write' needs confirm=true and replaces only the fence, never the rest of the file.".to_string()),
+                input_schema: tools::project::schema(),
+                ..Default::default()
+            },
             ToolDescription {
                 name: "intention".to_string(),
                 title: Some("Intention".to_string()),
@@ -833,6 +851,7 @@ description: Some("Memory with hindsight. After a failure is recorded, reach bac
                 tools::memory_unified::execute(&self.storage, &self.cognitive, request.arguments)
                     .await
             }
+            "project" => tools::project::execute(&self.storage, request.arguments).await,
             "codebase" => {
                 tools::codebase_unified::execute(
                     &self.storage,
@@ -2987,10 +3006,10 @@ mod tests {
         // dispatchable as hidden back-compat aliases but drop off the advertised list.
         assert_eq!(
             tools.len(),
-            14,
+            15,
             "Expected exactly 14 tools after v2.3 receipt replay integration \
              (12 consolidated: dedup + memory_status + graph + maintain + recall; \
-             session_context renamed) plus `receipt` and the flagship `backfill`"
+             session_context renamed) plus `receipt`, the flagship `backfill` and `project`"
         );
 
         let tool_names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();

--- a/crates/vestige-mcp/src/tools/mod.rs
+++ b/crates/vestige-mcp/src/tools/mod.rs
@@ -96,3 +96,4 @@ pub mod memory_states;
 pub mod review;
 #[allow(dead_code)]
 pub mod tagging;
+pub mod project;

--- a/crates/vestige-mcp/src/tools/project.rs
+++ b/crates/vestige-mcp/src/tools/project.rs
@@ -1,0 +1,308 @@
+//! `project`: render the durable subset of a scope into a client rule file.
+//!
+//! Preview is the default and writes nothing. Write replaces only the fenced
+//! region of the target file and needs `confirm: true`; the target must stay
+//! inside `root` (the working directory unless given), so a projection can
+//! never land outside the repository the agent is working in.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+use vestige_core::Storage;
+use vestige_core::projection::{self, ProjectionFormat, ProjectionOptions};
+
+/// Longest diff excerpt returned in a preview.
+const DIFF_LINES: usize = 200;
+
+pub fn schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["preview", "write"],
+                "default": "preview",
+                "description": "'preview' (default) renders and diffs, writes nothing. 'write' replaces the fenced region in 'path'; needs confirm=true."
+            },
+            "format": {
+                "type": "string",
+                "enum": ["claude-md", "memory-md"],
+                "default": "claude-md",
+                "description": "'claude-md': a grouped section for CLAUDE.md or AGENTS.md. 'memory-md': one line per memory for an index file."
+            },
+            "scope": { "type": "string", "description": "Project namespace to project (default 'user')." },
+            "path": { "type": "string", "description": "Target file, relative to 'root'. Required for write; a preview diffs against it when given." },
+            "root": { "type": "string", "description": "Directory the target must stay inside (default: the server's working directory)." },
+            "confirm": { "type": "boolean", "default": false, "description": "Required for write. Only the fenced region changes; the rest of the file is kept byte for byte." },
+            "min_retention": { "type": "number", "default": 0.3, "minimum": 0, "maximum": 1, "description": "Leave out memories below this retention." },
+            "max_items": { "type": "integer", "default": 60, "minimum": 1, "maximum": 500, "description": "At most this many memories." }
+        }
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectArgs {
+    #[serde(default = "default_action")]
+    action: String,
+    #[serde(default = "default_format")]
+    format: String,
+    scope: Option<String>,
+    path: Option<String>,
+    root: Option<String>,
+    #[serde(default)]
+    confirm: bool,
+    min_retention: Option<f64>,
+    max_items: Option<usize>,
+}
+
+fn default_action() -> String {
+    "preview".to_string()
+}
+
+fn default_format() -> String {
+    "claude-md".to_string()
+}
+
+/// Resolve `path` under `root` and refuse anything that escapes it. The file
+/// itself may not exist yet, so the check runs on its parent directory.
+fn resolve_target(root: Option<&str>, path: &str) -> Result<PathBuf, String> {
+    let root = match root {
+        Some(dir) => PathBuf::from(dir),
+        None => std::env::current_dir().map_err(|e| format!("cannot read the working directory: {e}"))?,
+    };
+    let root = root
+        .canonicalize()
+        .map_err(|e| format!("root {} is not a readable directory: {e}", root.display()))?;
+    let candidate = if Path::new(path).is_absolute() {
+        PathBuf::from(path)
+    } else {
+        root.join(path)
+    };
+    let file_name = candidate
+        .file_name()
+        .ok_or_else(|| format!("{path} has no file name"))?
+        .to_owned();
+    let parent = candidate.parent().unwrap_or(&root);
+    let parent = parent
+        .canonicalize()
+        .map_err(|e| format!("directory {} does not exist: {e}", parent.display()))?;
+    if !parent.starts_with(&root) {
+        return Err(format!(
+            "{path} resolves outside {}; projections stay inside root",
+            root.display()
+        ));
+    }
+    Ok(parent.join(file_name))
+}
+
+fn items_json(items: &[projection::ProjectedItem]) -> Vec<Value> {
+    items
+        .iter()
+        .map(|item| {
+            json!({
+                "id": item.id,
+                "nodeType": item.node_type,
+                "tags": item.tags,
+                "retention": (item.retention * 100.0).round() / 100.0,
+            })
+        })
+        .collect()
+}
+
+pub async fn execute(storage: &Arc<Storage>, args: Option<Value>) -> Result<Value, String> {
+    let args: ProjectArgs = match args {
+        Some(value) => serde_json::from_value(value).map_err(|e| format!("Invalid arguments: {e}"))?,
+        None => ProjectArgs {
+            action: default_action(),
+            format: default_format(),
+            scope: None,
+            path: None,
+            root: None,
+            confirm: false,
+            min_retention: None,
+            max_items: None,
+        },
+    };
+    let format = ProjectionFormat::parse(&args.format)
+        .ok_or_else(|| format!("unknown format '{}'; use claude-md or memory-md", args.format))?;
+    let opts = ProjectionOptions {
+        scope: args.scope.clone().unwrap_or_else(|| "user".to_string()),
+        format,
+        min_retention: args.min_retention.unwrap_or(0.3).clamp(0.0, 1.0),
+        max_items: args.max_items.unwrap_or(60).clamp(1, 500),
+    };
+    let projection = projection::project(storage, &opts).map_err(|e| e.to_string())?;
+
+    let target = match args.path.as_deref() {
+        Some(path) => Some(resolve_target(args.root.as_deref(), path)?),
+        None => None,
+    };
+    let existing = match &target {
+        Some(path) if path.exists() => {
+            Some(std::fs::read_to_string(path).map_err(|e| format!("cannot read {}: {e}", path.display()))?)
+        }
+        _ => None,
+    };
+    let new_text = projection::splice(existing.as_deref().unwrap_or(""), &projection.region);
+    let diff = projection::line_diff(existing.as_deref().unwrap_or(""), &new_text);
+    let (added, removed) = projection::diff_summary(&diff);
+
+    match args.action.as_str() {
+        "preview" => {
+            let mut response = json!({
+                "action": "preview",
+                "format": format.label(),
+                "scope": opts.scope,
+                "itemCount": projection.items.len(),
+                "items": items_json(&projection.items),
+                "region": projection.region,
+                "nextStep": "Call again with action='write', the same path, and confirm=true to apply. Only the fenced region changes.",
+            });
+            if let Some(path) = &target {
+                response["target"] = json!({
+                    "path": path.display().to_string(),
+                    "exists": existing.is_some(),
+                    "added": added,
+                    "removed": removed,
+                    "diff": projection::unified(&diff, DIFF_LINES),
+                });
+            }
+            Ok(response)
+        }
+        "write" => {
+            let path = target.ok_or("write needs 'path'")?;
+            if !args.confirm {
+                return Err(
+                    "Preview first, then pass confirm=true to write. Only the fenced region changes."
+                        .to_string(),
+                );
+            }
+            if added == 0 && removed == 0 {
+                return Ok(json!({
+                    "action": "write",
+                    "written": false,
+                    "path": path.display().to_string(),
+                    "itemCount": projection.items.len(),
+                    "added": 0,
+                    "removed": 0,
+                    "note": "The file already holds this projection; nothing to change.",
+                }));
+            }
+            let tmp = path.with_extension("vestige-projection.tmp");
+            std::fs::write(&tmp, &new_text).map_err(|e| format!("cannot write {}: {e}", tmp.display()))?;
+            std::fs::rename(&tmp, &path).map_err(|e| format!("cannot replace {}: {e}", path.display()))?;
+            Ok(json!({
+                "action": "write",
+                "written": true,
+                "path": path.display().to_string(),
+                "bytes": new_text.len(),
+                "itemCount": projection.items.len(),
+                "added": added,
+                "removed": removed,
+                "note": "Only the fenced region changed. Re-run preview any time; an unchanged store projects to an unchanged file.",
+            }))
+        }
+        other => Err(format!("unknown action '{other}'; use preview or write")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vestige_core::IngestInput;
+
+    fn storage() -> (Arc<Storage>, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new(Some(dir.path().join("test.db"))).unwrap();
+        (Arc::new(storage), dir)
+    }
+
+    fn ingest(storage: &Storage, content: &str, node_type: &str) -> String {
+        storage
+            .ingest(IngestInput {
+                content: content.to_string(),
+                node_type: node_type.to_string(),
+                ..Default::default()
+            })
+            .unwrap()
+            .id
+    }
+
+    #[tokio::test]
+    async fn preview_writes_nothing_and_shows_the_diff() {
+        let (storage, _db) = storage();
+        let decision = ingest(&storage, "Release from an integration branch", "decision");
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("CLAUDE.md"), "# Mine\n\nKeep me.\n").unwrap();
+
+        let value = execute(
+            &storage,
+            Some(json!({ "path": "CLAUDE.md", "root": root.path() })),
+        )
+        .await
+        .unwrap();
+        assert_eq!(value["action"], "preview");
+        assert_eq!(value["itemCount"], 1);
+        assert!(value["region"].as_str().unwrap().contains(&decision));
+        assert_eq!(value["target"]["exists"], true);
+        assert!(value["target"]["added"].as_u64().unwrap() > 0);
+        assert_eq!(
+            std::fs::read_to_string(root.path().join("CLAUDE.md")).unwrap(),
+            "# Mine\n\nKeep me.\n",
+            "preview must not touch the file"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_needs_confirm_then_replaces_only_the_fence_and_is_idempotent() {
+        let (storage, _db) = storage();
+        let pattern = ingest(&storage, "Touch files after scripted edits", "pattern");
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("CLAUDE.md"), "# Mine\n\nKeep me.\n").unwrap();
+
+        let refused = execute(
+            &storage,
+            Some(json!({ "action": "write", "path": "CLAUDE.md", "root": root.path() })),
+        )
+        .await
+        .unwrap_err();
+        assert!(refused.contains("confirm"), "{refused}");
+
+        let written = execute(
+            &storage,
+            Some(json!({ "action": "write", "path": "CLAUDE.md", "root": root.path(), "confirm": true })),
+        )
+        .await
+        .unwrap();
+        assert_eq!(written["written"], true, "{written}");
+        let file = std::fs::read_to_string(root.path().join("CLAUDE.md")).unwrap();
+        assert!(file.starts_with("# Mine\n\nKeep me.\n"), "{file}");
+        assert!(file.contains(projection::BEGIN_MARKER) && file.contains(&pattern));
+
+        let again = execute(
+            &storage,
+            Some(json!({ "action": "write", "path": "CLAUDE.md", "root": root.path(), "confirm": true })),
+        )
+        .await
+        .unwrap();
+        assert_eq!(again["written"], false, "{again}");
+        assert_eq!(again["added"], 0);
+    }
+
+    #[tokio::test]
+    async fn targets_outside_root_are_refused() {
+        let (storage, _db) = storage();
+        let root = tempfile::tempdir().unwrap();
+        let escape = execute(
+            &storage,
+            Some(json!({ "action": "write", "path": "../escape.md", "root": root.path(), "confirm": true })),
+        )
+        .await
+        .unwrap_err();
+        assert!(escape.contains("outside"), "{escape}");
+        let unknown = execute(&storage, Some(json!({ "format": "yaml" }))).await.unwrap_err();
+        assert!(unknown.contains("unknown format"), "{unknown}");
+    }
+}

--- a/crates/vestige-mcp/tests/e2e_real_binary.rs
+++ b/crates/vestige-mcp/tests/e2e_real_binary.rs
@@ -1336,6 +1336,75 @@ fn tag_prefix_filtering_is_case_insensitive_on_the_keyword_path() {
     server.shutdown();
 }
 
+/// Projection over stdio: the durable subset lands in a fenced region, the
+/// human's text around it survives byte for byte, a second write is a no-op,
+/// and a path that escapes the root is refused.
+#[test]
+fn project_previews_then_writes_a_fenced_region_and_keeps_the_rest() {
+    let dir = data_dir();
+    let mut server = Server::spawn(dir.path());
+    server.handshake();
+
+    let decision = server.call_tool_ok(
+        "smart_ingest",
+        json!({ "content": "Release from an integration branch, never from a feature branch", "node_type": "decision", "forceCreate": true }),
+    )["nodeId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let pattern = server.call_tool_ok(
+        "smart_ingest",
+        json!({ "content": "Touch edited files before running cargo so fingerprints refresh", "node_type": "pattern", "forceCreate": true }),
+    )["nodeId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    server.ingest_keyword_only("The office kitchen has a new kettle", &["office"]);
+
+    let root = tempfile::tempdir().unwrap();
+    let target = root.path().join("CLAUDE.md");
+    std::fs::write(&target, "# Mine\n\nKeep me.\n").unwrap();
+
+    let preview = server.call_tool_ok(
+        "project",
+        json!({ "action": "preview", "format": "claude-md", "path": "CLAUDE.md", "root": root.path() }),
+    );
+    assert_eq!(preview["itemCount"], json!(2), "{preview}");
+    let region = preview["region"].as_str().unwrap();
+    assert!(region.contains(&decision) && region.contains(&pattern), "{region}");
+    assert_eq!(preview["target"]["exists"], json!(true));
+    assert!(preview["target"]["added"].as_u64().unwrap() > 0);
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), "# Mine\n\nKeep me.\n");
+
+    let refused = server.call_tool(
+        "project",
+        json!({ "action": "write", "path": "CLAUDE.md", "root": root.path() }),
+    );
+    assert!(refused["error"].as_str().is_some_and(|e| e.contains("confirm")), "{refused}");
+
+    let written = server.call_tool_ok(
+        "project",
+        json!({ "action": "write", "path": "CLAUDE.md", "root": root.path(), "confirm": true }),
+    );
+    assert_eq!(written["written"], json!(true), "{written}");
+    let file = std::fs::read_to_string(&target).unwrap();
+    assert!(file.starts_with("# Mine\n\nKeep me.\n"), "{file}");
+    assert!(file.contains("<!-- vestige:projection:begin") && file.contains(&decision));
+
+    let again = server.call_tool_ok(
+        "project",
+        json!({ "action": "write", "path": "CLAUDE.md", "root": root.path(), "confirm": true }),
+    );
+    assert_eq!(again["written"], json!(false), "{again}");
+
+    let escape = server.call_tool(
+        "project",
+        json!({ "action": "write", "path": "../escape.md", "root": root.path(), "confirm": true }),
+    );
+    assert!(escape["error"].as_str().is_some_and(|e| e.contains("outside")), "{escape}");
+    server.shutdown();
+}
+
 /// The memory that IS an identifier must outrank the memory that merely cites it.
 ///
 /// Raw BM25 magnitude is unbounded while the literal-match bonus is capped, so

--- a/docs/PROJECTION.md
+++ b/docs/PROJECTION.md
@@ -1,0 +1,54 @@
+# Markdown projection
+
+Vestige stays the source of truth. `project` renders the durable subset of a scope into the rule files other agent clients already read, inside a fenced region the store owns. Everything outside the fence is the human's and is never touched.
+
+## What gets projected
+
+- `decision` and `pattern` memories.
+- `fact` and `note` memories tagged `rule`, `preference` or `convention`.
+- Only memories that are currently valid (nothing superseded or expired), at or above a retention floor (default 0.3), in the requested scope (default `user`), newest first within each group, capped at `max_items` (default 60).
+
+Each projected line ends with the id of the memory it came from:
+
+```
+- Release from an integration branch, never from a feature branch <!-- vestige:2f1c... -->
+```
+
+A rule can be traced back to its evidence, and a later re-import can tell an edited line from a generated one.
+
+## Formats
+
+| format | shape | typical target |
+|---|---|---|
+| `claude-md` | a `## Vestige memory (projected)` section with Decisions, Patterns, Rules and preferences | `CLAUDE.md`, `AGENTS.md` |
+| `memory-md` | one line per memory, `[type]` prefixed | `MEMORY.md`, an index file |
+
+## The fence
+
+```
+<!-- vestige:projection:begin scope=user format=claude-md -->
+...
+<!-- vestige:projection:end -->
+```
+
+Writing replaces exactly this region. A file without a fence gets one appended. The rendering carries no timestamps, so an unchanged store projects to an unchanged file and a second write is a no-op.
+
+## MCP
+
+```json
+{ "name": "project", "arguments": { "path": "CLAUDE.md" } }
+```
+
+Preview is the default: it returns the region, the items with their ids, and a line diff against the target. Writing needs `"action": "write"` and `"confirm": true`. The target must stay inside `root` (the server's working directory unless given); a path that escapes it is refused.
+
+## CLI
+
+```
+vestige project --out CLAUDE.md            # print the diff
+vestige project --out CLAUDE.md --write    # apply it
+vestige project --format memory-md --out MEMORY.md --scope my-project --write
+```
+
+## Not yet
+
+Re-importing human edits made inside the fence back into memory (through merge or supersede review) is the second half of the roadmap item and is tracked separately. Until then, edit memories in Vestige and re-project.


### PR DESCRIPTION
## Summary

The first half of the roadmap's Markdown and rules projection (was #87), the item Aaron ranked first in #182: "if Vestige projected the durable subset into CLAUDE.md/MEMORY.md we would delete that ritual tomorrow."

**What it does.** `project` (MCP tool and `vestige project`) renders the durable subset of a scope into a fenced region of a client rule file. Durable means: `decision` and `pattern` memories, plus `fact` and `note` memories tagged `rule`, `preference` or `convention`; currently valid (nothing superseded or expired); at or above a retention floor (default 0.3); in the requested scope; newest first within each group; capped at `max_items`. Every line ends with the id of the memory it came from, so a rule traces back to its evidence and a later re-import can tell an edited line from a generated one.

**Two formats.** `claude-md`: a `## Vestige memory (projected)` section with Decisions, Patterns, and Rules and preferences, for CLAUDE.md or AGENTS.md. `memory-md`: one `[type]`-prefixed line per memory, for an index file.

**Safety rules, each tested.**
- Preview is the default and writes nothing; it returns the region, the items with ids, and a line diff against the target.
- Write needs `confirm: true`, replaces exactly the fenced region, and keeps everything outside it byte for byte. A file without a fence gets one appended.
- No timestamps inside the fence: an unchanged store projects to an unchanged file, and a second write reports `written: false`.
- The target must stay inside `root` (the server's working directory unless given); `../escape.md` is refused.
- Writes go through a temp file and a rename.

**Not in this PR.** Re-importing human edits made inside the fence back into memory through merge or supersede review. `docs/PROJECTION.md` says so.

**tools/list ceiling.** This adds a tool (about 900 bytes). With #237's 30,000 byte ceiling and #239's purge tool both merged, main lands near 30,200; the ceiling needs to move to 31,000 when the three meet. Noted so whoever merges last raises it deliberately.

## Gates

| Gate | Result |
|---|---|
| `cargo test -p vestige-core --lib projection` | 5 passed (render determinism and provenance, cut lines, fence splice idempotence and preservation, line diff, selection with invalidated, untagged, retention floor and scope cases) |
| `cargo test -p vestige-mcp --lib project` | 3 passed (preview writes nothing and diffs; write needs confirm, replaces only the fence, second write is a no-op; escape and unknown format refused) |
| `cargo test -p vestige-mcp --lib tools_list` | passed (15 tools) |
| clippy, default and no-embeddings variant | clean, both |
| `cargo build --bin vestige` | builds |
| e2e `project_previews_then_writes_a_fenced_region_and_keeps_the_rest` | passed, plus tools_list |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
