### PR TITLE
fix(storage): label attached-runtime vectors with the profile's model id

### DIFF
--- a/crates/vestige-core/src/embedding/lifecycle.rs
+++ b/crates/vestige-core/src/embedding/lifecycle.rs
@@ -1503,4 +1503,115 @@ mod tests {
                 .is_empty()
         );
     }
+
+    #[test]
+    fn attached_runtime_vectors_carry_the_profile_model_id_and_do_not_churn() {
+        // Regression (kmsu S131, 2026-09-08). The attached-runtime write path
+        // labelled every vector with the PROFILE id, while the migration
+        // writer, `get_stats`, and the regeneration-candidate query all use the
+        // profile's MODEL id. Every vector the long-running server wrote was
+        // therefore reported as "mismatched" and re-embedded on every
+        // consolidation pass (269 of 10,596 live vectors re-stamped per pass).
+        let temp = tempfile::tempdir().unwrap();
+        let storage = Storage::new(Some(temp.path().join("store.sqlite"))).unwrap();
+        storage
+            .ingest(IngestInput {
+                content: "memory migrated before the runtime attached".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let source = EmbeddingProfileId::new("nomic-v1.5-legacy-raw-256").unwrap();
+        for node in storage.get_all_nodes(10, 0).unwrap() {
+            storage
+                .put_embedding_profile_vector(&EmbeddingProfileVector {
+                    profile_id: source.to_string(),
+                    node_id: node.id,
+                    embedding: f32_bytes(&vec![0.25; 256]),
+                    dimensions: 256,
+                    model: "nomic-ai/nomic-embed-text-v1.5".to_string(),
+                    created_at: Utc::now(),
+                })
+                .unwrap();
+        }
+        let artifact_path = temp.path().join("runner.bin");
+        fs::write(&artifact_path, b"local test artifact").unwrap();
+        let artifact = ModelArtifactHash::sha256("runner.bin", sha256_hex(b"local test artifact"));
+        let profile = profile(artifact.clone());
+        // The fixture separates all three candidate labels: the profile id
+        // ("test-local-profile-2d"), the runtime's own name ("test-local-runner"),
+        // and the profile's model id ("test/local"). Only the last one is the
+        // label the readers compare against.
+        assert_ne!(profile.model_id, profile.profile_id.to_string());
+        assert_ne!(profile.model_id, TinyEmbedder.model_name());
+        let artifacts = vec![VerifiedLocalArtifact::from_root(artifact, temp.path()).unwrap()];
+        let lifecycle = EmbeddingProfileLifecycle::new(&storage);
+        lifecycle
+            .install_verified(
+                profile.clone(),
+                &artifacts,
+                EmbeddingRuntimeMetadata {
+                    backend: EmbeddingRuntimeBackend::FastembedCandle,
+                    device: crate::embedding::EmbeddingDevice::Cpu,
+                    runtime_version: "test".to_string(),
+                    initialized_at: Utc::now(),
+                    local_only: true,
+                },
+                Arc::new(TinyEmbedder),
+            )
+            .unwrap();
+        let evaluation = EmbeddingEvaluationSummary {
+            evaluation_id: Uuid::new_v4(),
+            compared_against: source.clone(),
+            completed_at: Utc::now(),
+            corpus_size: 0,
+            recall_at_5: None,
+            recall_at_10: None,
+            ndcg_at_10: None,
+            exact_match_preservation: None,
+            false_positive_rate: None,
+            p50_query_latency_ms: None,
+            p95_query_latency_ms: None,
+            ingestion_throughput_per_second: None,
+            report_hash: "1".repeat(64),
+        };
+        let ready = lifecycle
+            .registry
+            .record_evaluation(&profile.profile_id, evaluation)
+            .unwrap();
+        storage.save_embedding_profile_manifest(&ready).unwrap();
+        lifecycle
+            .migrate_registered(&profile.profile_id, &source, None, None)
+            .unwrap();
+        storage
+            .activate_embedding_profile(&profile.profile_id)
+            .unwrap();
+        lifecycle
+            .attach_registered_active_profile(&profile.profile_id)
+            .unwrap();
+
+        // The live server's only write path: an ingest through the attached runtime.
+        let written = storage
+            .ingest(IngestInput {
+                content: "memory written through the attached runtime".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        let stored = storage
+            .embedding_profile_vector(&profile.profile_id, &written.id)
+            .unwrap()
+            .expect("the ingest wrote a vector for the active profile");
+        assert_eq!(
+            stored.model, profile.model_id,
+            "attached-runtime vectors must carry the profile's model id, the label \
+             the migration writer stores and every reader compares against"
+        );
+
+        let stats = storage.get_stats().unwrap();
+        assert_eq!(stats.nodes_with_mismatched_embeddings, 0);
+        assert_eq!(stats.nodes_with_active_embeddings, 2);
+
+        // No churn: a consolidation-style pass finds nothing to regenerate.
+        let again = storage.generate_embeddings(None, false).unwrap();
+        assert_eq!((again.successful, again.skipped, again.failed), (0, 0, 0));
+    }
 }

--- a/crates/vestige-core/src/storage/sqlite.rs
+++ b/crates/vestige-core/src/storage/sqlite.rs
@@ -3009,7 +3009,17 @@ impl SqliteMemoryStore {
                     .iter()
                     .flat_map(|value| value.to_le_bytes())
                     .collect::<Vec<_>>();
-                (bytes, vector.len(), active.profile_id.to_string(), vector)
+                // Label the vector with the profile's MODEL id: it is what the
+                // migration writer stores and what `get_stats` and the
+                // regeneration-candidate query compare against. Stamping the
+                // PROFILE id here made every server-written vector count as
+                // "mismatched" and re-embedded it on every consolidation pass.
+                (
+                    bytes,
+                    vector.len(),
+                    manifest.profile.model_id.clone(),
+                    vector,
+                )
             } else {
                 let embedding = self
                     .embedding_service


### PR DESCRIPTION
## Summary

`generate_embedding_for_node` stamps `embedding_profile_vectors.model` (and `knowledge_nodes.embedding_model`) with the active **profile id** when the vector comes from an attached local runtime. Every other party uses the profile's **model id**:

- the migration writer (`lifecycle.rs`, `destination_manifest.profile.model_id`),
- `get_stats` (compares against `embedding_profiles.model_id`),
- `embedding_regeneration_candidates` (`epv.model != profile_model`).

So on a long-running server with an attached Qwen profile, every vector the server itself writes is counted as mismatched, `system_status` warns "Stored embeddings from another model are present" permanently, and every consolidation pass re-embeds the whole server-written set and re-stamps the same wrong label. The set only grows. Retrieval is not affected (the vector readers select by `profile_id`), so this is a stats, warning and churn defect, not a recall defect.

Measured on a 10,596-memory store (Windows, CUDA runtime, `qwen3-0.6b-retrieval-v1-256` active): the drain pass of an outage backlog reported `embeddingsGenerated 269` (113 genuinely missing + 156 mislabelled), after which `mismatchedEmbeddings` read **269** — every regenerated vector had the wrong label too. After this fix one pass relabelled the 270 and a second pass generated 0.

## Fix

Use `manifest.profile.model_id` for the label; the manifest is already loaded at the top of the function. One line, no schema change.

## Test

`attached_runtime_vectors_carry_the_profile_model_id_and_do_not_churn` (lifecycle test module, next to `migration_is_resumable_isolated_and_builds_a_verified_sidecar`, whose fixtures it reuses). The fixture separates all three candidate labels (profile id `test-local-profile-2d`, runtime name `test-local-runner`, model id `test/local`), ingests through the attached runtime, and asserts the stored label, `nodes_with_mismatched_embeddings == 0`, `nodes_with_active_embeddings == 2`, and that a follow-up `generate_embeddings(None, false)` regenerates nothing.

On the previous line it fails with:

```
assertion `left == right` failed: attached-runtime vectors must carry the profile's model id ...
  left: "test-local-profile-2d"
 right: "test/local"
```

## Verification

- `cargo test --release -p vestige-core --no-default-features --features embeddings,ort-download,vector-search,bundled-sqlite embedding` on the pinned 1.98.1 toolchain (Windows/MSVC), on this branch: 45 passed, 0 failed (the new test plus the existing embedding tests).
- `cargo clippy --release -p vestige-core --no-default-features --features embeddings,ort-download,vector-search,bundled-sqlite -- -D warnings` clean.
- `rustfmt --check` leaves both hunks unchanged (the reflowed tuple is rustfmt's layout); pre-existing formatting drift elsewhere in `sqlite.rs` is untouched.
- Deployed on the reporting host since 2026-09-08 (branch build of v2.6.0 plus this commit): `mismatchedEmbeddings 0`, coverage 100%, no churn on subsequent consolidation passes.

The line is unchanged at tag v2.6.0 and on `main` today, so the patch applies cleanly to both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
