### PR TITLE
bench(memoryarena): preregister the Vestige run and ship the adapter (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Benchmarks
+
+- MemoryArena preregistration (#242). `docs/benchmarks/MEMORYARENA-PREREGISTRATION.md`
+  fixes the protocol before any run: the two formal-reasoning families, five
+  arms that all run every time (a no-memory floor, upstream's BM25 and
+  embedding RAG, upstream's long-context baseline, Vestige), Progress Score as
+  the primary metric, and a paired exact sign test against BM25 as the only
+  decision rule. `benchmarks/memoryarena/` ships the adapter that presents a
+  live `vestige-mcp` to upstream's memory interface (one shared server, one
+  scope per task, an embedding-readiness guard so a keyword-only fallback can
+  never be measured by accident, a JSONL sidecar with byte counts for the
+  blob-size confound), an installer that patches a pinned MemoryArena clone,
+  the run configs, a smoke test against the real binary, and the analysis
+  script. No number exists yet; the run is the next step.
+
 ### Fixed — CI
 
 - The Observatory privacy test built file paths from `import.meta.url` with

--- a/benchmarks/memoryarena/.gitignore
+++ b/benchmarks/memoryarena/.gitignore
@@ -1,0 +1,3 @@
+# Live Vestige databases and sidecar logs created by local runs.
+*datadir-*/
+__pycache__/

--- a/benchmarks/memoryarena/MEMORYARENA.lock.json
+++ b/benchmarks/memoryarena/MEMORYARENA.lock.json
@@ -1,0 +1,29 @@
+{
+  "_comment": "Pinned upstream revisions for the MemoryArena run. Do not edit by hand; a run that does not match these pins is a different experiment and must say so.",
+  "name": "MemoryArena",
+  "paper": "arXiv:2602.16313",
+  "paper_url": "https://arxiv.org/abs/2602.16313",
+  "paper_title": "MemoryArena: Benchmarking Agent Memory in Interdependent Multi-Session Agentic Tasks",
+  "repo": "https://github.com/ZexueHe/MemoryArena",
+  "repo_revision": "6cd9de14b71915e39ac742a20dc33785e14b6aab",
+  "repo_revision_date": "2026-06-01",
+  "repo_license": "upstream repository declares no LICENSE file as of this revision; nothing from it is vendored here, the adapter is installed into a local clone at run time",
+  "dataset": "ZexueHe/memoryarena",
+  "dataset_url": "https://huggingface.co/datasets/ZexueHe/memoryarena",
+  "dataset_revision": "da1a37c8b19280e18627ca01cf368195a5e1d92e",
+  "dataset_license": "CC-BY-4.0",
+  "dataset_configs": {
+    "formal_reasoning_math": { "rows": 40, "subtasks_per_row": "2-16", "fields": ["id", "paper_name", "backgrounds", "questions", "answers"] },
+    "formal_reasoning_phys": { "rows": 20, "subtasks_per_row": "2-12", "fields": ["id", "paper_name", "backgrounds", "questions", "answers"] },
+    "bundled_shopping": { "rows": 150, "subtasks_per_row": 6, "status": "not in the preregistered run" },
+    "group_travel_planner": { "rows": 270, "subtasks_per_row": "5-9", "status": "not in the preregistered run" },
+    "progressive_search": { "rows": 221, "subtasks_per_row": "2-16", "status": "not in the preregistered run; the paper reports 256 tasks, the released config has 221 rows" }
+  },
+  "upstream_metrics": {
+    "SR": "overall_average_passrate: fraction of tasks whose every subtask the judge marked correct",
+    "PS": "avg_progress_score: mean over tasks of correct subtasks / total subtasks",
+    "passrate_at_min_k": "per-position pass rate up to the shortest task length, every task contributes",
+    "evaluator": "env/env_systems/formal_reasoning_env/eval.py at repo_revision"
+  },
+  "retrieved_utc": "2026-09-05"
+}

--- a/benchmarks/memoryarena/README.md
+++ b/benchmarks/memoryarena/README.md
@@ -1,0 +1,63 @@
+# MemoryArena harness
+
+Vestige as a memory backend for
+[MemoryArena](https://github.com/ZexueHe/MemoryArena) (arXiv:2602.16313), the
+benchmark that scores memory inside an agent loop instead of as a retrieval
+quiz.
+
+**Status: preregistered, not run. There is no Vestige number on MemoryArena.**
+The protocol, arms, metrics and decision rules are fixed in
+[`docs/benchmarks/MEMORYARENA-PREREGISTRATION.md`](../../docs/benchmarks/MEMORYARENA-PREREGISTRATION.md).
+Read it before running anything, and read
+[`docs/BENCHMARKS.md`](../../docs/BENCHMARKS.md) before quoting anything.
+
+## Quick start (no MemoryArena checkout, no API key)
+
+```sh
+cargo build -p vestige-mcp
+python3 benchmarks/memoryarena/smoke_test.py
+```
+
+The smoke test drives the adapter against the real binary and asserts the
+properties the run depends on: a stored fact comes back for the right
+question, a second task never sees the first task's memories, the hits carry a
+real `semanticScore` (embeddings, not the keyword fallback), a 3,000-character
+LaTeX-heavy prompt wraps without error, an upstream-shaped
+`## Task ... ## solution ...` entry is retrievable by a later related task, and
+every add and wrap landed in the sidecar log with byte counts.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `vestige_memory_system.py` | The adapter. `VestigeMemorySystem` (add_chunk / wrap_user_prompt over MCP stdio, one shared server, one scope per task, readiness guard, JSONL sidecar) and `NoMemorySystem` (the floor arm). Self-contained so it can be copied into a MemoryArena clone. |
+| `install.py` | Installs the adapter into a pinned MemoryArena clone: copies the module, registers `vestige` and `none` in `memory/server.py`, copies the run configs. Anchored edits, idempotent, refuses an unpinned HEAD. |
+| `configs/` | Run configs mirroring upstream's field for field: `math_vestige`, `phys_vestige`, `math_none`, `phys_none`, and `phys_bm25` (upstream ships the math one only). |
+| `smoke_test.py` | The check above. Exit 1 on any failure. |
+| `analyze.py` | The preregistered analysis: per-arm PS and SR with n, paired exact sign test against the reference arm, sidecar confound summary. |
+| `MEMORYARENA.lock.json` | Pinned upstream code and dataset revisions, row counts, metric definitions. |
+| `results/` | Checked-in run outputs, once a run exists. Empty until then. |
+
+Standard library only. No `pip install` for anything in this directory; the
+upstream environment is upstream's business.
+
+## How the adapter fits upstream
+
+MemoryArena's memory server (`memory/server.py`) constructs one backend object
+per task and calls two methods: `add_chunk(chunk)` after each agent step with
+the agent's own memory entry, and `wrap_user_prompt(prompt)` before each step,
+expecting a string with a `<memory_context>` block followed by `User: <prompt>`.
+`install.py` adds a `name == "vestige"` branch that constructs
+`VestigeMemorySystem(user_id=req.user_id)`, so every task gets its own Vestige
+scope while sharing one `vestige-mcp` process for the whole run.
+
+Environment variables the adapter reads are documented at the top of
+`vestige_memory_system.py`. The two you will set for a real run are
+`VESTIGE_MCP_BINARY` (a release build) and `VESTIGE_ARENA_DATA_DIR` (a fresh
+directory per task family).
+
+## Running the benchmark
+
+The exact procedure, arm order and analysis call are in section 8 of the
+preregistration. Do not improvise on them; if something has to change, it is
+written into the Amendments section of that file first.

--- a/benchmarks/memoryarena/analyze.py
+++ b/benchmarks/memoryarena/analyze.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Preregistered analysis for the MemoryArena run. Written before any data existed.
+
+    python3 benchmarks/memoryarena/analyze.py \\
+        --arm none=/path/MemoryArena/results/json/math/none \\
+        --arm bm25=/path/MemoryArena/results/json/math/bm25 \\
+        --arm text-embedding-3-small=/path/MemoryArena/results/json/math/text-embedding-3-small \\
+        --arm long_context=/path/MemoryArena/results/json/math/long_context_gpt-5-mini \\
+        --arm vestige=/path/MemoryArena/results/json/math/vestige \\
+        --reference bm25 --sidecar /path/to/vestige-arena-log.jsonl --out results/math.json
+
+Each arm directory is upstream's per-method output: one `<paper_key>/result.jsonl`
+per task, one JSON line per subtask with an `is_correct` field (the judge's
+verdict). Nothing here re-judges anything.
+
+Reports, with n beside every aggregate:
+
+  * per arm: tasks scored, mean Progress Score (PS = correct subtasks / subtasks,
+    then averaged over tasks, upstream's avg_progress_score) and Success Rate
+    (SR = tasks with every subtask correct, upstream's overall_average_passrate)
+  * per arm vs the reference arm, paired on task: PS wins / losses / ties and the
+    exact two-sided sign test p-value with ties dropped
+  * the vestige sidecar: readiness record, wraps, mean context chars, hits per
+    wrap, semanticScore-null rate, recall errors
+
+The decision rule lives in docs/benchmarks/MEMORYARENA-PREREGISTRATION.md and is
+applied here without discretion: a difference is claimed only when p < 0.05 and
+the mean PS points the same way. Standard library only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import pathlib
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+ALPHA = 0.05
+
+
+def load_arm(path: pathlib.Path) -> Dict[str, Tuple[float, bool, int]]:
+    """paper_key -> (progress score, all correct, subtasks)."""
+    out: Dict[str, Tuple[float, bool, int]] = {}
+    for result_file in sorted(path.glob("*/result.jsonl")):
+        rows = [json.loads(l) for l in result_file.read_text(encoding="utf-8").splitlines() if l.strip()]
+        if not rows:
+            continue
+        verdicts = [bool(r.get("is_correct")) for r in rows]
+        out[result_file.parent.name] = (sum(verdicts) / len(verdicts), all(verdicts), len(verdicts))
+    return out
+
+
+def sign_test_p(wins: int, losses: int) -> Optional[float]:
+    """Exact two-sided binomial sign test, ties already removed."""
+    n = wins + losses
+    if n == 0:
+        return None
+    k = min(wins, losses)
+    tail = sum(math.comb(n, i) for i in range(0, k + 1)) / 2 ** n
+    return min(1.0, 2 * tail)
+
+
+def mean(xs: List[float]) -> Optional[float]:
+    return sum(xs) / len(xs) if xs else None
+
+
+def summarise_sidecar(path: pathlib.Path) -> Dict[str, Any]:
+    records = [json.loads(l) for l in path.read_text(encoding="utf-8").splitlines() if l.strip()]
+    starts = [r for r in records if r.get("op") == "start"]
+    wraps = [r for r in records if r.get("op") == "wrap"]
+    adds = [r for r in records if r.get("op") == "add"]
+    hits = sum(w.get("hits", 0) for w in wraps)
+    return {
+        "readiness": starts[-1].get("readiness") if starts else None,
+        "server_info": starts[-1].get("server_info") if starts else None,
+        "adds": len(adds),
+        "mean_add_bytes": mean([a.get("bytes", 0) for a in adds]),
+        "wraps": len(wraps),
+        "wraps_with_hits": sum(1 for w in wraps if w.get("hits", 0) > 0),
+        "mean_hits_per_wrap": mean([w.get("hits", 0) for w in wraps]),
+        "mean_context_chars": mean([w.get("context_chars", 0) for w in wraps]),
+        "semantic_null_rate": (sum(w.get("semantic_null", 0) for w in wraps) / hits) if hits else None,
+        "recall_errors": sum(1 for w in wraps if w.get("error")),
+    }
+
+
+def fmt(x: Optional[float], nd: int = 3) -> str:
+    return "n/a" if x is None else f"{x:.{nd}f}"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--arm", action="append", required=True, metavar="NAME=DIR",
+                    help="arm name and its upstream per-method results directory; repeat per arm")
+    ap.add_argument("--reference", default="bm25", help="arm every other arm is paired against (default bm25)")
+    ap.add_argument("--sidecar", type=pathlib.Path, help="vestige-arena-log.jsonl from the vestige arm")
+    ap.add_argument("--out", type=pathlib.Path, help="write the full report as JSON here")
+    args = ap.parse_args()
+
+    arms: Dict[str, Dict[str, Tuple[float, bool, int]]] = {}
+    for spec in args.arm:
+        if "=" not in spec:
+            sys.exit(f"--arm expects NAME=DIR, got {spec!r}")
+        name, path = spec.split("=", 1)
+        p = pathlib.Path(path)
+        if not p.is_dir():
+            sys.exit(f"arm {name}: {p} is not a directory")
+        arms[name] = load_arm(p)
+    if args.reference not in arms:
+        sys.exit(f"reference arm {args.reference!r} not among {sorted(arms)}")
+
+    report: Dict[str, Any] = {"alpha": ALPHA, "reference": args.reference, "arms": {}, "paired": {}}
+    print(f"| arm | tasks (n) | mean PS | SR | subtasks |")
+    print(f"| --- | --- | --- | --- | --- |")
+    for name, tasks in arms.items():
+        ps = [t[0] for t in tasks.values()]
+        sr = [1.0 if t[1] else 0.0 for t in tasks.values()]
+        subtasks = sum(t[2] for t in tasks.values())
+        report["arms"][name] = {"n_tasks": len(tasks), "mean_ps": mean(ps), "sr": mean(sr), "subtasks": subtasks}
+        print(f"| {name} | {len(tasks)} | {fmt(mean(ps))} | {fmt(mean(sr))} | {subtasks} |")
+
+    ref = arms[args.reference]
+    print()
+    print(f"| arm vs {args.reference} | paired n | wins | losses | ties | sign test p | verdict |")
+    print(f"| --- | --- | --- | --- | --- | --- | --- |")
+    for name, tasks in arms.items():
+        if name == args.reference:
+            continue
+        shared = sorted(set(tasks) & set(ref))
+        wins = sum(1 for k in shared if tasks[k][0] > ref[k][0])
+        losses = sum(1 for k in shared if tasks[k][0] < ref[k][0])
+        ties = len(shared) - wins - losses
+        p = sign_test_p(wins, losses)
+        mean_gap = mean([tasks[k][0] - ref[k][0] for k in shared])
+        if p is None:
+            verdict = "no paired tasks"
+        elif p < ALPHA and mean_gap is not None and mean_gap > 0 and wins > losses:
+            verdict = f"{name} above {args.reference}"
+        elif p < ALPHA and mean_gap is not None and mean_gap < 0 and losses > wins:
+            verdict = f"{name} below {args.reference}"
+        else:
+            verdict = "not separated at this n"
+        report["paired"][name] = {"paired_n": len(shared), "wins": wins, "losses": losses, "ties": ties,
+                                  "sign_test_p": p, "mean_ps_gap": mean_gap, "verdict": verdict}
+        print(f"| {name} | {len(shared)} | {wins} | {losses} | {ties} | {fmt(p, 4)} | {verdict} |")
+
+    if args.sidecar:
+        side = summarise_sidecar(args.sidecar)
+        report["vestige_sidecar"] = side
+        print()
+        print("vestige sidecar:", json.dumps(side, indent=2))
+        if side.get("readiness") and not side["readiness"].get("ready"):
+            print("WARNING: embeddings were never ready; this vestige arm is keyword-only and NOT the preregistered arm.")
+        if side.get("semantic_null_rate") not in (None, 0.0):
+            print("WARNING: some hits had no semanticScore; check the readiness record before quoting.")
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(report, indent=2) + "\n")
+        print(f"\nwrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/memoryarena/configs/math_none.json
+++ b/benchmarks/memoryarena/configs/math_none.json
@@ -1,0 +1,43 @@
+{
+  "task_name": "math",
+  "description": "MemoryArena math formal reasoning with NO memory: the floor arm every other arm is read against",
+  "agent": {
+    "model_name": "gpt-5-mini",
+    "temperature": 0.0,
+    "max_tokens": 8192,
+    "backend": "openai",
+    "base_url": "<OPENAI_BASE_URL>"
+  },
+  "memory": {
+    "session_wise_memory": true,
+    "judge_result_in_memory": false,
+    "memory_system_name": "none",
+    "base_url": "http://0.0.0.0:8000",
+    "timeout": 300
+  },
+  "env": {
+    "env_name": "math",
+    "base_url": "http://0.0.0.0:8001",
+    "timeout": 300,
+    "env_config": {
+      "model_name": "gpt-5-mini",
+      "temperature": 1.0,
+      "max_tokens": 4096,
+      "backend": "openai",
+      "base_url": "<OPENAI_BASE_URL>",
+      "max_steps": 10
+    }
+  },
+  "task_specific": {
+    "max_steps": 10,
+    "auto_eval_after_run": true,
+    "dataset": {
+      "hf_dataset": "ZexueHe/memoryarena",
+      "hf_config": "formal_reasoning_math",
+      "hf_split": "test"
+    }
+  },
+  "output": {
+    "json_output_dir": "./results/json/math"
+  }
+}

--- a/benchmarks/memoryarena/configs/math_vestige.json
+++ b/benchmarks/memoryarena/configs/math_vestige.json
@@ -1,0 +1,43 @@
+{
+  "task_name": "math",
+  "description": "MemoryArena formal reasoning with Vestige as the memory layer (preregistered run, see docs/benchmarks/MEMORYARENA-PREREGISTRATION.md)",
+  "agent": {
+    "model_name": "gpt-5-mini",
+    "temperature": 0.0,
+    "max_tokens": 8192,
+    "backend": "openai",
+    "base_url": "<OPENAI_BASE_URL>"
+  },
+  "memory": {
+    "session_wise_memory": true,
+    "judge_result_in_memory": false,
+    "memory_system_name": "vestige",
+    "base_url": "http://0.0.0.0:8000",
+    "timeout": 300
+  },
+  "env": {
+    "env_name": "math",
+    "base_url": "http://0.0.0.0:8001",
+    "timeout": 300,
+    "env_config": {
+      "model_name": "gpt-5-mini",
+      "temperature": 1.0,
+      "max_tokens": 4096,
+      "backend": "openai",
+      "base_url": "<OPENAI_BASE_URL>",
+      "max_steps": 10
+    }
+  },
+  "task_specific": {
+    "max_steps": 10,
+    "auto_eval_after_run": true,
+    "dataset": {
+      "hf_dataset": "ZexueHe/memoryarena",
+      "hf_config": "formal_reasoning_math",
+      "hf_split": "test"
+    }
+  },
+  "output": {
+    "json_output_dir": "./results/json/math"
+  }
+}

--- a/benchmarks/memoryarena/configs/phys_bm25.json
+++ b/benchmarks/memoryarena/configs/phys_bm25.json
@@ -1,0 +1,43 @@
+{
+  "task_name": "phys",
+  "description": "MemoryArena physics formal reasoning with the upstream BM25 control (upstream ships math_bm25.json but no phys_bm25.json; this file mirrors it field for field)",
+  "agent": {
+    "model_name": "gpt-5-mini",
+    "temperature": 0.0,
+    "max_tokens": 8192,
+    "backend": "openai",
+    "base_url": "<OPENAI_BASE_URL>"
+  },
+  "memory": {
+    "session_wise_memory": true,
+    "judge_result_in_memory": false,
+    "memory_system_name": "bm25",
+    "base_url": "http://0.0.0.0:8000",
+    "timeout": 300
+  },
+  "env": {
+    "env_name": "phys",
+    "base_url": "http://0.0.0.0:8001",
+    "timeout": 300,
+    "env_config": {
+      "model_name": "gpt-5-mini",
+      "temperature": 1.0,
+      "max_tokens": 4096,
+      "backend": "openai",
+      "base_url": "<OPENAI_BASE_URL>",
+      "max_steps": 10
+    }
+  },
+  "task_specific": {
+    "max_steps": 10,
+    "auto_eval_after_run": true,
+    "dataset": {
+      "hf_dataset": "ZexueHe/memoryarena",
+      "hf_config": "formal_reasoning_phys",
+      "hf_split": "test"
+    }
+  },
+  "output": {
+    "json_output_dir": "./results/json/phys"
+  }
+}

--- a/benchmarks/memoryarena/configs/phys_none.json
+++ b/benchmarks/memoryarena/configs/phys_none.json
@@ -1,0 +1,43 @@
+{
+  "task_name": "phys",
+  "description": "MemoryArena phys formal reasoning with NO memory: the floor arm every other arm is read against",
+  "agent": {
+    "model_name": "gpt-5-mini",
+    "temperature": 0.0,
+    "max_tokens": 8192,
+    "backend": "openai",
+    "base_url": "<OPENAI_BASE_URL>"
+  },
+  "memory": {
+    "session_wise_memory": true,
+    "judge_result_in_memory": false,
+    "memory_system_name": "none",
+    "base_url": "http://0.0.0.0:8000",
+    "timeout": 300
+  },
+  "env": {
+    "env_name": "phys",
+    "base_url": "http://0.0.0.0:8001",
+    "timeout": 300,
+    "env_config": {
+      "model_name": "gpt-5-mini",
+      "temperature": 1.0,
+      "max_tokens": 4096,
+      "backend": "openai",
+      "base_url": "<OPENAI_BASE_URL>",
+      "max_steps": 10
+    }
+  },
+  "task_specific": {
+    "max_steps": 10,
+    "auto_eval_after_run": true,
+    "dataset": {
+      "hf_dataset": "ZexueHe/memoryarena",
+      "hf_config": "formal_reasoning_phys",
+      "hf_split": "test"
+    }
+  },
+  "output": {
+    "json_output_dir": "./results/json/phys"
+  }
+}

--- a/benchmarks/memoryarena/configs/phys_vestige.json
+++ b/benchmarks/memoryarena/configs/phys_vestige.json
@@ -1,0 +1,43 @@
+{
+  "task_name": "phys",
+  "description": "MemoryArena physics formal reasoning with Vestige as the memory layer (preregistered run, see docs/benchmarks/MEMORYARENA-PREREGISTRATION.md)",
+  "agent": {
+    "model_name": "gpt-5-mini",
+    "temperature": 0.0,
+    "max_tokens": 8192,
+    "backend": "openai",
+    "base_url": "<OPENAI_BASE_URL>"
+  },
+  "memory": {
+    "session_wise_memory": true,
+    "judge_result_in_memory": false,
+    "memory_system_name": "vestige",
+    "base_url": "http://0.0.0.0:8000",
+    "timeout": 300
+  },
+  "env": {
+    "env_name": "phys",
+    "base_url": "http://0.0.0.0:8001",
+    "timeout": 300,
+    "env_config": {
+      "model_name": "gpt-5-mini",
+      "temperature": 1.0,
+      "max_tokens": 4096,
+      "backend": "openai",
+      "base_url": "<OPENAI_BASE_URL>",
+      "max_steps": 10
+    }
+  },
+  "task_specific": {
+    "max_steps": 10,
+    "auto_eval_after_run": true,
+    "dataset": {
+      "hf_dataset": "ZexueHe/memoryarena",
+      "hf_config": "formal_reasoning_phys",
+      "hf_split": "test"
+    }
+  },
+  "output": {
+    "json_output_dir": "./results/json/phys"
+  }
+}

--- a/benchmarks/memoryarena/install.py
+++ b/benchmarks/memoryarena/install.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Install the Vestige adapter into a local MemoryArena clone.
+
+    python3 benchmarks/memoryarena/install.py --memoryarena /path/to/MemoryArena
+
+What it does, idempotently, and refuses to guess about:
+
+1. Checks the clone's HEAD against MEMORYARENA.lock.json (--allow-unpinned to
+   proceed anyway; the run is then not the preregistered one and the results
+   must say so).
+2. Copies vestige_memory_system.py to memory/memory_systems/vestige.py.
+3. Adds `from .vestige import VestigeMemorySystem` to memory/memory_systems/__init__.py.
+4. Adds the import and a `name == "vestige"` branch to memory/server.py, next to
+   the existing reasoningbank branch, so the server constructs
+   VestigeMemorySystem(user_id=req.user_id) and each task gets its own scope.
+5. Copies the run configs into configs/formal_reasoning_configs/.
+
+Standard library only. Every edit is anchored on exact upstream text and fails
+loudly if the anchor is missing, instead of producing a half-installed tree.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+LOCK = json.loads((HERE / "MEMORYARENA.lock.json").read_text())
+
+IMPORT_ANCHOR = "    ZepMemorySystem,\n)"
+IMPORT_INSERT = "    ZepMemorySystem,\n    VestigeMemorySystem,\n    NoMemorySystem,\n)"
+BRANCH_ANCHOR = '    elif name in {"reasoningbank"}:\n'
+BRANCH_INSERT = (
+    '    elif name == "vestige":\n'
+    "        memory_system = VestigeMemorySystem(user_id=req.user_id)\n"
+    '    elif name == "none":\n'
+    "        memory_system = NoMemorySystem(user_id=req.user_id)\n"
+    '    elif name in {"reasoningbank"}:\n'
+)
+INIT_LINE = "from .vestige import VestigeMemorySystem, NoMemorySystem\n"
+
+
+def fail(msg: str) -> None:
+    sys.exit(f"install.py: {msg}")
+
+
+def head_of(repo: pathlib.Path) -> str:
+    try:
+        return subprocess.run(["git", "-C", str(repo), "rev-parse", "HEAD"],
+                              check=True, capture_output=True, text=True).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        fail(f"cannot read git HEAD of {repo}: {exc}")
+        return ""
+
+
+def edit(path: pathlib.Path, anchor: str, insert: str, marker: str, dry_run: bool) -> str:
+    text = path.read_text()
+    if marker in text:
+        return "already present"
+    if anchor not in text:
+        fail(f"anchor not found in {path}; upstream changed shape, refusing to guess:\n{anchor!r}")
+    if text.count(anchor) != 1:
+        fail(f"anchor is not unique in {path}: {anchor!r}")
+    if not dry_run:
+        path.write_text(text.replace(anchor, insert, 1))
+    return "inserted"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--memoryarena", required=True, help="path to a MemoryArena clone")
+    ap.add_argument("--allow-unpinned", action="store_true",
+                    help="proceed when HEAD differs from the pinned revision (results are then not preregistered)")
+    ap.add_argument("--dry-run", action="store_true", help="report what would change, write nothing")
+    args = ap.parse_args()
+
+    repo = pathlib.Path(args.memoryarena).resolve()
+    server_py = repo / "memory" / "server.py"
+    init_py = repo / "memory" / "memory_systems" / "__init__.py"
+    systems_dir = repo / "memory" / "memory_systems"
+    configs_dir = repo / "configs" / "formal_reasoning_configs"
+    for required in (server_py, init_py, configs_dir):
+        if not required.exists():
+            fail(f"{required} not found; is {repo} a MemoryArena clone?")
+
+    head = head_of(repo)
+    pinned = LOCK["repo_revision"]
+    if head != pinned:
+        msg = f"HEAD {head[:12]} differs from pinned {pinned[:12]}"
+        if not args.allow_unpinned:
+            fail(msg + ". Check out the pinned revision or pass --allow-unpinned.")
+        print(f"WARNING: {msg}; this run is NOT the preregistered one, record that with the results.")
+    else:
+        print(f"pinned revision confirmed: {head[:12]}")
+
+    # 2. adapter file
+    target = systems_dir / "vestige.py"
+    src = HERE / "vestige_memory_system.py"
+    if args.dry_run:
+        print(f"would copy {src.name} -> {target}")
+    else:
+        shutil.copyfile(src, target)
+        print(f"copied {src.name} -> {target}")
+
+    # 3. package export
+    init_text = init_py.read_text()
+    if INIT_LINE.strip() in init_text:
+        print("__init__.py: already present")
+    else:
+        if not args.dry_run:
+            sep = "" if init_text.endswith("\n") or not init_text else "\n"
+            init_py.write_text(init_text + sep + INIT_LINE)
+        print("__init__.py: inserted")
+
+    # 4. server wiring
+    print("server.py import:", edit(server_py, IMPORT_ANCHOR, IMPORT_INSERT, "VestigeMemorySystem,", args.dry_run))
+    print("server.py branch:", edit(server_py, BRANCH_ANCHOR, BRANCH_INSERT, 'name == "vestige"', args.dry_run))
+
+    # 5. configs
+    for cfg in sorted((HERE / "configs").glob("*.json")):
+        dest = configs_dir / cfg.name
+        if args.dry_run:
+            print(f"would copy {cfg.name} -> {dest}")
+        else:
+            shutil.copyfile(cfg, dest)
+            print(f"copied {cfg.name} -> {dest}")
+
+    print()
+    print("Next: export VESTIGE_MCP_BINARY=/abs/path/to/vestige-mcp (a release build),")
+    print("      export VESTIGE_ARENA_DATA_DIR=/abs/path/for/this/run,")
+    print("      start `python env/env_server.py` and `python memory/server.py`, then")
+    print("      python run_math.py -c configs/formal_reasoning_configs/math_vestige.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/memoryarena/smoke_test.py
+++ b/benchmarks/memoryarena/smoke_test.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Smoke test for the Vestige MemoryArena adapter against a real vestige-mcp.
+
+    cargo build -p vestige-mcp
+    python3 benchmarks/memoryarena/smoke_test.py
+
+Needs no MemoryArena checkout, no LLM key and no network. It checks the
+properties the preregistered run depends on, each as a hard assertion:
+
+  1. round trip:   add two facts, wrap a question, the right fact comes back
+                   inside <memory_context> (upstream test_memory.py's own check)
+  2. isolation:    a second task (another user_id) asking the same question
+                   gets "None", never the first task's memories
+  3. real vectors: the readiness guard reported embeddings ready, and the
+                   round-trip hits carry a non-null semanticScore
+  4. long query:   a 3,000+ character LaTeX-heavy prompt (the shape of a
+                   formal_reasoning task with BACKGROUND) wraps without error
+  5. entry shape:  an upstream-shaped "## Task ... ## solution ..." entry is
+                   retrievable by a later related task
+  6. sidecar log:  every add and wrap was written with byte counts
+
+Exit code 0 on PASS, 1 on any FAIL. Standard library only.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import time
+
+HERE = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+os.environ.setdefault("VESTIGE_ARENA_DATA_DIR", tempfile.mkdtemp(prefix="vestige-arena-smoke-"))
+
+import vestige_memory_system as vms  # noqa: E402
+
+FAILS: list[str] = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    print(f"[{'PASS' if ok else 'FAIL'}] {name}" + (f"  ({detail})" if detail else ""))
+    if not ok:
+        FAILS.append(name)
+
+
+def main() -> int:
+    t0 = time.monotonic()
+    a = vms.VestigeMemorySystem(user_id="smoke-task-a")
+    ready = vms.readiness()
+    print("readiness:", json.dumps(ready))
+    check("3a embeddings ready before first retrieval", ready.get("ready") is True, ready.get("method") or "")
+
+    # 1. round trip, upstream's own phrasing
+    a.add_chunk("Bob live in Boston and my favorite color is teal.")
+    a.add_chunk("Alice live in Santa Clara and her favorite color is black.")
+    wrapped = a.wrap_user_prompt("where does Bob live?")
+    check("1 markers present", "<memory_context>" in wrapped and "</memory_context>" in wrapped)
+    check("1 right fact retrieved", "Boston" in wrapped)
+    check("1 prompt appended in upstream shape", wrapped.rstrip().endswith("User: where does Bob live?"))
+
+    # 3b. real vectors on the round trip
+    log_path = pathlib.Path(os.environ.get("VESTIGE_ARENA_LOG") or
+                            pathlib.Path(a.server.data_dir) / "vestige-arena-log.jsonl")
+    wraps = [json.loads(l) for l in log_path.read_text().splitlines() if '"op": "wrap"' in l]
+    last = wraps[-1] if wraps else {}
+    check("3b semanticScore non-null on hits", last.get("hits", 0) > 0 and last.get("semantic_null") == 0,
+          f"hits={last.get('hits')} semantic_null={last.get('semantic_null')}")
+
+    # 2. isolation
+    b = vms.VestigeMemorySystem(user_id="smoke-task-b")
+    b.add_chunk("Carol lives in Denver and likes green.")
+    wrapped_b = b.wrap_user_prompt("where does Bob live?")
+    # Judge the memory block only: the echoed prompt legitimately contains "Bob".
+    context_b = wrapped_b.split("</memory_context>")[0]
+    check("2 other task's context has no Boston", "Boston" not in context_b and "teal" not in context_b)
+    records_b = [json.loads(l) for l in log_path.read_text().splitlines()]
+    added_b = {r["nodeId"] for r in records_b if r.get("op") == "add" and r.get("scope") == b.scope}
+    wrap_b = [r for r in records_b if r.get("op") == "wrap" and r.get("scope") == b.scope][-1]
+    check("2 every id returned to task b was written by task b", set(wrap_b["ids"]) <= added_b,
+          f"returned={wrap_b['ids']} own={sorted(added_b)}")
+    check("2 scopes differ", a.scope != b.scope, f"{a.scope} vs {b.scope}")
+
+    # 4. long LaTeX query
+    background = (
+        "### BACKGROUND:\nLet $G$ be a finite group and $H \\le G$ a subgroup. Define the index "
+        "$[G:H] = |G|/|H|$. For a prime $p$, a Sylow $p$-subgroup is a maximal $p$-subgroup. "
+        "Recall $\\sum_{i=1}^{n} \\frac{1}{i^2} = \\frac{\\pi^2}{6}$ in the limit, and "
+        "$\\int_0^\\infty e^{-x^2}\\,dx = \\frac{\\sqrt{\\pi}}{2}$. "
+    ) * 12
+    long_prompt = background + "\n### PROBLEM:\nShow that $n_p \\equiv 1 \\pmod p$ where $n_p$ is the number of Sylow $p$-subgroups."
+    check("4 long prompt is long enough to matter", len(long_prompt) > 3000, f"{len(long_prompt)} chars")
+    try:
+        wrapped_long = a.wrap_user_prompt(long_prompt)
+        check("4 long LaTeX prompt wraps without error", "<memory_context>" in wrapped_long)
+    except Exception as exc:  # pragma: no cover
+        check("4 long LaTeX prompt wraps without error", False, repr(exc)[:200])
+    last_long = [json.loads(l) for l in log_path.read_text().splitlines() if '"op": "wrap"' in l][-1]
+    check("4 recall did not error internally", last_long.get("error") is None, str(last_long.get("error"))[:120])
+
+    # 5. upstream entry shape
+    c = vms.VestigeMemorySystem(user_id="smoke-task-c")
+    c.add_chunk("## Task: Compute the order of the automorphism group of the cyclic group Z_12.\n"
+                "## solution: Aut(Z_12) is isomorphic to the unit group (Z/12Z)^*, which has phi(12) = 4 elements.\n")
+    c.add_chunk("## Task: State Lagrange's theorem for finite groups.\n"
+                "## solution: The order of a subgroup divides the order of the group.\n")
+    wrapped_c = c.wrap_user_prompt("Using the previous result on Aut(Z_12), how many automorphisms fix the generator?")
+    check("5 related earlier subtask retrieved", "Aut(Z_12)" in wrapped_c or "phi(12)" in wrapped_c)
+
+    # 6. sidecar completeness
+    records = [json.loads(l) for l in log_path.read_text().splitlines()]
+    adds = [r for r in records if r.get("op") == "add"]
+    wraps = [r for r in records if r.get("op") == "wrap"]
+    check("6 every add logged with bytes", len(adds) == 5 and all("bytes" in r for r in adds), f"{len(adds)} adds")
+    check("6 every wrap logged with context_chars", len(wraps) == 4 and all("context_chars" in r for r in wraps), f"{len(wraps)} wraps")
+    check("6 start record carries server_info", any(r.get("op") == "start" and r.get("server_info") for r in records))
+
+    print(f"\n{len(FAILS)} failure(s) in {time.monotonic() - t0:.1f}s; data dir {a.server.data_dir}")
+    if FAILS:
+        print("FAILED:", ", ".join(FAILS))
+        print("server stderr tail:")
+        for line in a.server.stderr_tail(15):
+            print("   ", line)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/memoryarena/vestige_memory_system.py
+++ b/benchmarks/memoryarena/vestige_memory_system.py
@@ -1,0 +1,451 @@
+"""Vestige as a MemoryArena memory system.
+
+MemoryArena (arXiv:2602.16313, https://github.com/ZexueHe/MemoryArena) drives a
+memory backend through two duck-typed methods on a class it constructs once per
+task: ``add_chunk(chunk: str)`` after every agent step, and
+``wrap_user_prompt(prompt: str) -> str`` before every step. This module gives
+that interface to a live ``vestige-mcp`` server over MCP stdio, so the agent,
+the environment, the judge and the evaluator stay exactly upstream's and the
+only variable that changes between arms is the memory layer.
+
+Design decisions, all preregistered in
+``docs/benchmarks/MEMORYARENA-PREREGISTRATION.md``:
+
+* One ``vestige-mcp`` process per Python process, shared by every task. Tasks
+  are isolated by Vestige's ``scope`` namespace (``includeCrossScope`` is off by
+  default on recall), so a task never sees another task's memories. A fresh
+  process per task would pay the embedding warm-up 40 times and prove nothing.
+* ``add_chunk`` writes with ``forceCreate: true``. The unit the agent stored is
+  the unit retrieval ranks, the same as upstream's BM25 and embedding arms.
+* ``wrap_user_prompt`` renders the retrieved memories in the exact shape of
+  upstream ``RAGMemorySystem.wrap_user_prompt`` (``<memory>`` blocks inside
+  ``<memory_context>``, then ``User: <prompt>``), with the same default
+  ``top_k`` of 3, so the agent prompt differs between arms only in which
+  memories were chosen.
+* Retrieval never runs against a half-ready server. The first instance blocks
+  until the embedding runtime reports ready (or a probe recall returns a real
+  ``semanticScore``). A keyword-only fallback is a different system; measuring
+  it by accident is the failure this guard exists for.
+* Every add and every wrap is appended to a JSONL sidecar with byte counts, so
+  the blob-size confound (a bigger context earns more judge credit) can be
+  checked after the run instead of argued about.
+
+Standard library only. No pip install.
+
+Environment variables:
+
+  VESTIGE_MCP_BINARY            path to vestige-mcp (default: target/debug/vestige-mcp
+                                two levels above this file, else `vestige-mcp` on PATH)
+  VESTIGE_ARENA_DATA_DIR        Vestige data dir for the run (default: a fresh temp dir)
+  VESTIGE_ARENA_TOP_K           memories per wrap (default 3, matches upstream RAG)
+  VESTIGE_ARENA_READY_TIMEOUT   seconds to wait for embeddings (default 180)
+  VESTIGE_ARENA_LOG             JSONL sidecar path (default <data dir>/vestige-arena-log.jsonl)
+  VESTIGE_ARENA_ALLOW_KEYWORD_ONLY=1
+                                proceed if embeddings never come up (logged loudly; the
+                                run is then NOT the preregistered arm)
+"""
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import pathlib
+import queue
+import re
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+
+DEFAULT_TOP_K = 3
+DEFAULT_READY_TIMEOUT = 180.0
+PROBE_SCOPE = "arena_probe"
+MEMORY_TAG = "memoryarena"
+
+
+class VestigeError(RuntimeError):
+    pass
+
+
+# --------------------------------------------------------------------------
+# Minimal JSON-RPC over stdio client. Same protocol lessons as
+# benchmarks/memconflict/mcp_client.py: line-delimited JSON, initialize then
+# notifications/initialized, stdin stays open for the life of the session,
+# server notifications (no id) are skipped while waiting for a response.
+# --------------------------------------------------------------------------
+class _StdioServer:
+    def __init__(self, binary: str, data_dir: str, timeout: float = 300.0) -> None:
+        self.binary = str(pathlib.Path(binary).resolve())
+        self.data_dir = str(pathlib.Path(data_dir).resolve())
+        self.timeout = timeout
+        self._id = 0
+        self._lock = threading.Lock()
+        self._proc: Optional[subprocess.Popen] = None
+        self._out: "queue.Queue[Optional[str]]" = queue.Queue()
+        self._stderr: List[str] = []
+        self.server_info: Dict[str, Any] = {}
+
+    def start(self) -> None:
+        pathlib.Path(self.data_dir).mkdir(parents=True, exist_ok=True)
+        env = dict(os.environ)
+        env["VESTIGE_DATA_DIR"] = self.data_dir
+        env["VESTIGE_DASHBOARD_ENABLED"] = "false"
+        env["VESTIGE_HTTP_ENABLED"] = "0"
+        self._proc = subprocess.Popen(
+            [self.binary],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            text=True,
+            bufsize=1,
+        )
+        threading.Thread(target=self._pump_stdout, daemon=True).start()
+        threading.Thread(target=self._pump_stderr, daemon=True).start()
+        result = self.request(
+            "initialize",
+            {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "vestige-memoryarena-adapter", "version": "1.0"},
+            },
+            timeout=120.0,
+        )
+        self.server_info = result.get("serverInfo", {})
+        self.notify("notifications/initialized")
+
+    def _pump_stdout(self) -> None:
+        assert self._proc and self._proc.stdout
+        for line in self._proc.stdout:
+            line = line.strip()
+            if line:
+                self._out.put(line)
+        self._out.put(None)
+
+    def _pump_stderr(self) -> None:
+        assert self._proc and self._proc.stderr
+        for line in self._proc.stderr:
+            self._stderr.append(line.rstrip())
+            if len(self._stderr) > 2000:
+                del self._stderr[:1000]
+
+    def close(self) -> None:
+        proc, self._proc = self._proc, None
+        if proc is None:
+            return
+        try:
+            if proc.stdin:
+                proc.stdin.close()
+            proc.terminate()
+            proc.wait(timeout=15)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    def stderr_tail(self, n: int = 30) -> List[str]:
+        return self._stderr[-n:]
+
+    def _send(self, payload: Dict[str, Any]) -> None:
+        if not self._proc or not self._proc.stdin:
+            raise VestigeError("vestige-mcp is not running")
+        self._proc.stdin.write(json.dumps(payload) + "\n")
+        self._proc.stdin.flush()
+
+    def _await(self, want_id: int, timeout: float) -> Dict[str, Any]:
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise VestigeError(f"timeout waiting for response id={want_id}")
+            try:
+                line = self._out.get(timeout=remaining)
+            except queue.Empty:
+                raise VestigeError(f"timeout waiting for response id={want_id}")
+            if line is None:
+                tail = "\n".join(self.stderr_tail())
+                raise VestigeError(f"vestige-mcp exited. stderr tail:\n{tail}")
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if msg.get("id") == want_id:
+                return msg
+            # Anything else is a server notification (warm-up logging, etc.).
+
+    def request(self, method: str, params: Optional[Dict[str, Any]] = None,
+                timeout: Optional[float] = None) -> Dict[str, Any]:
+        # MemoryArena's FastAPI server may call from worker threads; serialise.
+        with self._lock:
+            self._id += 1
+            rid = self._id
+            self._send({"jsonrpc": "2.0", "id": rid, "method": method, "params": params or {}})
+            msg = self._await(rid, timeout if timeout is not None else self.timeout)
+        if "error" in msg:
+            raise VestigeError(f"{method} failed: {msg['error']}")
+        return msg.get("result", {})
+
+    def notify(self, method: str, params: Optional[Dict[str, Any]] = None) -> None:
+        with self._lock:
+            self._send({"jsonrpc": "2.0", "method": method, "params": params or {}})
+
+    def call_tool(self, name: str, arguments: Dict[str, Any]) -> Any:
+        result = self.request("tools/call", {"name": name, "arguments": arguments})
+        if result.get("isError"):
+            raise VestigeError(f"tool {name} returned isError: {result}")
+        for block in result.get("content") or []:
+            if block.get("type") == "text":
+                text = block.get("text", "")
+                try:
+                    return json.loads(text)
+                except json.JSONDecodeError:
+                    return text
+        return result
+
+
+# --------------------------------------------------------------------------
+# Shared server + sidecar log
+# --------------------------------------------------------------------------
+_SERVER: Optional[_StdioServer] = None
+_SERVER_LOCK = threading.Lock()
+_LOG_PATH: Optional[pathlib.Path] = None
+_LOG_LOCK = threading.Lock()
+_READINESS: Dict[str, Any] = {}
+
+
+def _default_binary() -> str:
+    env = os.environ.get("VESTIGE_MCP_BINARY")
+    if env:
+        return env
+    here = pathlib.Path(__file__).resolve()
+    for candidate in (
+        here.parents[2] / "target" / "debug" / "vestige-mcp",
+        here.parents[2] / "target" / "release" / "vestige-mcp",
+    ):
+        if candidate.exists():
+            return str(candidate)
+    found = shutil.which("vestige-mcp")
+    if found:
+        return found
+    raise VestigeError(
+        "vestige-mcp binary not found. Set VESTIGE_MCP_BINARY or run `cargo build -p vestige-mcp`."
+    )
+
+
+def _log(record: Dict[str, Any]) -> None:
+    if _LOG_PATH is None:
+        return
+    record = dict(record)
+    record["t"] = round(time.time(), 3)
+    with _LOG_LOCK:
+        with _LOG_PATH.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def _find_key(value: Any, key: str) -> Any:
+    """Depth-first search for `key` in a nested JSON value. None if absent."""
+    if isinstance(value, dict):
+        if key in value:
+            return value[key]
+        for v in value.values():
+            hit = _find_key(v, key)
+            if hit is not None:
+                return hit
+    elif isinstance(value, list):
+        for v in value:
+            hit = _find_key(v, key)
+            if hit is not None:
+                return hit
+    return None
+
+
+def _results_of(response: Any) -> List[Dict[str, Any]]:
+    if isinstance(response, dict):
+        for key in ("results", "memories", "items"):
+            if isinstance(response.get(key), list):
+                return [r for r in response[key] if isinstance(r, dict)]
+    return []
+
+
+def _wait_ready(server: _StdioServer, timeout: float) -> Dict[str, Any]:
+    """Block until the embedding runtime is ready.
+
+    Two signals, tried in order on every poll: the `embeddingReady` flag that
+    `memory_status(action="health")` reports, then a probe (ingest one memory in a
+    dedicated scope, recall it, require a non-null `semanticScore`). Either one
+    is enough. Neither within `timeout` is a hard failure unless
+    VESTIGE_ARENA_ALLOW_KEYWORD_ONLY=1.
+    """
+    t0 = time.monotonic()
+    probe_id: Optional[str] = None
+    probe_text = "Vestige MemoryArena readiness probe: the lighthouse keeper feeds the gulls at dawn."
+    polls = 0
+    while True:
+        polls += 1
+        # Signal 1: the status flag.
+        try:
+            status = server.call_tool("memory_status", {"view": "health"})
+            flag = _find_key(status, "embeddingReady")
+            if flag is True:
+                return {"ready": True, "method": "memory_status.embeddingReady",
+                        "seconds": round(time.monotonic() - t0, 2), "polls": polls}
+        except VestigeError:
+            flag = None
+        # Signal 2: the probe.
+        try:
+            if probe_id is None:
+                created = server.call_tool(
+                    "smart_ingest",
+                    {"content": probe_text, "node_type": "note", "tags": [MEMORY_TAG, "probe"],
+                     "scope": PROBE_SCOPE, "forceCreate": True},
+                )
+                probe_id = str(_find_key(created, "nodeId") or "")
+            hits = _results_of(server.call_tool(
+                "recall",
+                {"query": "lighthouse keeper gulls dawn", "limit": 3, "scope": PROBE_SCOPE,
+                 "detail_level": "summary"},
+            ))
+            if any(h.get("semanticScore") is not None for h in hits):
+                return {"ready": True, "method": "probe.semanticScore",
+                        "seconds": round(time.monotonic() - t0, 2), "polls": polls,
+                        "status_flag_seen": flag}
+        except VestigeError:
+            pass
+        if time.monotonic() - t0 >= timeout:
+            record = {"ready": False, "method": None, "seconds": round(time.monotonic() - t0, 2),
+                      "polls": polls, "status_flag_seen": flag,
+                      "stderr_tail": server.stderr_tail(10)}
+            if os.environ.get("VESTIGE_ARENA_ALLOW_KEYWORD_ONLY") == "1":
+                record["WARNING"] = ("embeddings never became ready; this run is keyword-only and "
+                                     "is NOT the preregistered vestige arm")
+                return record
+            raise VestigeError(
+                f"embedding runtime not ready after {timeout:.0f}s; refusing to measure a "
+                f"keyword-only fallback. Set VESTIGE_ARENA_ALLOW_KEYWORD_ONLY=1 to override. "
+                f"stderr tail: {server.stderr_tail(10)}"
+            )
+        time.sleep(2.0)
+
+
+def shared_server() -> _StdioServer:
+    """Start (once) and return the process-wide vestige-mcp server."""
+    global _SERVER, _LOG_PATH, _READINESS
+    with _SERVER_LOCK:
+        if _SERVER is not None:
+            return _SERVER
+        binary = _default_binary()
+        data_dir = os.environ.get("VESTIGE_ARENA_DATA_DIR") or tempfile.mkdtemp(prefix="vestige-arena-datadir-")
+        _LOG_PATH = pathlib.Path(os.environ.get("VESTIGE_ARENA_LOG") or
+                                 pathlib.Path(data_dir) / "vestige-arena-log.jsonl")
+        _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        server = _StdioServer(binary, data_dir)
+        server.start()
+        timeout = float(os.environ.get("VESTIGE_ARENA_READY_TIMEOUT", DEFAULT_READY_TIMEOUT))
+        _READINESS = _wait_ready(server, timeout)
+        _log({"op": "start", "binary": server.binary, "data_dir": server.data_dir,
+              "server_info": server.server_info, "readiness": _READINESS,
+              "top_k": int(os.environ.get("VESTIGE_ARENA_TOP_K", DEFAULT_TOP_K)),
+              # names only: a ranking override must not go unrecorded, values may be paths
+              "vestige_env_names": sorted(k for k in os.environ if k.startswith("VESTIGE_"))})
+        atexit.register(server.close)
+        _SERVER = server
+        return server
+
+
+def readiness() -> Dict[str, Any]:
+    return dict(_READINESS)
+
+
+def scope_for(user_id: str) -> str:
+    """A scope name Vestige accepts, derived from MemoryArena's user_id (a uuid)."""
+    cleaned = re.sub(r"[^A-Za-z0-9]", "", str(user_id))
+    return f"arena_{cleaned[:32] or uuid.uuid4().hex[:32]}"
+
+
+# --------------------------------------------------------------------------
+# The MemoryArena-facing class
+# --------------------------------------------------------------------------
+class VestigeMemorySystem:
+    """Duck-typed MemoryArena memory backend backed by a live vestige-mcp."""
+
+    def __init__(self, user_id: Optional[str] = None, top_k: Optional[int] = None) -> None:
+        self.user_id = str(user_id) if user_id is not None else str(uuid.uuid4())
+        self.scope = scope_for(self.user_id)
+        self.top_k = int(top_k if top_k is not None else os.environ.get("VESTIGE_ARENA_TOP_K", DEFAULT_TOP_K))
+        self.server = shared_server()
+        self.adds = 0
+        self.wraps = 0
+        _log({"op": "init", "user_id": self.user_id, "scope": self.scope, "top_k": self.top_k})
+
+    # MemoryArena calls this after every step with agent.build_memory_entry(...)
+    def add_chunk(self, chunk: str) -> Dict[str, Any]:
+        if not chunk or not chunk.strip():
+            return {"status": "skipped", "reason": "empty chunk"}
+        t0 = time.monotonic()
+        response = self.server.call_tool(
+            "smart_ingest",
+            {"content": chunk, "node_type": "event", "tags": [MEMORY_TAG],
+             "scope": self.scope, "forceCreate": True},
+        )
+        self.adds += 1
+        node_id = _find_key(response, "nodeId")
+        _log({"op": "add", "scope": self.scope, "chars": len(chunk), "bytes": len(chunk.encode("utf-8")),
+              "nodeId": node_id, "ms": round((time.monotonic() - t0) * 1000, 1)})
+        return {"status": "ok", "nodeId": node_id}
+
+    # MemoryArena calls this before every step with the full task prompt.
+    def wrap_user_prompt(self, prompt: str) -> str:
+        t0 = time.monotonic()
+        hits: List[Dict[str, Any]] = []
+        error: Optional[str] = None
+        if self.adds > 0:
+            try:
+                hits = _results_of(self.server.call_tool(
+                    "recall",
+                    {"query": prompt, "limit": self.top_k, "scope": self.scope,
+                     "detail_level": "summary", "retrieval_mode": "balanced"},
+                ))
+            except VestigeError as exc:  # never take the run down; record it
+                error = str(exc)[:500]
+        lines = ["<memory_context>"]
+        if hits:
+            for hit in hits:
+                content = hit.get("content")
+                if content:
+                    lines.append(f"<memory>{content}</memory>")
+        if len(lines) == 1:
+            lines.append("None")
+        lines.append("</memory_context>")
+        lines.append(f"User: {prompt}")
+        wrapped = "\n".join(lines)
+        self.wraps += 1
+        context_chars = len(wrapped) - len(prompt) - len("User: ") - 1
+        _log({"op": "wrap", "scope": self.scope, "hits": len(hits),
+              "semantic_null": sum(1 for h in hits if h.get("semanticScore") is None),
+              "ids": [h.get("id") for h in hits],
+              "query_chars": len(prompt), "context_chars": context_chars,
+              "error": error, "ms": round((time.monotonic() - t0) * 1000, 1)})
+        return wrapped
+
+
+class NoMemorySystem:
+    """The floor arm: no memory at all, same prompt shape as every other arm.
+
+    Upstream's setup notes mention a "none" memory system but memory/server.py
+    at the pinned revision has no such backend, so the floor is provided here.
+    Anything an agent scores with this arm is the agent and the judge, not
+    memory. Every other arm is read against it.
+    """
+
+    def __init__(self, user_id: Optional[str] = None) -> None:
+        self.user_id = str(user_id) if user_id is not None else str(uuid.uuid4())
+
+    def add_chunk(self, chunk: str) -> Dict[str, Any]:
+        return {"status": "dropped"}
+
+    def wrap_user_prompt(self, prompt: str) -> str:
+        return "\n".join(["<memory_context>", "None", "</memory_context>", f"User: {prompt}"])

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -349,6 +349,36 @@ bounded by ingest throughput.
 
 ---
 
+## MemoryArena, preregistered, not yet run
+
+**Paper:** [MemoryArena: Benchmarking Agent Memory in Interdependent
+Multi-Session Agentic Tasks](https://arxiv.org/abs/2602.16313)
+(arXiv:2602.16313)
+**Upstream code:** <https://github.com/ZexueHe/MemoryArena>, pinned at
+`6cd9de14b71915e39ac742a20dc33785e14b6aab`
+**Harness:** `benchmarks/memoryarena/`
+**Protocol:** [`benchmarks/MEMORYARENA-PREREGISTRATION.md`](benchmarks/MEMORYARENA-PREREGISTRATION.md)
+
+MemoryArena scores memory inside a Memory-Agent-Environment loop: later
+subtasks depend on what the agent learned earlier, so the metric is whether
+retrieval changed a decision, not whether a fact could be found. That is the
+question Vestige exists to answer, which makes it the first standard benchmark
+we fill in.
+
+**There is no Vestige number on MemoryArena.** What exists is the
+preregistration: two formal-reasoning families (40 and 20 tasks), five arms
+that all run every time (a no-memory floor, upstream's BM25 and embedding RAG,
+upstream's long-context baseline, Vestige), Progress Score as the primary
+metric, and one decision rule, a paired exact sign test against BM25 at alpha
+0.05, applied by an analysis script written before any data. The adapter that
+presents a live `vestige-mcp` to upstream's memory interface ships with a smoke
+test against the real binary (round trip, per-task isolation, real vectors,
+long LaTeX prompts). When a run happens, its transcripts, sidecar log and
+manifest are checked in under `benchmarks/memoryarena/results/` and a README
+row appears. Not before, and never next to the paper's own table.
+
+---
+
 ## Rules for citing any number from this page
 
 1. Always cite the arm, the dataset revision, the instance/session cap, and the

--- a/docs/benchmarks/MEMORYARENA-PREREGISTRATION.md
+++ b/docs/benchmarks/MEMORYARENA-PREREGISTRATION.md
@@ -1,0 +1,242 @@
+# MemoryArena: preregistered protocol for the Vestige run
+
+**Status: preregistered, not run. No Vestige number on MemoryArena exists.**
+
+This file fixes the protocol before any data exists. When a number appears, it
+was produced by exactly this protocol, or the deviation is written into the
+Amendments section at the bottom before the number is quoted anywhere. The
+preregistration is the commit that adds this file; the run must use a Vestige
+build whose history contains that commit.
+
+Harness: `benchmarks/memoryarena/`. Tracking issue: #242. Read
+[`../BENCHMARKS.md`](../BENCHMARKS.md) first for why this page is written the
+way it is: after the CauseBench retraction, a number a stranger cannot re-run is
+worse than no number.
+
+## 1. What MemoryArena measures, and why it is the first standard benchmark we fill in
+
+MemoryArena (He et al., [arXiv:2602.16313](https://arxiv.org/abs/2602.16313),
+code at <https://github.com/ZexueHe/MemoryArena>) evaluates memory inside a
+Memory-Agent-Environment loop rather than as a retrieval quiz. An agent works
+through a task made of dependent subtasks; before each subtask the memory
+system wraps the prompt with whatever it chooses to surface, after each
+subtask the agent's trajectory is stored, and later subtasks are only solvable
+if what the agent learned earlier is retrieved and used. The paper's finding is
+that agents near saturation on LoCoMo-style recall benchmarks score low here.
+That gap, passive recall versus decision-relevant memory, is the thesis Vestige
+is built on and the one our own Silent Rotation harness tests. MemoryArena is
+the independent, third-party version of that question, which is why it goes
+first.
+
+The paper's published tables are not reproduced on this page. Read them from
+the PDF. Nothing measured here is placed next to them (section 7).
+
+## 2. Scope of the run
+
+Two of the five task families, both from the released dataset
+`ZexueHe/memoryarena` at the pinned revision:
+
+| family (HF config) | tasks | subtasks per task | one task is |
+| --- | --- | --- | --- |
+| `formal_reasoning_math` | 40 | 2 to 16 | one paper: ordered questions, each with a background text; later questions build on earlier results |
+| `formal_reasoning_phys` | 20 | 2 to 12 | same shape, physics papers |
+
+Why these two: the environment is self-contained (no WebShop server, no travel
+environment, no web-search API), the LLM judge is the only external call, and
+the whole run reproduces from one machine with one API key. The other three
+families (bundled shopping, group travel, progressive search) are out of scope
+for this preregistration. Each gets its own preregistration before any run.
+
+## 3. Pinned before the run
+
+| what | value | where it is recorded |
+| --- | --- | --- |
+| MemoryArena code | `6cd9de14b71915e39ac742a20dc33785e14b6aab` (2026-06-01) | `benchmarks/memoryarena/MEMORYARENA.lock.json`; `install.py` refuses another HEAD without `--allow-unpinned` |
+| Dataset | `ZexueHe/memoryarena` revision `da1a37c8b19280e18627ca01cf368195a5e1d92e`, CC-BY-4.0 | lock file |
+| Evaluator | upstream `env/env_systems/formal_reasoning_env/eval.py` at the pinned revision, unmodified | run manifest |
+| Task agent | `gpt-5-mini`, temperature 0.0, max_tokens 8192 (upstream config values, unchanged) | the config files in `benchmarks/memoryarena/configs/` |
+| Judge | `gpt-5-mini`, temperature 1.0, max_tokens 4096 (upstream values, unchanged) | same |
+| Loop | `max_steps` 10, `session_wise_memory` true, `judge_result_in_memory` false: memory stores the agent's own task, answer and tool calls, never the judge's verdict | same |
+| Vestige | a `--release` build of a commit containing this file; `serverInfo.version`, the commit and the binary SHA-256 go in the manifest and the sidecar start record | `vestige-arena-log.jsonl` start record, `manifest.json` |
+| Vestige configuration | defaults, plus: `forceCreate: true` on every write, `top_k` 3, `retrieval_mode` balanced, `detail_level` summary, one `scope` per task. Nothing else. The sidecar start record lists every `VESTIGE_*` environment variable name present so a ranking-related override cannot go unrecorded | adapter, sidecar |
+| Embedding readiness | the first retrieval waits until `memory_status(view=health)` reports `embeddingReady`, or a probe recall returns a non-null `semanticScore`; the method and the wait are recorded. A run that never got there is keyword-only and is not this arm | sidecar |
+| Data directory | a fresh `VESTIGE_ARENA_DATA_DIR` per family, so the store holds only what this run wrote | manifest |
+
+`forceCreate` is the one non-default and it is there for comparability: the
+unit the agent stored is the unit retrieval ranks, the same as upstream's BM25
+and embedding arms, which index each chunk as written. Letting the ingest gate
+merge or supersede entries would change the corpus the arms are compared on.
+
+## 4. Arms
+
+All five run on both families, same tasks, same task order, same agent, same
+judge. None is optional. One variable changes between arms: what is put inside
+`<memory_context>`.
+
+| arm | `memory_system_name` | what it is | why it is here |
+| --- | --- | --- | --- |
+| `none` | `none` | nothing stored, nothing retrieved; the prompt shape is identical to every other arm | the floor. Anything it scores is the agent and the judge, not memory |
+| `bm25` | `bm25` | upstream `RAGMemorySystem`, Okapi BM25 over the stored chunks, top_k 3 | the earned-complexity bar. A memory system that cannot beat this has not earned its complexity |
+| `text-embedding-3-small` | `text-embedding-3-small` | upstream `RAGMemorySystem` with OpenAI embeddings, top_k 3 | the plain embedding-retrieval bar |
+| `long_context` | `long_context` | upstream: the whole transcript in the prompt, up to 120k tokens | the paper's primary baseline |
+| `vestige` | `vestige` | this adapter over a live `vestige-mcp` | the system under test |
+
+The `none` arm is provided by our adapter because upstream's server at the
+pinned revision has no such backend. It renders `<memory_context>\nNone\n
+</memory_context>\nUser: <prompt>`, which is exactly what upstream's RAG arm
+renders when it has nothing to return, so the agent sees the same shape.
+
+The vestige arm renders retrieved memories as upstream's RAG arm does:
+`<memory>...</memory>` blocks inside `<memory_context>`, then `User: <prompt>`.
+The prompt differs between arms only in which memories were chosen.
+
+Run order within a family: `none` first. If the floor is not near zero on PS
+(section 6), stop and look at the judge before spending on the other arms. Then
+`bm25`, `text-embedding-3-small`, `long_context`, `vestige`. All arms of a
+family run inside the same 48 hours and the dates go in the manifest, because
+the API models behind `gpt-5-mini` drift.
+
+## 5. Metrics
+
+Computed by upstream `eval.py`, unmodified, then read by
+`benchmarks/memoryarena/analyze.py`, which was written before any data existed.
+
+| metric | definition (upstream) | role |
+| --- | --- | --- |
+| PS, Progress Score | per task, correct subtasks / subtasks; then the mean over tasks (`avg_progress_score`) | primary |
+| SR, Success Rate | fraction of tasks with every subtask correct (`overall_average_passrate`) | secondary, reported, never the basis of a claim |
+| `cummulative_passrate_at_min_k` | pass rate by subtask position up to the shortest task, every task contributing | tertiary, reported as the curve: does the memory arm hold up as the dependency chain grows |
+
+Confound metrics, from the vestige sidecar: mean `context_chars` per wrap,
+hits per wrap, `semanticScore`-null rate, recall errors, mean stored-entry
+bytes and the share past Vestige's 8192-byte embedding horizon (full-text
+search still indexes the rest of such an entry).
+
+Every aggregate is printed with its n beside it.
+
+## 6. Decision rules
+
+Applied by `analyze.py` without discretion.
+
+1. **Reference arm is `bm25`.** Every other arm is paired against it task by
+   task on PS. Wins, losses and ties are counted; ties are dropped; the exact
+   two-sided binomial sign test gives p. Alpha is 0.05.
+2. **"Vestige above BM25 on `<family>`" is claimed only if** p < 0.05, wins
+   exceed losses, and mean PS(vestige) exceeds mean PS(bm25). Otherwise the
+   result is written as "not separated at this n", and that sentence comes
+   first, before any number, the way the MemConflict page does it.
+3. **The same rule** gives the comparisons against `text-embedding-3-small` and
+   `long_context`. They are reported; the BM25 comparison is the headline.
+4. **Families are never pooled.** Math and physics are separate claims with
+   separate n.
+5. **SR never carries a claim.** At n of 40 and 20 with near-zero base rates,
+   SR moves by one task.
+6. **Floor check.** If PS(`none`) exceeds 0.15 on a family, the judge is
+   awarding credit without memory on that family; that is reported and no
+   claim is made on the family.
+7. **Blob-size confound.** If the vestige arm's mean `context_chars` exceeds
+   1.25 times three times the mean stored-entry length (the upstream RAG arms'
+   budget: three chunks), every vestige claim on that family carries the
+   confound in the same sentence.
+8. **Readiness.** If the sidecar's readiness record says embeddings were not
+   ready, the vestige arm was keyword-only. It is reported as such and its
+   number is not quoted as Vestige's.
+9. **One run per task per arm.** A task that crashed (API error, timeout) is
+   rerun once and the rerun is logged. Nothing is rerun because of its result.
+   Nothing is re-judged.
+
+## 7. What will not be claimed
+
+- **No placement next to the paper's tables.** The paper reports a
+  GPT-5.1-mini backbone; the released configs run `gpt-5-mini`; the judge is
+  stochastic at temperature 1.0; the API models drift between dates. Our
+  numbers and the paper's do not share a table, a sentence, or a chart.
+- **Nothing about shopping, travel or search.** Not run, not claimed.
+- **No "state of the art", no ranking against systems we did not run** on the
+  same day with the same agent and judge.
+- **No significance where the sign test has nothing to work with.** p is
+  reported with its paired n whatever the n is; a small n is printed, not
+  hidden.
+- **No cross-family pooling and no SR-based claim** (rules 4 and 5).
+
+## 8. Run procedure
+
+Placeholders in angle brackets. Keys go in the environment, never in a config
+file, never in a commit.
+
+```sh
+# upstream, at the pinned revision
+git clone https://github.com/ZexueHe/MemoryArena
+cd MemoryArena
+git checkout 6cd9de14b71915e39ac742a20dc33785e14b6aab
+conda env create -f env/env_systems/formal_reasoning_env/environment.yml   # upstream's environment
+
+# the adapter, the none arm and the run configs
+python3 <vestige>/benchmarks/memoryarena/install.py --memoryarena .
+# edit the copied configs: replace <OPENAI_BASE_URL> with your endpoint (no keys in files)
+
+# Vestige, release build of a commit that contains this file
+(cd <vestige> && cargo build --release -p vestige-mcp)
+export VESTIGE_MCP_BINARY=<vestige>/target/release/vestige-mcp
+export VESTIGE_ARENA_DATA_DIR=<fresh dir for this family>
+export OPENAI_API_KEY=<key>
+
+# servers (two terminals)
+python env/env_server.py
+python memory/server.py
+
+# math, arms in the preregistered order; then eval
+for cfg in math_none math_bm25 math_text_embedding math_longcontext_gpt-5-mini math_vestige; do
+  python run_math.py -c configs/formal_reasoning_configs/$cfg.json
+  python env/env_systems/formal_reasoning_env/eval.py configs/formal_reasoning_configs/$cfg.json
+done
+# physics: a fresh VESTIGE_ARENA_DATA_DIR, then
+# phys_none phys_bm25 phys_text-embedding phys_longcontext_gpt-5-mini phys_vestige
+
+# analysis, one call per family
+python3 <vestige>/benchmarks/memoryarena/analyze.py \
+  --arm none=results/json/math/none \
+  --arm bm25=results/json/math/bm25 \
+  --arm text-embedding-3-small=results/json/math/text-embedding-3-small \
+  --arm long_context=results/json/math/long_context_gpt-5-mini \
+  --arm vestige=results/json/math/vestige \
+  --reference bm25 --sidecar $VESTIGE_ARENA_DATA_DIR/vestige-arena-log.jsonl \
+  --out <vestige>/benchmarks/memoryarena/results/<UTC>/math.json
+```
+
+Before the run, the smoke test must pass against the exact binary that will be
+used:
+
+```sh
+VESTIGE_MCP_BINARY=<vestige>/target/release/vestige-mcp python3 <vestige>/benchmarks/memoryarena/smoke_test.py
+```
+
+## 9. What gets checked in
+
+`benchmarks/memoryarena/results/<UTC>/` containing:
+
+- `manifest.json`: Vestige commit, binary SHA-256, `serverInfo`, MemoryArena
+  and dataset revisions, agent and judge model names, API provider, start and
+  end dates per arm, total API cost, the smoke test output.
+- per family and arm: upstream's `all_results.json` and every
+  `<paper>/result.jsonl` (the transcripts: memory-wrapped prompt, response,
+  judge verdict), unedited.
+- the vestige sidecar `vestige-arena-log.jsonl` for each family.
+- `analyze.py` output JSON and the markdown tables it printed.
+
+The README then gets one table row: both PS numbers with n, the sign test
+verdict, and links to this file and the results directory. Not before.
+
+## 10. Cost and time, an estimate
+
+Upper bound on subtasks per arm: 40 tasks times 16 plus 20 tasks times 12, or
+880; five arms give at most 4,400 agent calls and 4,400 judge calls, all on
+`gpt-5-mini`. Upstream runs tasks sequentially, so wall-clock is dominated by
+API latency: plan on a day for both families across five arms, and API cost
+in the tens of dollars at list prices. These are estimates for planning, not
+part of the protocol.
+
+## 11. Amendments
+
+None. Format for any future entry: date, what changed, why, and whether data
+already existed when the change was made.


### PR DESCRIPTION
## What

Preregisters the MemoryArena run (#242) and ships the adapter, installer, configs, smoke test and analysis script. No benchmark number is in this PR. The run is the next step and needs an OpenAI key.

## Why

MemoryArena (arXiv:2602.16313) scores memory inside an agent loop where later subtasks depend on what was learned earlier. That is the question Vestige exists to answer, so it is the first standard benchmark whose empty Vestige column we fill. After the CauseBench retraction the rule is that a number a stranger cannot re-run is worse than no number, so the protocol, the arms, the metric and the decision rule are fixed here, in a commit that predates any data.

## The protocol, in short

- Two families: `formal_reasoning_math` (40 tasks) and `formal_reasoning_phys` (20 tasks). The other three need their own preregistration.
- Five arms, all run every time: `none` (floor), `bm25` (upstream RAG, top_k 3), `text-embedding-3-small` (upstream), `long_context` (upstream), `vestige`.
- Primary metric: Progress Score. SR is reported and never carries a claim. Families are never pooled.
- One decision rule: paired per-task exact two-sided sign test against BM25, ties dropped, alpha 0.05. "Vestige above BM25" only if p < 0.05, wins exceed losses, and mean PS is higher. Otherwise "not separated at this n", said first.
- Floor check, blob-size confound check, readiness check, one run per task, no re-judging. Nothing goes next to the paper's Table 3.
- Any deviation is written into the Amendments section before a number is quoted.

## What ships

| File | Purpose |
| --- | --- |
| `docs/benchmarks/MEMORYARENA-PREREGISTRATION.md` | The protocol. |
| `benchmarks/memoryarena/vestige_memory_system.py` | `VestigeMemorySystem` over MCP stdio: one shared server, one scope per task, forceCreate writes, top_k 3 in upstream's exact prompt shape, readiness guard, JSONL sidecar. `NoMemorySystem` for the floor arm. |
| `benchmarks/memoryarena/install.py` | Patches a pinned MemoryArena clone with anchored idempotent edits. Refuses an unpinned HEAD. |
| `benchmarks/memoryarena/configs/` | `math_vestige`, `phys_vestige`, `math_none`, `phys_none`, `phys_bm25`, mirroring upstream field for field. |
| `benchmarks/memoryarena/smoke_test.py` | Against the real binary, no checkout, no key. |
| `benchmarks/memoryarena/analyze.py` | Per-arm PS and SR with n, paired sign test, sidecar confound summary. |
| `benchmarks/memoryarena/MEMORYARENA.lock.json` | Upstream code and dataset revisions, row counts, metric definitions. |
| `docs/BENCHMARKS.md`, `CHANGELOG.md` | The status section and the entry. |

Standard library only, like `benchmarks/memconflict/`.

## Verification

- `smoke_test.py` against the debug build: 15 of 15. Readiness came from `memory_status(view=health).embeddingReady` in about two seconds on a warm model cache. Isolation is checked by node ids: every id returned to task B was written by task B. The first draft of that assertion was wrong (it searched the whole wrapped string, and the echoed prompt legitimately contains "Bob"); the engine was never at fault, the sidecar showed one hit with B's own id.
- `install.py` against a fresh clone of upstream at `6cd9de14`: dry run, real run, second run idempotent; patched `server.py` and `__init__.py` parse; the diff is the two imports and the two `elif` branches.
- `analyze.py` on synthetic upstream-shaped results: 40 tasks, sign test p(15,5) = 0.0414 and p(10,10) = 1.0 as expected.
- `git diff --check` clean. No em-dashes, no private paths.

## Notes for merging

Touches only new directories plus a CHANGELOG entry and a BENCHMARKS.md section, so it is independent of the other open PRs. The CHANGELOG insertion sits at the top of Unreleased and will conflict trivially with #245's entry; keep both.

Closes nothing yet. #242 stays open until the run is checked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
