### PR TITLE
ci(release): aarch64-unknown-linux-gnu asset, built and smoked like x86_64 (#240)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,3 +438,101 @@ jobs:
             -v "$PWD/scripts:/opt/scripts:ro" \
             debian:bookworm \
             bash -lc 'apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq libstdc++6 >/dev/null && bash /opt/scripts/smoke-vestige-mcp.sh /opt/vestige/vestige-mcp'
+
+  # aarch64 Linux (Raspberry Pi 5, Graviton, Ampere) on GitHub's arm64 runner,
+  # inside the same Ubuntu 22.04 container so the glibc 2.35 floor holds. ort-sys
+  # ships an ONNX Runtime prebuilt for aarch64-unknown-linux-gnu, so the default
+  # feature set builds unchanged. Same glibc check and the same smoke on Ubuntu
+  # 22.04 and Debian 12 arm64 images as the x86_64 job.
+  release-build-linux-arm64:
+    name: Release Build (aarch64-unknown-linux-gnu, glibc 2.35)
+    runs-on: ubuntu-24.04-arm
+    container: ubuntu:22.04
+    if: |
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'pull_request'
+    needs: [test]
+    env:
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: Install build dependencies
+        run: bash -lc "apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git build-essential pkg-config cmake python3 perl xz-utils unzip binutils libssl-dev"
+
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+
+      - name: Add target to the pinned toolchain
+        run: rustup target add aarch64-unknown-linux-gnu
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: linux-gnu-arm64-glibc235-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build release
+        run: cargo build --release --target aarch64-unknown-linux-gnu -p vestige-mcp
+
+      - name: Package
+        run: |
+          cd target/aarch64-unknown-linux-gnu/release
+          tar czf ../../../vestige-mcp-aarch64-unknown-linux-gnu.tar.gz vestige-mcp vestige vestige-restore
+
+      - name: Check glibc ceiling
+        run: ./scripts/check-linux-glibc.sh target/aarch64-unknown-linux-gnu/release/vestige-mcp
+
+      - name: Exec vestige-mcp on Ubuntu 22.04
+        run: ./scripts/smoke-vestige-mcp.sh target/aarch64-unknown-linux-gnu/release/vestige-mcp
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vestige-mcp-aarch64-unknown-linux-gnu
+          path: vestige-mcp-aarch64-unknown-linux-gnu.tar.gz
+
+  linux-compat-smoke-arm64:
+    name: Linux arm64 compat smoke (Ubuntu 22.04 / Debian 12)
+    runs-on: ubuntu-24.04-arm
+    needs: [release-build-linux-arm64]
+    if: |
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download linux-gnu artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: vestige-mcp-aarch64-unknown-linux-gnu
+          path: dist
+
+      - name: Extract
+        run: tar -xzf dist/vestige-mcp-aarch64-unknown-linux-gnu.tar.gz -C dist
+
+      - name: Check glibc ceiling
+        run: ./scripts/check-linux-glibc.sh dist/vestige-mcp
+
+      - name: Exec vestige-mcp on Ubuntu 22.04
+        run: |
+          docker run --rm --platform linux/arm64 \
+            -v "$PWD/dist:/opt/vestige:ro" \
+            -v "$PWD/scripts:/opt/scripts:ro" \
+            ubuntu:22.04 \
+            bash -lc 'apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq libstdc++6 >/dev/null && bash /opt/scripts/smoke-vestige-mcp.sh /opt/vestige/vestige-mcp'
+
+      - name: Exec vestige-mcp on Debian 12 bookworm
+        run: |
+          docker run --rm --platform linux/arm64 \
+            -v "$PWD/dist:/opt/vestige:ro" \
+            -v "$PWD/scripts:/opt/scripts:ro" \
+            debian:bookworm \
+            bash -lc 'apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq libstdc++6 >/dev/null && bash /opt/scripts/smoke-vestige-mcp.sh /opt/vestige/vestige-mcp'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,3 +360,177 @@ jobs:
             dist/vestige-mcp-x86_64-unknown-linux-gnu.tar.gz.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # aarch64 Linux asset (#240): the x86_64 job on GitHub's arm64 runner, same
+  # Ubuntu 22.04 container for the glibc 2.35 floor, same checks and smokes.
+  build-linux-arm64:
+    name: Build aarch64-unknown-linux-gnu (glibc 2.35)
+    runs-on: ubuntu-24.04-arm
+    container: ubuntu:22.04
+    env:
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: Install build dependencies
+        run: bash -lc "apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git build-essential pkg-config cmake python3 perl xz-utils unzip binutils libssl-dev"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.inputs.tag || github.ref }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+
+      - name: Add target to the pinned toolchain
+        run: rustup target add aarch64-unknown-linux-gnu
+
+      - name: Validate release version
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          node <<'NODE'
+          const { execFileSync } = require('node:child_process');
+          const tag = process.env.RELEASE_TAG || '';
+          const expected = tag.replace(/^refs\/tags\//, '').replace(/^v/, '');
+          if (!expected) {
+            throw new Error('Release tag is empty');
+          }
+
+          const packageFiles = [
+            'package.json',
+            'apps/dashboard/package.json',
+            'packages/vestige-init/package.json',
+            'packages/vestige-mcp-npm/package.json'
+          ];
+          for (const file of packageFiles) {
+            const actual = require(`./${file}`).version;
+            if (actual !== expected) {
+              throw new Error(`${file} version ${actual} does not match ${tag}`);
+            }
+          }
+
+          const metadata = JSON.parse(execFileSync('cargo', [
+            'metadata',
+            '--format-version',
+            '1',
+            '--locked',
+            '--no-deps'
+          ], { encoding: 'utf8' }));
+          for (const name of ['vestige-core', 'vestige-mcp']) {
+            const pkg = metadata.packages.find((candidate) => candidate.name === name);
+            if (!pkg) throw new Error(`Missing Cargo package ${name}`);
+            if (pkg.version !== expected) {
+              throw new Error(`${name} version ${pkg.version} does not match ${tag}`);
+            }
+          }
+          NODE
+
+      - name: Build embedded dashboard
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter @vestige/dashboard check
+          pnpm --filter @vestige/dashboard test
+          pnpm --filter @vestige/dashboard build
+          node <<'NODE'
+          const fs = require('node:fs');
+          const tag = process.env.RELEASE_TAG || '';
+          const expected = tag.replace(/^refs\/tags\//, '').replace(/^v/, '');
+          const versionFile = 'apps/dashboard/build/_app/version.json';
+          const version = JSON.parse(fs.readFileSync(versionFile, 'utf8')).version;
+          if (version !== expected) {
+            throw new Error(`${versionFile} version ${version} does not match ${tag}`);
+          }
+          for (const file of ['apps/dashboard/build/index.html', versionFile]) {
+            if (!fs.existsSync(file)) {
+              throw new Error(`Dashboard build did not produce ${file}`);
+            }
+          }
+          NODE
+
+      - name: Build
+        run: cargo build --locked --package vestige-mcp --release --target aarch64-unknown-linux-gnu
+
+      - name: Package
+        run: |
+          cd target/aarch64-unknown-linux-gnu/release
+          tar -czf ../../../vestige-mcp-aarch64-unknown-linux-gnu.tar.gz vestige-mcp vestige vestige-restore
+
+      - name: Check glibc ceiling
+        run: bash scripts/check-linux-glibc.sh target/aarch64-unknown-linux-gnu/release/vestige-mcp
+
+      - name: Exec vestige-mcp on Ubuntu 22.04
+        run: bash scripts/smoke-vestige-mcp.sh target/aarch64-unknown-linux-gnu/release/vestige-mcp
+
+      - name: Upload linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vestige-mcp-aarch64-unknown-linux-gnu
+          path: vestige-mcp-aarch64-unknown-linux-gnu.tar.gz
+
+  publish-linux-arm64:
+    name: Smoke + publish aarch64-unknown-linux-gnu
+    runs-on: ubuntu-24.04-arm
+    needs: [build-linux-arm64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.inputs.tag || github.ref }}
+
+      - name: Download linux-gnu artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: vestige-mcp-aarch64-unknown-linux-gnu
+          path: dist
+
+      - name: Extract
+        run: tar -xzf dist/vestige-mcp-aarch64-unknown-linux-gnu.tar.gz -C dist
+
+      - name: Check glibc ceiling
+        run: bash scripts/check-linux-glibc.sh dist/vestige-mcp
+
+      - name: Exec vestige-mcp on Ubuntu 22.04
+        run: |
+          docker run --rm --platform linux/arm64 \
+            -v "$PWD/dist:/opt/vestige:ro" \
+            -v "$PWD/scripts:/opt/scripts:ro" \
+            ubuntu:22.04 \
+            bash -lc 'apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq libstdc++6 >/dev/null && bash /opt/scripts/smoke-vestige-mcp.sh /opt/vestige/vestige-mcp'
+
+      - name: Exec vestige-mcp on Debian 12 bookworm
+        run: |
+          docker run --rm --platform linux/arm64 \
+            -v "$PWD/dist:/opt/vestige:ro" \
+            -v "$PWD/scripts:/opt/scripts:ro" \
+            debian:bookworm \
+            bash -lc 'apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq libstdc++6 >/dev/null && bash /opt/scripts/smoke-vestige-mcp.sh /opt/vestige/vestige-mcp'
+
+      - name: Generate checksum
+        working-directory: dist
+        run: sha256sum vestige-mcp-aarch64-unknown-linux-gnu.tar.gz > vestige-mcp-aarch64-unknown-linux-gnu.tar.gz.sha256
+
+      - name: Upload to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          files: |
+            dist/vestige-mcp-aarch64-unknown-linux-gnu.tar.gz
+            dist/vestige-mcp-aarch64-unknown-linux-gnu.tar.gz.sha256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Linux arm64 release asset
+
+- `vestige-mcp-aarch64-unknown-linux-gnu.tar.gz` joins the release (#240):
+  Raspberry Pi 5, Graviton and Ampere hosts no longer build from source. Built
+  on GitHub's arm64 runner inside the same Ubuntu 22.04 container as the x86_64
+  asset, so the glibc 2.35 floor holds; the same glibc check and the same
+  smoke on Ubuntu 22.04 and Debian 12 arm64 images gate it, in CI on every pull
+  request and in the release workflow. ort-sys ships an ONNX Runtime prebuilt
+  for the target, so embeddings work unchanged. `npm install -g
+  vestige-mcp-server` on arm64 Linux now downloads it.
+
 ### Fixed — CI
 
 - The Observatory privacy test built file paths from `import.meta.url` with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   request and in the release workflow. ort-sys ships an ONNX Runtime prebuilt
   for the target, so embeddings work unchanged. `npm install -g
   vestige-mcp-server` on arm64 Linux now downloads it.
+- The aarch64 ONNX Runtime archive imports `__isoc23_strtol`, `__isoc23_strtoll`
+  and `__isoc23_strtoull` (glibc 2.38) and `__cxa_call_terminate` (GCC 13
+  libstdc++), none of which the Ubuntu 22.04 release container has, so the
+  first arm64 build failed at link time. The x86_64 archive imports neither,
+  which is why the x86_64 job never saw it. `crates/vestige-mcp/src/glibc_compat.rs`
+  now defines the four symbols in each binary root, forwarding the C23 string
+  parsers to the classic glibc entry points and terminating on
+  `__cxa_call_terminate` the way libsupc++ does; the linker resolves the
+  archive against them and no `GLIBC_2.38` or `CXXABI_1.3.15` version need is
+  emitted. Unit tests cover the forwarding, the `endptr` contract and that the
+  terminate shim dies from SIGABRT.
 
 ### Fixed — CI
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The cause never looks like the bug. That is the whole product.
 
 ## Install
 
-You need Node.js. No Docker, no signup, no compile step (prebuilt for macOS ARM + Intel, Linux x86_64, Windows x86_64).
+You need Node.js. No Docker, no signup, no compile step (prebuilt for macOS ARM + Intel, Linux x86_64 + arm64, Windows x86_64).
 
 Android (Termux) builds from source today; see [docs/INSTALL-TERMUX.md](docs/INSTALL-TERMUX.md).
 

--- a/crates/vestige-mcp/src/bin/cli.rs
+++ b/crates/vestige-mcp/src/bin/cli.rs
@@ -2,6 +2,15 @@
 //!
 //! Command-line interface for managing cognitive memory system.
 
+// Supplies the `__isoc23_*` and `__cxa_call_terminate` symbols that the
+// statically linked ONNX Runtime archive imports from glibc >= 2.38 and
+// libstdc++ >= GCC 13. Compiled into each binary root rather than into the
+// library so the definitions are always part of the final link instead of
+// being subject to archive member selection. See the module docs.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[path = "../glibc_compat.rs"]
+mod glibc_compat;
+
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;

--- a/crates/vestige-mcp/src/bin/restore.rs
+++ b/crates/vestige-mcp/src/bin/restore.rs
@@ -1,3 +1,12 @@
+// Supplies the `__isoc23_*` and `__cxa_call_terminate` symbols that the
+// statically linked ONNX Runtime archive imports from glibc >= 2.38 and
+// libstdc++ >= GCC 13. Compiled into each binary root rather than into the
+// library so the definitions are always part of the final link instead of
+// being subject to archive member selection. See the module docs.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[path = "../glibc_compat.rs"]
+mod glibc_compat;
+
 use std::path::PathBuf;
 use vestige_core::{IngestInput, Storage};
 

--- a/crates/vestige-mcp/src/glibc_compat.rs
+++ b/crates/vestige-mcp/src/glibc_compat.rs
@@ -1,0 +1,201 @@
+//! Symbols the statically linked ONNX Runtime archive imports from a newer
+//! glibc and libstdc++ than the release floor provides (Linux/gnu only).
+//!
+//! # What breaks without this
+//!
+//! `ort-sys` downloads a prebuilt `libonnxruntime.a` and links it into every
+//! Vestige binary. The archive was compiled with a recent toolchain, and its
+//! objects import two families of symbols that the release container (Ubuntu
+//! 22.04: glibc 2.35, libstdc++ from GCC 12) does not have:
+//!
+//! - `__isoc23_strtol`, `__isoc23_strtoll`, `__isoc23_strtoull`: glibc 2.38
+//!   added C23 flavours of the string-to-integer functions (they additionally
+//!   accept `0b` binary literals). A translation unit compiled in C23 mode
+//!   against glibc >= 2.38 headers gets its plain `strtol` call silently
+//!   redirected by an asm label to `__isoc23_strtol@GLIBC_2.38`.
+//! - `__cxa_call_terminate`: GCC 13 emits calls to this libsupc++ helper when
+//!   an exception escapes a `noexcept` region; libstdc++ exports it only from
+//!   `CXXABI_1.3.15`, which Ubuntu 22.04, Debian 12 and RHEL 9 all lack.
+//!
+//! The x86_64 archive happens not to import either family, which is why the
+//! x86_64 release job never saw this. The aarch64 archive imports all four
+//! (123 `__isoc23_*` and 180 `__cxa_call_terminate` references in ORT 1.23.2),
+//! so the first aarch64 release build failed at link time with "undefined
+//! reference". Nothing we compile is involved; the references live in a
+//! prebuilt archive, so neither a compiler flag nor an older runner can remove
+//! them, and a newer runner would only move the problem to users' machines as
+//! `version GLIBC_2.38 not found` at startup.
+//!
+//! # The fix
+//!
+//! Define the symbols here and forward to what every supported glibc and
+//! libstdc++ already has. Rust `extern "C"` declarations are not subject to
+//! the `<stdlib.h>` redirect, so `strtol` below binds to the classic entry
+//! point. The linker resolves the archive's undefined references against these
+//! definitions and emits no `GLIBC_2.38` or `CXXABI_1.3.15` version need. The
+//! module is compiled into each binary root (`main.rs`, `bin/cli.rs`,
+//! `bin/restore.rs`) rather than into the library, so the definitions are
+//! always part of the final link instead of depending on archive member
+//! selection.
+//!
+//! Behavioural differences, both deliberate:
+//!
+//! - The C23 `0b1010` binary-literal form is not recognised, which is what
+//!   these call sites did on every glibc before 2.38 anyway.
+//! - `__cxa_call_terminate` aborts the process directly instead of running a
+//!   `std::set_terminate` handler. Neither Vestige nor ONNX Runtime installs
+//!   one, and the default handler is `abort()`; this also keeps the shim free
+//!   of any libstdc++ dependency, so builds without C++ code link unchanged.
+//!
+//! `scripts/check-linux-glibc.sh` keeps the ceiling honest in CI, and the
+//! release job then starts each binary on Ubuntu 22.04 and Debian 12.
+
+use std::os::raw::{c_char, c_int, c_long, c_longlong, c_ulong, c_ulonglong, c_void};
+
+unsafe extern "C" {
+    fn strtol(nptr: *const c_char, endptr: *mut *mut c_char, base: c_int) -> c_long;
+    fn strtoll(nptr: *const c_char, endptr: *mut *mut c_char, base: c_int) -> c_longlong;
+    fn strtoul(nptr: *const c_char, endptr: *mut *mut c_char, base: c_int) -> c_ulong;
+    fn strtoull(nptr: *const c_char, endptr: *mut *mut c_char, base: c_int) -> c_ulonglong;
+}
+
+/// C23 `strtol`, forwarded to the pre-2.38 entry point.
+///
+/// # Safety
+///
+/// Same contract as `strtol(3)`: `nptr` must point at a NUL-terminated string
+/// and `endptr` must be null or point at a writable `*mut c_char`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __isoc23_strtol(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    base: c_int,
+) -> c_long {
+    unsafe { strtol(nptr, endptr, base) }
+}
+
+/// C23 `strtoll`, forwarded to the pre-2.38 entry point.
+///
+/// # Safety
+///
+/// Same contract as `strtoll(3)`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __isoc23_strtoll(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    base: c_int,
+) -> c_longlong {
+    unsafe { strtoll(nptr, endptr, base) }
+}
+
+/// C23 `strtoul`, forwarded to the pre-2.38 entry point.
+///
+/// # Safety
+///
+/// Same contract as `strtoul(3)`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __isoc23_strtoul(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    base: c_int,
+) -> c_ulong {
+    unsafe { strtoul(nptr, endptr, base) }
+}
+
+/// C23 `strtoull`, forwarded to the pre-2.38 entry point.
+///
+/// # Safety
+///
+/// Same contract as `strtoull(3)`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __isoc23_strtoull(
+    nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    base: c_int,
+) -> c_ulonglong {
+    unsafe { strtoull(nptr, endptr, base) }
+}
+
+/// GCC 13's `__cxa_call_terminate(_Unwind_Exception*)`, exported by libstdc++
+/// only from `CXXABI_1.3.15`.
+///
+/// The compiler emits a call to it when an exception propagates out of a
+/// `noexcept` region; the only legal outcome is termination. libsupc++ marks
+/// the exception caught and calls `std::terminate()`, whose default handler is
+/// `abort()`. This version aborts directly (see the module docs for why), so
+/// the exception header is not inspected.
+#[unsafe(no_mangle)]
+pub extern "C" fn __cxa_call_terminate(_exception: *mut c_void) -> ! {
+    std::process::abort()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ptr;
+
+    #[test]
+    fn forwards_decimal_and_hex_like_strtol() {
+        unsafe {
+            assert_eq!(__isoc23_strtol(c"1234".as_ptr(), ptr::null_mut(), 10), 1234);
+            assert_eq!(__isoc23_strtol(c"0x2a".as_ptr(), ptr::null_mut(), 0), 42);
+            assert_eq!(
+                __isoc23_strtoll(c"-9000".as_ptr(), ptr::null_mut(), 10),
+                -9000
+            );
+            assert_eq!(
+                __isoc23_strtoul(c"4294967295".as_ptr(), ptr::null_mut(), 10),
+                4294967295
+            );
+            assert_eq!(
+                __isoc23_strtoull(c"18446744073709551615".as_ptr(), ptr::null_mut(), 10),
+                u64::MAX
+            );
+        }
+    }
+
+    #[test]
+    fn reports_the_unparsed_tail_through_endptr() {
+        unsafe {
+            let input = c"77rest";
+            let mut end: *mut c_char = ptr::null_mut();
+            assert_eq!(__isoc23_strtol(input.as_ptr(), &mut end, 10), 77);
+            assert_eq!(
+                std::ffi::CStr::from_ptr(end).to_str().unwrap(),
+                "rest",
+                "endptr must point at the first unconsumed byte"
+            );
+        }
+    }
+
+    /// The shim must terminate the process, and with SIGABRT specifically, so
+    /// a crash inside ONNX Runtime looks exactly like the libstdc++ original.
+    /// Runs itself as a child: the child hits the probe env var and calls the
+    /// shim; the parent checks how it died.
+    #[test]
+    fn calling_cxa_call_terminate_aborts_the_process() {
+        use std::os::unix::process::ExitStatusExt;
+        const PROBE: &str = "VESTIGE_GLIBC_COMPAT_ABORT_PROBE";
+        const SIGABRT: i32 = 6;
+
+        if std::env::var_os(PROBE).is_some() {
+            __cxa_call_terminate(ptr::null_mut());
+        }
+
+        let exe = std::env::current_exe().expect("test binary path");
+        let status = std::process::Command::new(exe)
+            .arg("--exact")
+            .arg("glibc_compat::tests::calling_cxa_call_terminate_aborts_the_process")
+            .env(PROBE, "1")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("spawn probe child");
+        assert!(!status.success(), "the probe child must not exit cleanly");
+        assert_eq!(
+            status.signal(),
+            Some(SIGABRT),
+            "the probe child must die from SIGABRT, got {status:?}"
+        );
+    }
+}

--- a/crates/vestige-mcp/src/main.rs
+++ b/crates/vestige-mcp/src/main.rs
@@ -27,6 +27,15 @@
 //! - Reconsolidation (memories editable on retrieval)
 //! - Memory Chains (reasoning paths)
 
+// Supplies the `__isoc23_*` and `__cxa_call_terminate` symbols that the
+// statically linked ONNX Runtime archive imports from glibc >= 2.38 and
+// libstdc++ >= GCC 13. Compiled into each binary root rather than into the
+// library so the definitions are always part of the final link instead of
+// being subject to archive member selection. See the module docs.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[path = "glibc_compat.rs"]
+mod glibc_compat;
+
 use vestige_mcp::cognitive;
 use vestige_mcp::protocol;
 use vestige_mcp::server;

--- a/packages/vestige-mcp-npm/scripts/postinstall.js
+++ b/packages/vestige-mcp-npm/scripts/postinstall.js
@@ -29,7 +29,7 @@ const archStr = ARCH_MAP[ARCH];
 
 if (!platformStr || !archStr) {
   console.error(`Unsupported platform: ${PLATFORM}-${ARCH}`);
-  console.error('Supported release assets: macOS x64/arm64, Linux x64, Windows x64');
+  console.error('Supported release assets: macOS x64/arm64, Linux x64/arm64, Windows x64');
   process.exit(1);
 }
 
@@ -38,6 +38,7 @@ const SUPPORTED_TARGETS = new Set([
   'aarch64-apple-darwin',
   'x86_64-apple-darwin',
   'x86_64-unknown-linux-gnu',
+  'aarch64-unknown-linux-gnu',
   'x86_64-pc-windows-msvc',
 ]);
 if (!SUPPORTED_TARGETS.has(target)) {


### PR DESCRIPTION
## Summary

Closes #240. Raspberry Pi 5, Graviton and Ampere hosts run aarch64 Linux and had no release asset, so they built from source.

- **CI**: `release-build-linux-arm64` and `linux-compat-smoke-arm64` mirror the x86_64 jobs on GitHub's `ubuntu-24.04-arm` runner (available to public repos), inside the same `ubuntu:22.04` container so the glibc 2.35 floor holds. Same `check-linux-glibc.sh`, same smoke on Ubuntu 22.04 and Debian 12, on `linux/arm64` images. They run on every pull request, so this PR's own CI is the first arm64 build.
- **Release**: `build-linux-arm64` and `publish-linux-arm64` mirror `build-linux` and `publish-linux`, uploading `vestige-mcp-aarch64-unknown-linux-gnu.tar.gz` and its checksum.
- **Why the default feature set works**: ort-sys 2.0.0-rc.11's download manifest lists an ONNX Runtime 1.23.2 prebuilt for `aarch64-unknown-linux-gnu` (verified in the local registry copy), so embeddings need no special build.
- **npm**: `SUPPORTED_TARGETS` gains the target (arch mapping already turns `arm64` into `aarch64`); README lists Linux arm64 among the prebuilt platforms.

The two Linux scripts (`check-linux-glibc.sh`, `smoke-vestige-mcp.sh`) carry no architecture assumptions; `objdump` handles both.

## Gates

| Gate | Result |
|---|---|
| YAML parses; job graph | ci: 10 jobs, release: 5 jobs |
| `release-build-linux-arm64` and `linux-compat-smoke-arm64` | this PR's CI run |

## Second build: the link fix (c556a53)

The first arm64 build failed at link time, and only there: 123 undefined references to `__isoc23_strtol`, `__isoc23_strtoll` and `__isoc23_strtoull` (glibc 2.38) and 180 to `__cxa_call_terminate` (GCC 13 libsupc++, `CXXABI_1.3.15`), all from the prebuilt `libonnxruntime.a` that ort-sys links statically. The x86_64 archive imports neither family, which is why the x86_64 job in the same Ubuntu 22.04 container never saw it. Nothing we compile is involved, so no flag or runner change removes the references.

`crates/vestige-mcp/src/glibc_compat.rs` now defines the four symbols in each binary root: the C23 parsers forward to the classic glibc entry points, and `__cxa_call_terminate` aborts the way libsupc++'s default `std::terminate` does, with no libstdc++ dependency. Unit tests cover the forwarding, the `endptr` contract and that the terminate shim dies from SIGABRT.

Verified before pushing by reproducing this job on a native aarch64 Linux VM in the same `ubuntu:22.04` image with the pinned 1.98.1 toolchain:

| check | result |
| --- | --- |
| `cargo build --locked --release --target aarch64-unknown-linux-gnu` | all three binaries link |
| `scripts/check-linux-glibc.sh` on each binary | ok, within glibc 2.35 / GLIBCXX 3.4.30 |
| highest version needs (`readelf -V`) | `GLIBC_2.34`, `GLIBCXX_3.4.30`, `CXXABI_1.3.11` |
| dynamic references to the shimmed symbols (`objdump -T`) | 0 on each binary |
| `DT_NEEDED` | libstdc++, libgcc_s, libm, libc, the loader; no libmvec |
| `scripts/smoke-vestige-mcp.sh` on Ubuntu 22.04 | starts, answers initialize |
| same smoke on Debian 12 | starts, answers initialize; `vestige` and `vestige-restore` start too |
| `cargo clippy -p vestige-mcp --all-targets -- -D warnings` on the linux-gnu cfg (the module is compiled out on macOS) | clean |
| `cargo test -p vestige-mcp --bins glibc_compat` | 9 passed, 3 per binary, including the SIGABRT probe |

One local detail worth knowing for anyone reproducing: with a 6 GB VM the three fat-LTO links in parallel get the linker killed, so build with `-j 1`. The GitHub arm64 runner has more memory and the release workflow is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
