### PR TITLE
feat(intentions): add evidence lifecycle and durable recurring reminders

### DIFF
--- a/crates/vestige-core/src/intention_graph.rs
+++ b/crates/vestige-core/src/intention_graph.rs
@@ -1,0 +1,3511 @@
+//! Pure, deterministic intention evidence lifecycle evaluation.
+//!
+//! This module deliberately has no storage, network, model, or side-effect
+//! dependencies. Callers provide evidence snapshots and persist the serialized
+//! graph plus their own immutable command journal. Evidence is caller-asserted:
+//! an evaluation label records what this state machine concluded from those
+//! assertions, but is not cryptographic proof, truth verification, or authority
+//! to perform an external effect.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+pub const INTENTION_GRAPH_SCHEMA_VERSION: u32 = 1;
+pub const INTENTION_GRAPH_ALGORITHM_VERSION: &str = "intention-evidence-v1";
+
+const MAX_PLANS: usize = 1_024;
+const MAX_REQUIREMENTS_PER_PLAN: usize = 128;
+const MAX_VERSIONS_PER_PLAN: usize = 1_024;
+const MAX_SOURCES: usize = 4_096;
+const MAX_EVENT_RECEIPTS: usize = 16_384;
+const MAX_EVALUATIONS: usize = 16_384;
+const MAX_ATTENTION_EVENTS: usize = 16_384;
+const MAX_EVENTS_PER_OBSERVATION: usize = 256;
+const MAX_CONFLICT_KEYS: usize = 64;
+const MAX_ID_BYTES: usize = 160;
+const MAX_SOURCE_KEY_BYTES: usize = 512;
+const MAX_DESCRIPTION_BYTES: usize = 8_192;
+const MAX_TEXT_BYTES: usize = 4_096;
+const MAX_ATTENTION_INTERVAL_SECONDS: u64 = 365 * 24 * 60 * 60;
+const MAX_RECEIPT_RESPONSE_BYTES: usize = 256 * 1_024;
+
+fn default_attention_interval_seconds() -> u64 {
+    60 * 60
+}
+
+fn default_schema_version() -> u32 {
+    INTENTION_GRAPH_SCHEMA_VERSION
+}
+
+fn default_algorithm_version() -> String {
+    INTENTION_GRAPH_ALGORITHM_VERSION.to_owned()
+}
+
+/// A bounded scalar suitable for exact deterministic evidence comparisons.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum EvidenceValue {
+    Bool(bool),
+    Integer(i64),
+    Text(String),
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Priority {
+    Low,
+    #[default]
+    Normal,
+    High,
+    Critical,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventExpectation {
+    Occurred,
+    Absent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum EvidenceCondition {
+    Exists,
+    Equals { value: EvidenceValue },
+    NotEquals { value: EvidenceValue },
+}
+
+/// A requirement is exact and declarative. No semantic inference is performed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Requirement {
+    Evidence {
+        id: String,
+        source_key: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        memory_id: Option<String>,
+        condition: EvidenceCondition,
+    },
+    Event {
+        id: String,
+        source_key: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        memory_id: Option<String>,
+        event: String,
+        expectation: EventExpectation,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        window_start: Option<DateTime<Utc>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        window_end: Option<DateTime<Utc>>,
+        #[serde(default)]
+        grace_seconds: u64,
+    },
+    PlanFulfilled {
+        id: String,
+        plan_id: String,
+    },
+}
+
+impl Requirement {
+    pub fn id(&self) -> &str {
+        match self {
+            Self::Evidence { id, .. } | Self::Event { id, .. } | Self::PlanFulfilled { id, .. } => {
+                id
+            }
+        }
+    }
+
+    pub fn source_key(&self) -> Option<&str> {
+        match self {
+            Self::Evidence { source_key, .. } | Self::Event { source_key, .. } => Some(source_key),
+            Self::PlanFulfilled { .. } => None,
+        }
+    }
+
+    pub fn prerequisite_plan_id(&self) -> Option<&str> {
+        match self {
+            Self::PlanFulfilled { plan_id, .. } => Some(plan_id),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CompletionBasis {
+    UserReport { report: String },
+    Evidence { requirement_ids: Vec<String> },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimedCommand {
+    pub command: Command,
+    pub now: DateTime<Utc>,
+}
+
+/// Public command contract. It is internally tagged so MCP callers send a
+/// single object with an `action` field.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum Command {
+    Plan {
+        id: String,
+        description: String,
+        #[serde(default)]
+        priority: Priority,
+        #[serde(default)]
+        requirements: Vec<Requirement>,
+        #[serde(default = "default_attention_interval_seconds")]
+        min_attention_interval_seconds: u64,
+        #[serde(default)]
+        conflict_keys: Vec<String>,
+    },
+    Revise {
+        id: String,
+        expected_version: u32,
+        #[serde(default)]
+        description: Option<String>,
+        #[serde(default)]
+        priority: Option<Priority>,
+        #[serde(default)]
+        requirements: Option<Vec<Requirement>>,
+        #[serde(default)]
+        min_attention_interval_seconds: Option<u64>,
+        #[serde(default)]
+        conflict_keys: Option<Vec<String>>,
+    },
+    Observe {
+        event_id: String,
+        source_key: String,
+        source_revision: u64,
+        #[serde(default)]
+        value: Option<EvidenceValue>,
+        #[serde(default)]
+        observed_events: Vec<String>,
+        #[serde(default)]
+        covered_events: Vec<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        coverage_start: Option<DateTime<Utc>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        coverage_end: Option<DateTime<Utc>>,
+    },
+    Evaluate {
+        #[serde(default)]
+        id: Option<String>,
+    },
+    Explain {
+        id: String,
+    },
+    Portfolio,
+    Complete {
+        id: String,
+        expected_version: u32,
+        basis: CompletionBasis,
+    },
+    Cancel {
+        id: String,
+        expected_version: u32,
+        reason: String,
+    },
+    Acknowledge {
+        queue_id: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanLifecycle {
+    Active,
+    Fulfilled,
+    Disputed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Readiness {
+    Ready,
+    Unknown,
+    Blocked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RequirementState {
+    Satisfied,
+    Unmet,
+    Missing,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanVersion {
+    pub version: u32,
+    pub revised_at: DateTime<Utc>,
+    pub description: String,
+    pub priority: Priority,
+    pub requirements: Vec<Requirement>,
+    pub min_attention_interval_seconds: u64,
+    pub conflict_keys: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompletionRecord {
+    pub basis: CompletionBasis,
+    pub plan_version: u32,
+    pub completed_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disputed_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dispute_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancellationRecord {
+    pub reason: String,
+    pub plan_version: u32,
+    pub cancelled_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Plan {
+    pub id: String,
+    pub original_description: String,
+    pub versions: Vec<PlanVersion>,
+    pub lifecycle: PlanLifecycle,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion: Option<CompletionRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cancellation: Option<CancellationRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_attention_acknowledged_at: Option<DateTime<Utc>>,
+}
+
+impl Plan {
+    pub fn current(&self) -> &PlanVersion {
+        self.versions
+            .last()
+            .expect("a validated plan always has one version")
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvidenceSource {
+    pub source_key: String,
+    pub revision: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<EvidenceValue>,
+    pub observed_events: BTreeSet<String>,
+    pub covered_events: BTreeSet<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coverage_start: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coverage_end: Option<DateTime<Utc>>,
+    pub observed_at: DateTime<Utc>,
+    /// Fixed provenance label; callers cannot mark supplied evidence verified.
+    pub provenance: EvidenceProvenance,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceProvenance {
+    CallerAsserted,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ObservationReceipt {
+    pub event_id: String,
+    pub command_digest: String,
+    pub source_key: String,
+    pub source_revision: u64,
+    pub response: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RequirementEvaluation {
+    pub requirement_id: String,
+    pub state: RequirementState,
+    pub detail: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluationSnapshot {
+    pub plan_id: String,
+    pub plan_version: u32,
+    pub lifecycle: PlanLifecycle,
+    pub readiness: Readiness,
+    pub requirements: Vec<RequirementEvaluation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvaluationRecord {
+    pub label: String,
+    pub evaluated_at: DateTime<Utc>,
+    pub snapshot: EvaluationSnapshot,
+    pub record_kind: EvaluationRecordKind,
+    pub cryptographic_proof: bool,
+    pub grants_authority: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvaluationRecordKind {
+    DeterministicEvaluation,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttentionEvent {
+    pub queue_id: String,
+    pub fingerprint: String,
+    pub plan_id: String,
+    pub priority: Priority,
+    pub created_at: DateTime<Utc>,
+    pub deliver_after: DateTime<Utc>,
+    pub reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acknowledged_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub superseded_at: Option<DateTime<Utc>>,
+}
+
+/// Serializable state. BTreeMap/BTreeSet are used throughout so snapshots and
+/// responses are stable across runs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IntentionGraph {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    #[serde(default = "default_algorithm_version")]
+    pub algorithm_version: String,
+    pub plans: BTreeMap<String, Plan>,
+    pub sources: BTreeMap<String, EvidenceSource>,
+    pub observation_receipts: BTreeMap<String, ObservationReceipt>,
+    pub evaluations: BTreeMap<String, EvaluationRecord>,
+    pub attention_queue: BTreeMap<String, AttentionEvent>,
+    #[serde(default)]
+    pub attention_sequence_by_plan: BTreeMap<String, u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_mutation_at: Option<DateTime<Utc>>,
+}
+
+impl Default for IntentionGraph {
+    fn default() -> Self {
+        Self {
+            schema_version: INTENTION_GRAPH_SCHEMA_VERSION,
+            algorithm_version: INTENTION_GRAPH_ALGORITHM_VERSION.to_owned(),
+            plans: BTreeMap::new(),
+            sources: BTreeMap::new(),
+            observation_receipts: BTreeMap::new(),
+            evaluations: BTreeMap::new(),
+            attention_queue: BTreeMap::new(),
+            attention_sequence_by_plan: BTreeMap::new(),
+            last_mutation_at: None,
+        }
+    }
+}
+
+impl IntentionGraph {
+    /// Apply one command atomically. Read-only commands borrow the current
+    /// graph; mutating commands commit only after every validation succeeds.
+    pub fn apply(&mut self, command: Command, now: DateTime<Utc>) -> Result<Value, String> {
+        self.validate_state()?;
+        match &command {
+            Command::Explain { id } => {
+                self.reject_historical_read(now)?;
+                self.explain(id, now)
+            }
+            Command::Portfolio => {
+                self.reject_historical_read(now)?;
+                self.portfolio(now)
+            }
+            _ => {
+                let is_noop_reapplication = match &command {
+                    Command::Observe { event_id, .. } => {
+                        self.observation_receipts.contains_key(event_id)
+                    }
+                    Command::Acknowledge { queue_id } => self
+                        .attention_queue
+                        .get(queue_id)
+                        .is_some_and(|event| event.acknowledged_at.is_some()),
+                    Command::Complete {
+                        id,
+                        expected_version,
+                        basis,
+                    } => self.plans.get(id).is_some_and(|plan| {
+                        plan.lifecycle == PlanLifecycle::Fulfilled
+                            && plan.current().version == *expected_version
+                            && plan.completion.as_ref().is_some_and(|completion| {
+                                completion.plan_version == *expected_version
+                                    && completion.basis == *basis
+                            })
+                    }),
+                    Command::Cancel {
+                        id,
+                        expected_version,
+                        reason,
+                    } => self.plans.get(id).is_some_and(|plan| {
+                        plan.lifecycle == PlanLifecycle::Cancelled
+                            && plan.current().version == *expected_version
+                            && plan.cancellation.as_ref().is_some_and(|cancellation| {
+                                cancellation.plan_version == *expected_version
+                                    && cancellation.reason == *reason
+                            })
+                    }),
+                    _ => false,
+                };
+                if !is_noop_reapplication
+                    && let Some(last_mutation_at) = self.last_mutation_at
+                    && now < last_mutation_at
+                {
+                    return Err(format!(
+                        "out-of-order mutation timestamp {now}; last mutation was {last_mutation_at}"
+                    ));
+                }
+                let mut next = self.clone();
+                let response = next.apply_mutating(command, now)?;
+                if !is_noop_reapplication {
+                    next.last_mutation_at = Some(now);
+                }
+                // A successful command must never persist a state that the
+                // next command would reject. Validate output-derived limits
+                // as well as the caller's input before committing the clone.
+                next.validate_state()?;
+                *self = next;
+                Ok(response)
+            }
+        }
+    }
+
+    fn validate_engine_version(&self) -> Result<(), String> {
+        if self.schema_version != INTENTION_GRAPH_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported intention graph schema version {}; expected {}",
+                self.schema_version, INTENTION_GRAPH_SCHEMA_VERSION
+            ));
+        }
+        if self.algorithm_version != INTENTION_GRAPH_ALGORITHM_VERSION {
+            return Err(format!(
+                "unsupported intention graph algorithm version '{}'; expected '{}'",
+                self.algorithm_version, INTENTION_GRAPH_ALGORITHM_VERSION
+            ));
+        }
+        Ok(())
+    }
+
+    fn reject_historical_read(&self, now: DateTime<Utc>) -> Result<(), String> {
+        if self
+            .last_mutation_at
+            .is_some_and(|last_mutation_at| now < last_mutation_at)
+        {
+            return Err(format!(
+                "historical evaluation is unsupported: requested {now}, current state is from {}",
+                self.last_mutation_at.expect("checked as some")
+            ));
+        }
+        Ok(())
+    }
+
+    /// Validate a deserialized graph before any evaluator path can rely on its
+    /// internal invariants.
+    pub fn validate_state(&self) -> Result<(), String> {
+        self.validate_engine_version()?;
+        if self.plans.len() > MAX_PLANS {
+            return Err(format!(
+                "serialized graph exceeds plan limit of {MAX_PLANS}"
+            ));
+        }
+        if self.sources.len() > MAX_SOURCES {
+            return Err(format!(
+                "serialized graph exceeds source limit of {MAX_SOURCES}"
+            ));
+        }
+        if self.observation_receipts.len() > MAX_EVENT_RECEIPTS {
+            return Err(format!(
+                "serialized graph exceeds observation receipt limit of {MAX_EVENT_RECEIPTS}"
+            ));
+        }
+        if self.evaluations.len() > MAX_EVALUATIONS {
+            return Err(format!(
+                "serialized graph exceeds evaluation limit of {MAX_EVALUATIONS}"
+            ));
+        }
+        if self.attention_queue.len() > MAX_ATTENTION_EVENTS {
+            return Err(format!(
+                "serialized graph exceeds attention limit of {MAX_ATTENTION_EVENTS}"
+            ));
+        }
+
+        let mut latest_stored_at: Option<DateTime<Utc>> = None;
+        for (plan_id, plan) in &self.plans {
+            validate_id("serialized plan map key", plan_id)?;
+            if plan.id != *plan_id {
+                return Err(format!(
+                    "serialized plan map key '{plan_id}' does not match embedded id '{}'",
+                    plan.id
+                ));
+            }
+            validate_description(&plan.original_description)?;
+            if plan.versions.is_empty() {
+                return Err(format!("serialized plan '{plan_id}' has no versions"));
+            }
+            if plan.versions.len() > MAX_VERSIONS_PER_PLAN {
+                return Err(format!(
+                    "serialized plan '{plan_id}' exceeds version limit of {MAX_VERSIONS_PER_PLAN}"
+                ));
+            }
+            let mut prior_revised_at = None;
+            for (index, version) in plan.versions.iter().enumerate() {
+                let expected_version = u32::try_from(index + 1)
+                    .map_err(|_| format!("serialized plan '{plan_id}' version overflow"))?;
+                if version.version != expected_version {
+                    return Err(format!(
+                        "serialized plan '{plan_id}' has non-contiguous version {}; expected {expected_version}",
+                        version.version
+                    ));
+                }
+                if prior_revised_at.is_some_and(|prior| version.revised_at < prior) {
+                    return Err(format!(
+                        "serialized plan '{plan_id}' has out-of-order revision timestamps"
+                    ));
+                }
+                validate_description(&version.description)?;
+                validate_plan_fields(
+                    plan_id,
+                    &version.requirements,
+                    version.min_attention_interval_seconds,
+                    &version.conflict_keys,
+                )?;
+                prior_revised_at = Some(version.revised_at);
+                update_latest(&mut latest_stored_at, version.revised_at);
+            }
+            match plan.lifecycle {
+                PlanLifecycle::Fulfilled | PlanLifecycle::Disputed if plan.completion.is_none() => {
+                    return Err(format!(
+                        "serialized {:?} plan '{plan_id}' has no completion record",
+                        plan.lifecycle
+                    ));
+                }
+                PlanLifecycle::Cancelled if plan.cancellation.is_none() => {
+                    return Err(format!(
+                        "serialized cancelled plan '{plan_id}' has no cancellation record"
+                    ));
+                }
+                _ => {}
+            }
+            if let Some(completion) = &plan.completion {
+                validate_completion_basis(&completion.basis)?;
+                if completion.plan_version == 0 || completion.plan_version > plan.current().version
+                {
+                    return Err(format!(
+                        "serialized plan '{plan_id}' has invalid completion plan_version {}",
+                        completion.plan_version
+                    ));
+                }
+                if completion.disputed_at.is_some() != completion.dispute_reason.is_some() {
+                    return Err(format!(
+                        "serialized plan '{plan_id}' has incomplete dispute metadata"
+                    ));
+                }
+                update_latest(&mut latest_stored_at, completion.completed_at);
+                if let Some(disputed_at) = completion.disputed_at {
+                    if disputed_at < completion.completed_at {
+                        return Err(format!(
+                            "serialized plan '{plan_id}' dispute predates completion"
+                        ));
+                    }
+                    update_latest(&mut latest_stored_at, disputed_at);
+                }
+            }
+            if let Some(cancellation) = &plan.cancellation {
+                validate_bounded_nonempty(
+                    "serialized cancellation reason",
+                    &cancellation.reason,
+                    MAX_TEXT_BYTES,
+                )?;
+                if cancellation.plan_version == 0
+                    || cancellation.plan_version > plan.current().version
+                {
+                    return Err(format!(
+                        "serialized plan '{plan_id}' has invalid cancellation plan_version {}",
+                        cancellation.plan_version
+                    ));
+                }
+                update_latest(&mut latest_stored_at, cancellation.cancelled_at);
+            }
+            if let Some(acknowledged_at) = plan.last_attention_acknowledged_at {
+                update_latest(&mut latest_stored_at, acknowledged_at);
+            }
+        }
+        for (plan_id, plan) in &self.plans {
+            self.validate_dependency_graph(plan_id, &plan.current().requirements)?;
+        }
+
+        for (source_key, source) in &self.sources {
+            validate_source_key(source_key)?;
+            if source.source_key != *source_key {
+                return Err(format!(
+                    "serialized source map key '{source_key}' does not match embedded key '{}'",
+                    source.source_key
+                ));
+            }
+            if source.revision == 0 {
+                return Err(format!(
+                    "serialized source '{source_key}' has revision zero"
+                ));
+            }
+            validate_evidence_value(source.value.as_ref())?;
+            validate_event_list(
+                "serialized observed_events",
+                &source.observed_events.iter().cloned().collect::<Vec<_>>(),
+            )?;
+            validate_event_list(
+                "serialized covered_events",
+                &source.covered_events.iter().cloned().collect::<Vec<_>>(),
+            )?;
+            validate_window(
+                source.coverage_start,
+                source.coverage_end,
+                "serialized observation coverage",
+            )?;
+            if source
+                .coverage_end
+                .is_some_and(|coverage_end| coverage_end > source.observed_at)
+            {
+                return Err(format!(
+                    "serialized source '{source_key}' promises coverage after it was observed"
+                ));
+            }
+            update_latest(&mut latest_stored_at, source.observed_at);
+        }
+
+        for (event_id, receipt) in &self.observation_receipts {
+            validate_id("serialized observation receipt key", event_id)?;
+            if receipt.event_id != *event_id {
+                return Err(format!(
+                    "serialized observation receipt key '{event_id}' does not match embedded id '{}'",
+                    receipt.event_id
+                ));
+            }
+            validate_source_key(&receipt.source_key)?;
+            let source = self.sources.get(&receipt.source_key).ok_or_else(|| {
+                format!(
+                    "serialized observation receipt '{event_id}' references missing source '{}'",
+                    receipt.source_key
+                )
+            })?;
+            if receipt.source_revision == 0 || receipt.source_revision > source.revision {
+                return Err(format!(
+                    "serialized observation receipt '{event_id}' has invalid source revision {}",
+                    receipt.source_revision
+                ));
+            }
+            if receipt.command_digest.len() != 64
+                || !receipt
+                    .command_digest
+                    .bytes()
+                    .all(|byte| byte.is_ascii_hexdigit())
+            {
+                return Err(format!(
+                    "serialized observation receipt '{event_id}' has invalid command digest"
+                ));
+            }
+            let response_size = serde_json::to_vec(&receipt.response)
+                .map_err(|error| format!("cannot serialize receipt '{event_id}': {error}"))?
+                .len();
+            if response_size > MAX_RECEIPT_RESPONSE_BYTES {
+                return Err(format!(
+                    "serialized observation receipt '{event_id}' response exceeds {MAX_RECEIPT_RESPONSE_BYTES} bytes"
+                ));
+            }
+        }
+
+        for (label, evaluation) in &self.evaluations {
+            validate_id("serialized evaluation label", label)?;
+            if evaluation.label != *label {
+                return Err(format!(
+                    "serialized evaluation key '{label}' does not match embedded label '{}'",
+                    evaluation.label
+                ));
+            }
+            let plan = self
+                .plans
+                .get(&evaluation.snapshot.plan_id)
+                .ok_or_else(|| {
+                    format!(
+                        "serialized evaluation '{label}' references missing plan '{}'",
+                        evaluation.snapshot.plan_id
+                    )
+                })?;
+            if evaluation.snapshot.plan_version == 0
+                || evaluation.snapshot.plan_version > plan.current().version
+            {
+                return Err(format!(
+                    "serialized evaluation '{label}' has invalid plan version {}",
+                    evaluation.snapshot.plan_version
+                ));
+            }
+            if evaluation.snapshot.requirements.len() > MAX_REQUIREMENTS_PER_PLAN {
+                return Err(format!(
+                    "serialized evaluation '{label}' has too many requirement results"
+                ));
+            }
+            if evaluation.cryptographic_proof || evaluation.grants_authority {
+                return Err(format!(
+                    "serialized evaluation '{label}' illegally claims proof or authority"
+                ));
+            }
+            update_latest(&mut latest_stored_at, evaluation.evaluated_at);
+        }
+
+        for (queue_id, event) in &self.attention_queue {
+            validate_id("serialized attention key", queue_id)?;
+            if event.queue_id != *queue_id {
+                return Err(format!(
+                    "serialized attention key '{queue_id}' does not match embedded id '{}'",
+                    event.queue_id
+                ));
+            }
+            if !self.plans.contains_key(&event.plan_id) {
+                return Err(format!(
+                    "serialized attention '{queue_id}' references missing plan '{}'",
+                    event.plan_id
+                ));
+            }
+            if event.deliver_after < event.created_at {
+                return Err(format!(
+                    "serialized attention '{queue_id}' is deliverable before creation"
+                ));
+            }
+            if event
+                .acknowledged_at
+                .is_some_and(|acknowledged_at| acknowledged_at < event.created_at)
+                || event
+                    .superseded_at
+                    .is_some_and(|superseded_at| superseded_at < event.created_at)
+            {
+                return Err(format!(
+                    "serialized attention '{queue_id}' has an invalid lifecycle timestamp"
+                ));
+            }
+            update_latest(&mut latest_stored_at, event.created_at);
+            if let Some(acknowledged_at) = event.acknowledged_at {
+                update_latest(&mut latest_stored_at, acknowledged_at);
+            }
+            if let Some(superseded_at) = event.superseded_at {
+                update_latest(&mut latest_stored_at, superseded_at);
+            }
+        }
+        for plan_id in self.attention_sequence_by_plan.keys() {
+            if !self.plans.contains_key(plan_id) {
+                return Err(format!(
+                    "serialized attention sequence references missing plan '{plan_id}'"
+                ));
+            }
+        }
+        if self.attention_sequence_by_plan.len() > self.plans.len() {
+            return Err("serialized graph has too many attention sequence entries".to_owned());
+        }
+        match (latest_stored_at, self.last_mutation_at) {
+            (Some(_), None) => {
+                return Err("serialized non-empty graph has no last_mutation_at".to_owned());
+            }
+            (Some(latest), Some(last)) if latest > last => {
+                return Err(format!(
+                    "serialized state timestamp {latest} is later than last_mutation_at {last}"
+                ));
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn apply_mutating(&mut self, command: Command, now: DateTime<Utc>) -> Result<Value, String> {
+        match command {
+            Command::Plan {
+                id,
+                description,
+                priority,
+                requirements,
+                min_attention_interval_seconds,
+                conflict_keys,
+            } => self.plan(
+                id,
+                description,
+                priority,
+                requirements,
+                min_attention_interval_seconds,
+                conflict_keys,
+                now,
+            ),
+            Command::Revise {
+                id,
+                expected_version,
+                description,
+                priority,
+                requirements,
+                min_attention_interval_seconds,
+                conflict_keys,
+            } => self.revise(
+                id,
+                expected_version,
+                description,
+                priority,
+                requirements,
+                min_attention_interval_seconds,
+                conflict_keys,
+                now,
+            ),
+            Command::Observe {
+                event_id,
+                source_key,
+                source_revision,
+                value,
+                observed_events,
+                covered_events,
+                coverage_start,
+                coverage_end,
+            } => self.observe(
+                event_id,
+                source_key,
+                source_revision,
+                value,
+                observed_events,
+                covered_events,
+                coverage_start,
+                coverage_end,
+                now,
+            ),
+            Command::Evaluate { id } => self.evaluate(id.as_deref(), now),
+            Command::Complete {
+                id,
+                expected_version,
+                basis,
+            } => self.complete(id, expected_version, basis, now),
+            Command::Cancel {
+                id,
+                expected_version,
+                reason,
+            } => self.cancel(id, expected_version, reason, now),
+            Command::Acknowledge { queue_id } => self.acknowledge(queue_id, now),
+            Command::Explain { .. } | Command::Portfolio => {
+                Err("read-only command reached mutating dispatcher".to_owned())
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn plan(
+        &mut self,
+        id: String,
+        description: String,
+        priority: Priority,
+        requirements: Vec<Requirement>,
+        min_attention_interval_seconds: u64,
+        conflict_keys: Vec<String>,
+        now: DateTime<Utc>,
+    ) -> Result<Value, String> {
+        validate_id("plan id", &id)?;
+        validate_description(&description)?;
+        if self.plans.contains_key(&id) {
+            return Err(format!("plan '{id}' already exists"));
+        }
+        if self.plans.len() >= MAX_PLANS {
+            return Err(format!("plan limit of {MAX_PLANS} reached"));
+        }
+        validate_plan_fields(
+            &id,
+            &requirements,
+            min_attention_interval_seconds,
+            &conflict_keys,
+        )?;
+        self.validate_dependency_graph(&id, &requirements)?;
+
+        let version = PlanVersion {
+            version: 1,
+            revised_at: now,
+            description: description.clone(),
+            priority,
+            requirements,
+            min_attention_interval_seconds,
+            conflict_keys: normalized_unique(conflict_keys),
+        };
+        self.plans.insert(
+            id.clone(),
+            Plan {
+                id: id.clone(),
+                original_description: description,
+                versions: vec![version],
+                lifecycle: PlanLifecycle::Active,
+                completion: None,
+                cancellation: None,
+                last_attention_acknowledged_at: None,
+            },
+        );
+
+        let evaluations = self.evaluate_plan_set([id.clone()].into_iter().collect(), now)?;
+        Ok(json!({
+            "plan": self.plans.get(&id),
+            "evaluations": evaluations,
+            "attention": self.queue_partition(now),
+        }))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn revise(
+        &mut self,
+        id: String,
+        expected_version: u32,
+        description: Option<String>,
+        priority: Option<Priority>,
+        requirements: Option<Vec<Requirement>>,
+        min_attention_interval_seconds: Option<u64>,
+        conflict_keys: Option<Vec<String>>,
+        now: DateTime<Utc>,
+    ) -> Result<Value, String> {
+        validate_id("plan id", &id)?;
+        let plan = self
+            .plans
+            .get(&id)
+            .ok_or_else(|| format!("unknown plan '{id}'"))?;
+        if plan.lifecycle == PlanLifecycle::Cancelled {
+            return Err(format!("cancelled plan '{id}' cannot be revised"));
+        }
+        let current = plan.current().clone();
+        if current.version != expected_version {
+            return Err(format!(
+                "stale plan version for '{id}': expected {expected_version}, current is {}",
+                current.version
+            ));
+        }
+
+        let next_description = description.unwrap_or(current.description);
+        validate_description(&next_description)?;
+        let next_requirements = requirements.unwrap_or(current.requirements);
+        let next_interval =
+            min_attention_interval_seconds.unwrap_or(current.min_attention_interval_seconds);
+        let next_conflicts = conflict_keys.unwrap_or(current.conflict_keys);
+        validate_plan_fields(&id, &next_requirements, next_interval, &next_conflicts)?;
+        self.validate_dependency_graph(&id, &next_requirements)?;
+
+        let next_version = current
+            .version
+            .checked_add(1)
+            .ok_or_else(|| format!("version overflow for plan '{id}'"))?;
+        if plan.versions.len() >= MAX_VERSIONS_PER_PLAN {
+            return Err(format!(
+                "plan '{id}' reached version limit of {MAX_VERSIONS_PER_PLAN}; start a new scoped plan and retain this graph for audit"
+            ));
+        }
+        let plan = self.plans.get_mut(&id).expect("plan existence checked");
+        plan.versions.push(PlanVersion {
+            version: next_version,
+            revised_at: now,
+            description: next_description,
+            priority: priority.unwrap_or(current.priority),
+            requirements: next_requirements,
+            min_attention_interval_seconds: next_interval,
+            conflict_keys: normalized_unique(next_conflicts),
+        });
+        if matches!(
+            plan.lifecycle,
+            PlanLifecycle::Fulfilled | PlanLifecycle::Disputed
+        ) {
+            plan.lifecycle = PlanLifecycle::Active;
+            if let Some(completion) = &mut plan.completion {
+                completion.disputed_at = Some(now);
+                completion.dispute_reason = Some(format!(
+                    "plan revised from version {} to version {next_version}; prior completion requires reconciliation",
+                    completion.plan_version
+                ));
+            }
+        }
+
+        let affected = self.dependent_closure([id.clone()].into_iter().collect());
+        let evaluations = self.evaluate_plan_set(affected, now)?;
+        Ok(json!({
+            "plan": self.plans.get(&id),
+            "evaluations": evaluations,
+            "attention": self.queue_partition(now),
+        }))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn observe(
+        &mut self,
+        event_id: String,
+        source_key: String,
+        source_revision: u64,
+        value: Option<EvidenceValue>,
+        observed_events: Vec<String>,
+        covered_events: Vec<String>,
+        coverage_start: Option<DateTime<Utc>>,
+        coverage_end: Option<DateTime<Utc>>,
+        now: DateTime<Utc>,
+    ) -> Result<Value, String> {
+        validate_id("event id", &event_id)?;
+        validate_source_key(&source_key)?;
+        validate_evidence_value(value.as_ref())?;
+        validate_event_list("observed_events", &observed_events)?;
+        validate_event_list("covered_events", &covered_events)?;
+        validate_window(coverage_start, coverage_end, "observation coverage")?;
+        if source_revision == 0 {
+            return Err("source_revision must be greater than zero".to_owned());
+        }
+
+        let digest_material = Command::Observe {
+            event_id: event_id.clone(),
+            source_key: source_key.clone(),
+            source_revision,
+            value: value.clone(),
+            observed_events: observed_events.clone(),
+            covered_events: covered_events.clone(),
+            coverage_start,
+            coverage_end,
+        };
+        let command_digest = stable_digest(&digest_material)?;
+        if let Some(prior) = self.observation_receipts.get(&event_id) {
+            if prior.command_digest != command_digest {
+                return Err(format!(
+                    "event id '{event_id}' was already used for a different observation"
+                ));
+            }
+            let mut response = prior.response.clone();
+            if let Some(object) = response.as_object_mut() {
+                object.insert("idempotent".to_owned(), Value::Bool(true));
+            }
+            return Ok(response);
+        }
+        if coverage_end.is_some_and(|coverage_end| coverage_end > now) {
+            return Err("coverage_end cannot be later than the observation time".to_owned());
+        }
+
+        if self.observation_receipts.len() >= MAX_EVENT_RECEIPTS {
+            return Err(format!(
+                "observation receipt limit of {MAX_EVENT_RECEIPTS} reached"
+            ));
+        }
+        if !self.sources.contains_key(&source_key) && self.sources.len() >= MAX_SOURCES {
+            return Err(format!("evidence source limit of {MAX_SOURCES} reached"));
+        }
+        if let Some(current) = self.sources.get(&source_key)
+            && source_revision <= current.revision
+        {
+            return Err(format!(
+                "stale source revision for '{source_key}': got {source_revision}, current is {}",
+                current.revision
+            ));
+        }
+
+        self.sources.insert(
+            source_key.clone(),
+            EvidenceSource {
+                source_key: source_key.clone(),
+                revision: source_revision,
+                value,
+                observed_events: observed_events.into_iter().collect(),
+                covered_events: covered_events.into_iter().collect(),
+                coverage_start,
+                coverage_end,
+                observed_at: now,
+                provenance: EvidenceProvenance::CallerAsserted,
+            },
+        );
+
+        let direct: BTreeSet<String> = self
+            .plans
+            .iter()
+            .filter(|(_, plan)| {
+                plan.current()
+                    .requirements
+                    .iter()
+                    .any(|requirement| requirement.source_key() == Some(source_key.as_str()))
+            })
+            .map(|(plan_id, _)| plan_id.clone())
+            .collect();
+        let affected = self.dependent_closure(direct);
+        let affected_plan_ids: Vec<String> = affected.iter().cloned().collect();
+        let evaluations = self.evaluate_plan_set(affected, now)?;
+
+        let response = json!({
+            "event_id": event_id,
+            "idempotent": false,
+            "source_key": source_key,
+            "source_revision": source_revision,
+            "evidence_provenance": "caller_asserted",
+            "affected_plan_ids": affected_plan_ids,
+            "evaluations": evaluations,
+            "attention": self.queue_partition(now),
+        });
+        self.observation_receipts.insert(
+            event_id.clone(),
+            ObservationReceipt {
+                event_id,
+                command_digest,
+                source_key,
+                source_revision,
+                response: response.clone(),
+            },
+        );
+        Ok(response)
+    }
+
+    fn evaluate(&mut self, id: Option<&str>, now: DateTime<Utc>) -> Result<Value, String> {
+        let roots = if let Some(id) = id {
+            validate_id("plan id", id)?;
+            if !self.plans.contains_key(id) {
+                return Err(format!("unknown plan '{id}'"));
+            }
+            self.dependent_closure([id.to_owned()].into_iter().collect())
+        } else {
+            self.plans.keys().cloned().collect()
+        };
+        let evaluations = self.evaluate_plan_set(roots, now)?;
+        Ok(json!({
+            "evaluations": evaluations,
+            "attention": self.queue_partition(now),
+        }))
+    }
+
+    fn complete(
+        &mut self,
+        id: String,
+        expected_version: u32,
+        basis: CompletionBasis,
+        now: DateTime<Utc>,
+    ) -> Result<Value, String> {
+        validate_id("plan id", &id)?;
+        let plan = self
+            .plans
+            .get(&id)
+            .ok_or_else(|| format!("unknown plan '{id}'"))?;
+        if plan.lifecycle == PlanLifecycle::Cancelled {
+            return Err(format!("cancelled plan '{id}' cannot be completed"));
+        }
+        if plan.current().version != expected_version {
+            return Err(format!(
+                "stale plan version for '{id}': expected {expected_version}, current is {}",
+                plan.current().version
+            ));
+        }
+        if let Some(completion) = &plan.completion {
+            if plan.lifecycle == PlanLifecycle::Fulfilled && completion.basis == basis {
+                return Ok(json!({
+                    "plan": plan,
+                    "idempotent": true,
+                    "attention": self.queue_partition(now),
+                }));
+            }
+            if plan.lifecycle == PlanLifecycle::Fulfilled {
+                return Err(format!(
+                    "plan '{id}' is already fulfilled with a different completion basis"
+                ));
+            }
+            if plan.lifecycle == PlanLifecycle::Disputed
+                && completion.plan_version == expected_version
+            {
+                return Err(format!(
+                    "disputed plan '{id}' must be explicitly revised before recompletion"
+                ));
+            }
+        }
+        validate_completion_basis(&basis)?;
+
+        if let CompletionBasis::Evidence { requirement_ids } = &basis {
+            let snapshot = self.evaluate_plan_read_only(&id, now)?;
+            let by_id: BTreeMap<&str, RequirementState> = snapshot
+                .requirements
+                .iter()
+                .map(|evaluation| (evaluation.requirement_id.as_str(), evaluation.state))
+                .collect();
+            if let Some(unsatisfied) = snapshot
+                .requirements
+                .iter()
+                .find(|evaluation| evaluation.state != RequirementState::Satisfied)
+            {
+                return Err(format!(
+                    "evidence completion rejected: all current requirements must be satisfied; '{}' is {:?}",
+                    unsatisfied.requirement_id, unsatisfied.state
+                ));
+            }
+            for requirement_id in requirement_ids {
+                match by_id.get(requirement_id.as_str()) {
+                    Some(RequirementState::Satisfied) => {}
+                    Some(state) => {
+                        return Err(format!(
+                            "evidence completion rejected: requirement '{requirement_id}' is {state:?}"
+                        ));
+                    }
+                    None => {
+                        return Err(format!(
+                            "evidence completion rejected: unknown requirement '{requirement_id}'"
+                        ));
+                    }
+                }
+            }
+        }
+
+        let plan = self.plans.get_mut(&id).expect("plan existence checked");
+        plan.lifecycle = PlanLifecycle::Fulfilled;
+        plan.completion = Some(CompletionRecord {
+            basis,
+            plan_version: expected_version,
+            completed_at: now,
+            disputed_at: None,
+            dispute_reason: None,
+        });
+        plan.cancellation = None;
+
+        let affected = self.dependent_closure([id.clone()].into_iter().collect());
+        let evaluations = self.evaluate_plan_set(affected, now)?;
+        Ok(json!({
+            "plan": self.plans.get(&id),
+            "evaluations": evaluations,
+            "attention": self.queue_partition(now),
+        }))
+    }
+
+    fn cancel(
+        &mut self,
+        id: String,
+        expected_version: u32,
+        reason: String,
+        now: DateTime<Utc>,
+    ) -> Result<Value, String> {
+        validate_id("plan id", &id)?;
+        validate_bounded_nonempty("cancellation reason", &reason, MAX_TEXT_BYTES)?;
+        let plan = self
+            .plans
+            .get(&id)
+            .ok_or_else(|| format!("unknown plan '{id}'"))?;
+        if plan.current().version != expected_version {
+            return Err(format!(
+                "stale plan version for '{id}': expected {expected_version}, current is {}",
+                plan.current().version
+            ));
+        }
+        if let Some(cancellation) = &plan.cancellation {
+            if cancellation.reason == reason {
+                return Ok(json!({
+                    "plan": plan,
+                    "idempotent": true,
+                    "attention": self.queue_partition(now),
+                }));
+            }
+            return Err(format!(
+                "plan '{id}' is already cancelled with a different reason"
+            ));
+        }
+        let plan = self.plans.get_mut(&id).expect("plan existence checked");
+        plan.lifecycle = PlanLifecycle::Cancelled;
+        plan.cancellation = Some(CancellationRecord {
+            reason,
+            plan_version: expected_version,
+            cancelled_at: now,
+        });
+
+        let affected = self.dependent_closure([id.clone()].into_iter().collect());
+        let evaluations = self.evaluate_plan_set(affected, now)?;
+        Ok(json!({
+            "plan": self.plans.get(&id),
+            "evaluations": evaluations,
+            "attention": self.queue_partition(now),
+        }))
+    }
+
+    fn acknowledge(&mut self, queue_id: String, now: DateTime<Utc>) -> Result<Value, String> {
+        validate_id("queue id", &queue_id)?;
+        let event = self
+            .attention_queue
+            .get_mut(&queue_id)
+            .ok_or_else(|| format!("unknown attention queue id '{queue_id}'"))?;
+        if event.superseded_at.is_some() {
+            return Err(format!(
+                "attention queue id '{queue_id}' has been superseded"
+            ));
+        }
+        if event.acknowledged_at.is_none() {
+            event.acknowledged_at = Some(now);
+            if let Some(plan) = self.plans.get_mut(&event.plan_id) {
+                plan.last_attention_acknowledged_at = Some(now);
+            }
+        }
+        Ok(json!({
+            "attention_event": self.attention_queue.get(&queue_id),
+            "attention": self.queue_partition(now),
+        }))
+    }
+
+    fn explain(&self, id: &str, now: DateTime<Utc>) -> Result<Value, String> {
+        validate_id("plan id", id)?;
+        let plan = self
+            .plans
+            .get(id)
+            .ok_or_else(|| format!("unknown plan '{id}'"))?;
+        let evaluation = self.evaluate_plan_read_only(id, now)?;
+        let source_keys: BTreeSet<String> = plan
+            .current()
+            .requirements
+            .iter()
+            .filter_map(|requirement| requirement.source_key().map(str::to_owned))
+            .collect();
+        let sources: Vec<&EvidenceSource> = source_keys
+            .iter()
+            .filter_map(|source_key| self.sources.get(source_key))
+            .collect();
+        let pending_attention: Vec<&AttentionEvent> = self
+            .attention_queue
+            .values()
+            .filter(|event| {
+                event.plan_id == id
+                    && event.acknowledged_at.is_none()
+                    && event.superseded_at.is_none()
+            })
+            .collect();
+
+        Ok(json!({
+            "plan": plan,
+            "current": plan.current(),
+            "evaluation": evaluation,
+            "sources": sources,
+            "pending_attention": pending_attention,
+            "evidence_boundary": {
+                "provenance": "caller_asserted",
+                "cryptographic_proof": false,
+                "grants_authority": false,
+                "note": "Evaluation records are deterministic labels over caller-supplied evidence, not proof, truth verification, or authorization for an effect."
+            }
+        }))
+    }
+
+    fn portfolio(&self, now: DateTime<Utc>) -> Result<Value, String> {
+        let mut summaries = Vec::with_capacity(self.plans.len());
+        for plan in self.plans.values() {
+            let evaluation = self.evaluate_plan_read_only(&plan.id, now)?;
+            summaries.push(json!({
+                "id": plan.id,
+                "version": plan.current().version,
+                "description": plan.current().description,
+                "priority": plan.current().priority,
+                "lifecycle": plan.lifecycle,
+                "readiness": evaluation.readiness,
+            }));
+        }
+        summaries.sort_by(|a, b| {
+            let a_id = a.get("id").and_then(Value::as_str).unwrap_or_default();
+            let b_id = b.get("id").and_then(Value::as_str).unwrap_or_default();
+            let a_priority = self
+                .plans
+                .get(a_id)
+                .map(|plan| plan.current().priority)
+                .unwrap_or(Priority::Low);
+            let b_priority = self
+                .plans
+                .get(b_id)
+                .map(|plan| plan.current().priority)
+                .unwrap_or(Priority::Low);
+            b_priority.cmp(&a_priority).then_with(|| a_id.cmp(b_id))
+        });
+
+        let mut shared_by_signature: BTreeMap<String, Vec<Value>> = BTreeMap::new();
+        let mut conflicts_by_key: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        let mut unmet_prerequisites = Vec::new();
+        for plan in self
+            .plans
+            .values()
+            .filter(|plan| !matches!(plan.lifecycle, PlanLifecycle::Cancelled))
+        {
+            for requirement in &plan.current().requirements {
+                let signature = requirement_signature(requirement)?;
+                shared_by_signature
+                    .entry(signature)
+                    .or_default()
+                    .push(json!({
+                        "plan_id": plan.id,
+                        "requirement_id": requirement.id(),
+                    }));
+                if let Requirement::PlanFulfilled {
+                    id: requirement_id,
+                    plan_id: prerequisite_plan_id,
+                } = requirement
+                {
+                    let prerequisite_status = self
+                        .plans
+                        .get(prerequisite_plan_id)
+                        .map(|prerequisite| prerequisite.lifecycle);
+                    if prerequisite_status != Some(PlanLifecycle::Fulfilled) {
+                        unmet_prerequisites.push(json!({
+                            "plan_id": plan.id,
+                            "requirement_id": requirement_id,
+                            "prerequisite_plan_id": prerequisite_plan_id,
+                            "prerequisite_status": prerequisite_status,
+                        }));
+                    }
+                }
+            }
+            if matches!(
+                plan.lifecycle,
+                PlanLifecycle::Active | PlanLifecycle::Disputed
+            ) {
+                for conflict_key in &plan.current().conflict_keys {
+                    conflicts_by_key
+                        .entry(conflict_key.clone())
+                        .or_default()
+                        .push(plan.id.clone());
+                }
+            }
+        }
+
+        let shared_requirements: Vec<Value> = shared_by_signature
+            .into_iter()
+            .filter_map(|(signature, uses)| {
+                (uses.len() > 1).then(|| json!({ "signature": signature, "uses": uses }))
+            })
+            .collect();
+        let conflicts: Vec<Value> = conflicts_by_key
+            .into_iter()
+            .filter_map(|(conflict_key, plan_ids)| {
+                (plan_ids.len() > 1)
+                    .then(|| json!({ "conflict_key": conflict_key, "plan_ids": plan_ids }))
+            })
+            .collect();
+
+        Ok(json!({
+            "plans": summaries,
+            "shared_requirements": shared_requirements,
+            "conflicts": conflicts,
+            "unmet_prerequisites": unmet_prerequisites,
+            "attention": self.queue_partition(now),
+        }))
+    }
+
+    fn evaluate_plan_set(
+        &mut self,
+        plan_ids: BTreeSet<String>,
+        now: DateTime<Utc>,
+    ) -> Result<Vec<EvaluationRecord>, String> {
+        let ordered = self.topological_plan_ids(&plan_ids);
+        let mut records = Vec::with_capacity(ordered.len());
+        for plan_id in ordered {
+            records.push(self.evaluate_and_record(&plan_id, now)?);
+        }
+        Ok(records)
+    }
+
+    fn evaluate_and_record(
+        &mut self,
+        plan_id: &str,
+        now: DateTime<Utc>,
+    ) -> Result<EvaluationRecord, String> {
+        let initial = self.evaluate_plan_read_only(plan_id, now)?;
+        let dispute_requirement = {
+            let plan = self
+                .plans
+                .get(plan_id)
+                .ok_or_else(|| format!("unknown plan '{plan_id}'"))?;
+            if plan.lifecycle != PlanLifecycle::Fulfilled {
+                None
+            } else {
+                match plan.completion.as_ref().map(|record| &record.basis) {
+                    Some(CompletionBasis::Evidence { .. }) => initial
+                        .requirements
+                        .iter()
+                        .find(|evaluation| evaluation.state != RequirementState::Satisfied)
+                        .map(|evaluation| evaluation.requirement_id.clone()),
+                    _ => None,
+                }
+            }
+        };
+        if let Some(requirement_id) = dispute_requirement {
+            let plan = self.plans.get_mut(plan_id).expect("plan existence checked");
+            plan.lifecycle = PlanLifecycle::Disputed;
+            if let Some(completion) = &mut plan.completion {
+                completion.disputed_at = Some(now);
+                completion.dispute_reason = Some(format!(
+                    "completion evidence requirement '{requirement_id}' is no longer satisfied"
+                ));
+            }
+        }
+
+        let snapshot = self.evaluate_plan_read_only(plan_id, now)?;
+        let label_material = json!({
+            "plan_id": snapshot.plan_id,
+            "plan_version": snapshot.plan_version,
+            "lifecycle": snapshot.lifecycle,
+            "readiness": snapshot.readiness,
+            "requirements": snapshot.requirements,
+            "evaluated_at": now,
+        });
+        let label = format!("eval_{}", stable_digest(&label_material)?);
+        let record = EvaluationRecord {
+            label: label.clone(),
+            evaluated_at: now,
+            snapshot,
+            record_kind: EvaluationRecordKind::DeterministicEvaluation,
+            cryptographic_proof: false,
+            grants_authority: false,
+        };
+        if !self.evaluations.contains_key(&label) && self.evaluations.len() >= MAX_EVALUATIONS {
+            return Err(format!(
+                "evaluation record limit of {MAX_EVALUATIONS} reached"
+            ));
+        }
+        self.evaluations.insert(label, record.clone());
+        self.maybe_enqueue_attention(&record, now)?;
+        Ok(record)
+    }
+
+    fn evaluate_plan_read_only(
+        &self,
+        plan_id: &str,
+        now: DateTime<Utc>,
+    ) -> Result<EvaluationSnapshot, String> {
+        let plan = self
+            .plans
+            .get(plan_id)
+            .ok_or_else(|| format!("unknown plan '{plan_id}'"))?;
+        let current = plan.current();
+        let requirements: Vec<RequirementEvaluation> = current
+            .requirements
+            .iter()
+            .map(|requirement| self.evaluate_requirement(requirement, now))
+            .collect();
+        let readiness = if requirements.iter().any(|evaluation| {
+            matches!(
+                evaluation.state,
+                RequirementState::Unmet | RequirementState::Missing
+            )
+        }) {
+            Readiness::Blocked
+        } else if requirements
+            .iter()
+            .any(|evaluation| evaluation.state == RequirementState::Unknown)
+        {
+            Readiness::Unknown
+        } else {
+            Readiness::Ready
+        };
+        Ok(EvaluationSnapshot {
+            plan_id: plan_id.to_owned(),
+            plan_version: current.version,
+            lifecycle: plan.lifecycle,
+            readiness,
+            requirements,
+        })
+    }
+
+    fn evaluate_requirement(
+        &self,
+        requirement: &Requirement,
+        now: DateTime<Utc>,
+    ) -> RequirementEvaluation {
+        match requirement {
+            Requirement::Evidence {
+                id,
+                source_key,
+                condition,
+                ..
+            } => {
+                let Some(source) = self.sources.get(source_key) else {
+                    return requirement_evaluation(
+                        id,
+                        RequirementState::Unknown,
+                        "source has not been observed",
+                        Some(source_key),
+                        None,
+                    );
+                };
+                let (state, detail) = match (condition, source.value.as_ref()) {
+                    (EvidenceCondition::Exists, Some(_)) => {
+                        (RequirementState::Satisfied, "source has a value")
+                    }
+                    (EvidenceCondition::Exists, None) => (
+                        RequirementState::Missing,
+                        "source was observed without a value",
+                    ),
+                    (EvidenceCondition::Equals { .. }, None)
+                    | (EvidenceCondition::NotEquals { .. }, None) => (
+                        RequirementState::Missing,
+                        "source was observed without a comparable value",
+                    ),
+                    (EvidenceCondition::Equals { value }, Some(actual)) if actual == value => (
+                        RequirementState::Satisfied,
+                        "source value equals expected value",
+                    ),
+                    (EvidenceCondition::Equals { .. }, Some(_)) => (
+                        RequirementState::Unmet,
+                        "source value does not equal expected value",
+                    ),
+                    (EvidenceCondition::NotEquals { value }, Some(actual)) if actual != value => (
+                        RequirementState::Satisfied,
+                        "source value differs from excluded value",
+                    ),
+                    (EvidenceCondition::NotEquals { .. }, Some(_)) => (
+                        RequirementState::Unmet,
+                        "source value equals excluded value",
+                    ),
+                };
+                requirement_evaluation(id, state, detail, Some(source_key), Some(source.revision))
+            }
+            Requirement::Event {
+                id,
+                source_key,
+                event,
+                expectation,
+                window_start,
+                window_end,
+                grace_seconds,
+                ..
+            } => {
+                let Some(source) = self.sources.get(source_key) else {
+                    return requirement_evaluation(
+                        id,
+                        RequirementState::Unknown,
+                        "event source has not been observed",
+                        Some(source_key),
+                        None,
+                    );
+                };
+                let occurred = source.observed_events.contains(event);
+                let occurrence_applies =
+                    occurred && event_occurrence_applies(source, *window_start, *window_end);
+                let coverage_complete = event_coverage_complete(
+                    source,
+                    event,
+                    *window_start,
+                    *window_end,
+                    *grace_seconds,
+                    now,
+                );
+                let (state, detail) = match (
+                    expectation,
+                    occurred,
+                    occurrence_applies,
+                    coverage_complete,
+                ) {
+                    (EventExpectation::Occurred, true, true, _) => (
+                        RequirementState::Satisfied,
+                        "required event is present in the supplied snapshot",
+                    ),
+                    (EventExpectation::Occurred, true, false, _) => (
+                        RequirementState::Unknown,
+                        "event is present but its observation interval is not inside the required window",
+                    ),
+                    (EventExpectation::Occurred, false, _, true) => (
+                        RequirementState::Missing,
+                        "required event is absent from complete observation coverage",
+                    ),
+                    (EventExpectation::Occurred, false, _, false) => (
+                        RequirementState::Unknown,
+                        "required event is absent but observation coverage is incomplete",
+                    ),
+                    (EventExpectation::Absent, true, true, _) => (
+                        RequirementState::Unmet,
+                        "excluded event is present in the supplied snapshot",
+                    ),
+                    (EventExpectation::Absent, true, false, _) => (
+                        RequirementState::Unknown,
+                        "excluded event is present but is not placed inside the required window",
+                    ),
+                    (EventExpectation::Absent, false, _, true) => (
+                        RequirementState::Satisfied,
+                        "excluded event is absent after complete window coverage and grace",
+                    ),
+                    (EventExpectation::Absent, false, _, false) => (
+                        RequirementState::Unknown,
+                        "event absence is not established by complete elapsed window coverage",
+                    ),
+                };
+                requirement_evaluation(id, state, detail, Some(source_key), Some(source.revision))
+            }
+            Requirement::PlanFulfilled { id, plan_id } => match self.plans.get(plan_id) {
+                Some(plan) if plan.lifecycle == PlanLifecycle::Fulfilled => requirement_evaluation(
+                    id,
+                    RequirementState::Satisfied,
+                    "prerequisite plan is fulfilled",
+                    None,
+                    None,
+                ),
+                Some(plan) => requirement_evaluation(
+                    id,
+                    RequirementState::Unmet,
+                    &format!("prerequisite plan is {:?}", plan.lifecycle).to_lowercase(),
+                    None,
+                    None,
+                ),
+                None => requirement_evaluation(
+                    id,
+                    RequirementState::Missing,
+                    "prerequisite plan does not exist",
+                    None,
+                    None,
+                ),
+            },
+        }
+    }
+
+    fn maybe_enqueue_attention(
+        &mut self,
+        record: &EvaluationRecord,
+        now: DateTime<Utc>,
+    ) -> Result<(), String> {
+        let plan = self
+            .plans
+            .get(&record.snapshot.plan_id)
+            .ok_or_else(|| format!("unknown plan '{}'", record.snapshot.plan_id))?;
+        let requirement_states: Vec<Value> = record
+            .snapshot
+            .requirements
+            .iter()
+            .map(|requirement| {
+                json!({
+                    "requirement_id": requirement.requirement_id,
+                    "state": requirement.state,
+                })
+            })
+            .collect();
+        let fingerprint_material = json!({
+            "plan_id": record.snapshot.plan_id,
+            "plan_version": record.snapshot.plan_version,
+            "lifecycle": record.snapshot.lifecycle,
+            "readiness": record.snapshot.readiness,
+            "requirement_states": requirement_states,
+        });
+        let fingerprint = stable_digest(&fingerprint_material)?;
+        if self.attention_queue.values().any(|event| {
+            event.plan_id == record.snapshot.plan_id
+                && event.superseded_at.is_none()
+                && event.fingerprint == fingerprint
+        }) {
+            return Ok(());
+        }
+        for event in self.attention_queue.values_mut().filter(|event| {
+            event.plan_id == record.snapshot.plan_id
+                && event.superseded_at.is_none()
+                && event.fingerprint != fingerprint
+        }) {
+            event.superseded_at = Some(now);
+        }
+        let needs_attention = record.snapshot.lifecycle == PlanLifecycle::Disputed
+            || record.snapshot.lifecycle == PlanLifecycle::Active;
+        if !needs_attention {
+            return Ok(());
+        }
+        if self.attention_queue.len() >= MAX_ATTENTION_EVENTS {
+            return Err(format!(
+                "attention event limit of {MAX_ATTENTION_EVENTS} reached"
+            ));
+        }
+        let sequence = self
+            .attention_sequence_by_plan
+            .get(&record.snapshot.plan_id)
+            .copied()
+            .unwrap_or(0)
+            .checked_add(1)
+            .ok_or_else(|| {
+                format!(
+                    "attention sequence overflow for plan '{}'",
+                    record.snapshot.plan_id
+                )
+            })?;
+        let queue_id = format!(
+            "attn_{}",
+            stable_digest(&json!({
+                "plan_id": record.snapshot.plan_id,
+                "fingerprint": fingerprint,
+                "sequence": sequence,
+            }))?
+        );
+        let interval = Duration::seconds(plan.current().min_attention_interval_seconds as i64);
+        let deliver_after = match plan.last_attention_acknowledged_at {
+            Some(last) => last
+                .checked_add_signed(interval)
+                .ok_or_else(|| "attention interval exceeds timestamp range".to_owned())?
+                .max(now),
+            None => now,
+        };
+        let reason = if record.snapshot.lifecycle == PlanLifecycle::Disputed {
+            "previously fulfilled completion evidence is disputed".to_owned()
+        } else if record.snapshot.readiness == Readiness::Ready {
+            "plan requirements are ready".to_owned()
+        } else {
+            format!("plan readiness is {:?}", record.snapshot.readiness).to_lowercase()
+        };
+        self.attention_queue.insert(
+            queue_id.clone(),
+            AttentionEvent {
+                queue_id,
+                fingerprint,
+                plan_id: record.snapshot.plan_id.clone(),
+                priority: plan.current().priority,
+                created_at: now,
+                deliver_after,
+                reason,
+                acknowledged_at: None,
+                superseded_at: None,
+            },
+        );
+        self.attention_sequence_by_plan
+            .insert(record.snapshot.plan_id.clone(), sequence);
+        Ok(())
+    }
+
+    fn dependent_closure(&self, mut affected: BTreeSet<String>) -> BTreeSet<String> {
+        loop {
+            let mut changed = false;
+            for (plan_id, plan) in &self.plans {
+                if affected.contains(plan_id) {
+                    continue;
+                }
+                if plan.current().requirements.iter().any(|requirement| {
+                    requirement
+                        .prerequisite_plan_id()
+                        .is_some_and(|prerequisite| affected.contains(prerequisite))
+                }) {
+                    affected.insert(plan_id.clone());
+                    changed = true;
+                }
+            }
+            if !changed {
+                return affected;
+            }
+        }
+    }
+
+    fn topological_plan_ids(&self, plan_ids: &BTreeSet<String>) -> Vec<String> {
+        fn visit(
+            graph: &IntentionGraph,
+            plan_ids: &BTreeSet<String>,
+            plan_id: &str,
+            visited: &mut BTreeSet<String>,
+            ordered: &mut Vec<String>,
+        ) {
+            if !visited.insert(plan_id.to_owned()) {
+                return;
+            }
+            if let Some(plan) = graph.plans.get(plan_id) {
+                for prerequisite in plan
+                    .current()
+                    .requirements
+                    .iter()
+                    .filter_map(Requirement::prerequisite_plan_id)
+                    .filter(|prerequisite| plan_ids.contains(*prerequisite))
+                {
+                    visit(graph, plan_ids, prerequisite, visited, ordered);
+                }
+            }
+            ordered.push(plan_id.to_owned());
+        }
+
+        let mut visited = BTreeSet::new();
+        let mut ordered = Vec::with_capacity(plan_ids.len());
+        for plan_id in plan_ids {
+            visit(self, plan_ids, plan_id, &mut visited, &mut ordered);
+        }
+        ordered
+    }
+
+    fn validate_dependency_graph(
+        &self,
+        candidate_id: &str,
+        candidate_requirements: &[Requirement],
+    ) -> Result<(), String> {
+        for prerequisite_id in candidate_requirements
+            .iter()
+            .filter_map(Requirement::prerequisite_plan_id)
+        {
+            if !self.plans.contains_key(prerequisite_id) {
+                return Err(format!(
+                    "plan '{candidate_id}' references unknown prerequisite plan '{prerequisite_id}'"
+                ));
+            }
+        }
+
+        fn visit(
+            graph: &IntentionGraph,
+            candidate_id: &str,
+            candidate_requirements: &[Requirement],
+            current: &str,
+            visiting: &mut BTreeSet<String>,
+            visited: &mut BTreeSet<String>,
+        ) -> bool {
+            if !visiting.insert(current.to_owned()) {
+                return true;
+            }
+            if visited.contains(current) {
+                visiting.remove(current);
+                return false;
+            }
+            let requirements = if current == candidate_id {
+                candidate_requirements
+            } else if let Some(plan) = graph.plans.get(current) {
+                &plan.current().requirements
+            } else {
+                visiting.remove(current);
+                return false;
+            };
+            for next in requirements
+                .iter()
+                .filter_map(Requirement::prerequisite_plan_id)
+            {
+                if visit(
+                    graph,
+                    candidate_id,
+                    candidate_requirements,
+                    next,
+                    visiting,
+                    visited,
+                ) {
+                    return true;
+                }
+            }
+            visiting.remove(current);
+            visited.insert(current.to_owned());
+            false
+        }
+
+        let mut visiting = BTreeSet::new();
+        let mut visited = BTreeSet::new();
+        if visit(
+            self,
+            candidate_id,
+            candidate_requirements,
+            candidate_id,
+            &mut visiting,
+            &mut visited,
+        ) {
+            return Err(format!(
+                "plan '{candidate_id}' would introduce a prerequisite cycle"
+            ));
+        }
+        Ok(())
+    }
+
+    fn queue_partition(&self, now: DateTime<Utc>) -> Value {
+        let mut pending: Vec<&AttentionEvent> = self
+            .attention_queue
+            .values()
+            .filter(|event| event.acknowledged_at.is_none() && event.superseded_at.is_none())
+            .collect();
+        pending.sort_by(|a, b| {
+            b.priority
+                .cmp(&a.priority)
+                .then_with(|| a.deliver_after.cmp(&b.deliver_after))
+                .then_with(|| a.queue_id.cmp(&b.queue_id))
+        });
+        let (deliverable, withheld): (Vec<_>, Vec<_>) = pending
+            .into_iter()
+            .partition(|event| event.deliver_after <= now);
+        json!({
+            "deliverable_queue_ids": deliverable
+                .iter()
+                .map(|event| event.queue_id.as_str())
+                .collect::<Vec<_>>(),
+            "withheld_queue_ids": withheld
+                .iter()
+                .map(|event| event.queue_id.as_str())
+                .collect::<Vec<_>>(),
+            "pending_count": deliverable.len() + withheld.len(),
+        })
+    }
+}
+
+/// Deterministically reconstruct a graph from a caller-owned journal.
+pub fn replay(entries: &[TimedCommand]) -> Result<IntentionGraph, String> {
+    let mut graph = IntentionGraph::default();
+    for (index, entry) in entries.iter().enumerate() {
+        graph
+            .apply(entry.command.clone(), entry.now)
+            .map_err(|error| format!("replay entry {index} failed: {error}"))?;
+    }
+    Ok(graph)
+}
+
+/// Public schema for the nested command payload. It intentionally documents
+/// semantic boundaries in addition to field types because the engine cannot
+/// verify a source or authorize an external action.
+pub fn schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "Vestige Intention Evidence Lifecycle",
+        "schema_version": INTENTION_GRAPH_SCHEMA_VERSION,
+        "algorithm_version": INTENTION_GRAPH_ALGORITHM_VERSION,
+        "type": "object",
+        "oneOf": [
+                {
+                    "title": "plan",
+                    "type": "object",
+                    "required": ["action", "id", "description"],
+                    "properties": {
+                        "action": { "const": "plan" },
+                        "id": bounded_string_schema(MAX_ID_BYTES),
+                        "description": bounded_string_schema(MAX_DESCRIPTION_BYTES),
+                        "priority": priority_schema(),
+                        "requirements": requirements_schema(),
+                        "min_attention_interval_seconds": { "type": "integer", "minimum": 0, "maximum": MAX_ATTENTION_INTERVAL_SECONDS },
+                        "conflict_keys": bounded_string_array_schema(MAX_CONFLICT_KEYS, MAX_ID_BYTES),
+                    },
+                    "additionalProperties": false,
+                },
+                {
+                    "title": "revise",
+                    "type": "object",
+                    "required": ["action", "id", "expected_version"],
+                    "properties": {
+                        "action": { "const": "revise" },
+                        "id": bounded_string_schema(MAX_ID_BYTES),
+                        "expected_version": { "type": "integer", "minimum": 1 },
+                        "description": bounded_string_schema(MAX_DESCRIPTION_BYTES),
+                        "priority": priority_schema(),
+                        "requirements": requirements_schema(),
+                        "min_attention_interval_seconds": { "type": "integer", "minimum": 0, "maximum": MAX_ATTENTION_INTERVAL_SECONDS },
+                        "conflict_keys": bounded_string_array_schema(MAX_CONFLICT_KEYS, MAX_ID_BYTES),
+                    },
+                    "additionalProperties": false,
+                },
+                {
+                    "title": "observe",
+                    "type": "object",
+                    "required": ["action", "event_id", "source_key", "source_revision"],
+                    "properties": {
+                        "action": { "const": "observe" },
+                        "event_id": bounded_string_schema(MAX_ID_BYTES),
+                        "source_key": bounded_string_schema(MAX_SOURCE_KEY_BYTES),
+                        "source_revision": { "type": "integer", "minimum": 1 },
+                        "value": evidence_value_schema(true),
+                        "observed_events": bounded_string_array_schema(MAX_EVENTS_PER_OBSERVATION, MAX_ID_BYTES),
+                        "covered_events": bounded_string_array_schema(MAX_EVENTS_PER_OBSERVATION, MAX_ID_BYTES),
+                        "coverage_start": { "type": "string", "format": "date-time" },
+                        "coverage_end": { "type": "string", "format": "date-time" },
+                    },
+                    "additionalProperties": false,
+                },
+                {
+                    "title": "evaluate",
+                    "type": "object",
+                    "required": ["action"],
+                    "properties": { "action": { "const": "evaluate" }, "id": bounded_string_schema(MAX_ID_BYTES) },
+                    "additionalProperties": false,
+                },
+                {
+                    "title": "explain",
+                    "type": "object",
+                    "required": ["action", "id"],
+                    "properties": { "action": { "const": "explain" }, "id": bounded_string_schema(MAX_ID_BYTES) },
+                    "additionalProperties": false,
+                },
+                {
+                    "title": "portfolio",
+                    "type": "object",
+                    "required": ["action"],
+                    "properties": { "action": { "const": "portfolio" } },
+                    "additionalProperties": false,
+                },
+                {
+                    "title": "complete",
+                    "type": "object",
+                    "required": ["action", "id", "expected_version", "basis"],
+                    "properties": {
+                        "action": { "const": "complete" },
+                        "id": bounded_string_schema(MAX_ID_BYTES),
+                        "expected_version": { "type": "integer", "minimum": 1 },
+                        "basis": {
+                            "oneOf": [
+                                {
+                                    "type": "object",
+                                    "required": ["type", "report"],
+                                    "properties": { "type": { "const": "user_report" }, "report": bounded_string_schema(MAX_TEXT_BYTES) },
+                                    "additionalProperties": false,
+                                },
+                                {
+                                    "type": "object",
+                                    "required": ["type", "requirement_ids"],
+                                    "properties": { "type": { "const": "evidence" }, "requirement_ids": bounded_string_array_schema(MAX_REQUIREMENTS_PER_PLAN, MAX_ID_BYTES) },
+                                    "additionalProperties": false,
+                                }
+                            ]
+                        }
+                    },
+                    "additionalProperties": false,
+                },
+                {
+                    "title": "cancel",
+                    "type": "object",
+                    "required": ["action", "id", "expected_version", "reason"],
+                    "properties": { "action": { "const": "cancel" }, "id": bounded_string_schema(MAX_ID_BYTES), "expected_version": { "type": "integer", "minimum": 1 }, "reason": bounded_string_schema(MAX_TEXT_BYTES) },
+                    "additionalProperties": false,
+                },
+                {
+                    "title": "acknowledge",
+                    "type": "object",
+                    "required": ["action", "queue_id"],
+                    "properties": { "action": { "const": "acknowledge" }, "queue_id": bounded_string_schema(MAX_ID_BYTES) },
+                    "additionalProperties": false,
+                }
+        ],
+        "semantics": {
+            "evidence_provenance": "caller_asserted",
+            "evaluation_records": "deterministic labels, not cryptographic proof or authorization",
+            "absence": "requires an elapsed explicit requirement window plus complete source coverage of that window and named event",
+            "external_effects": "never performed or authorized by this engine, including purchases",
+            "journal": "caller-owned; replay accepts timestamped commands",
+        },
+        "limits": {
+            "plans": MAX_PLANS,
+            "requirements_per_plan": MAX_REQUIREMENTS_PER_PLAN,
+            "sources": MAX_SOURCES,
+            "event_receipts": MAX_EVENT_RECEIPTS,
+        }
+    })
+}
+
+fn requirements_schema() -> Value {
+    json!({
+        "type": "array",
+        "maxItems": MAX_REQUIREMENTS_PER_PLAN,
+        "items": {
+            "oneOf": [
+                {
+                    "title": "evidence",
+                    "type": "object",
+                    "required": ["type", "id", "source_key", "condition"],
+                    "properties": {
+                        "type": { "const": "evidence" },
+                        "id": bounded_string_schema(MAX_ID_BYTES),
+                        "source_key": bounded_string_schema(MAX_SOURCE_KEY_BYTES),
+                        "memory_id": bounded_string_schema(MAX_ID_BYTES),
+                        "condition": {
+                            "oneOf": [
+                                { "type": "object", "required": ["op"], "properties": { "op": { "const": "exists" } }, "additionalProperties": false },
+                                { "type": "object", "required": ["op", "value"], "properties": { "op": { "const": "equals" }, "value": evidence_value_schema(false) }, "additionalProperties": false },
+                                { "type": "object", "required": ["op", "value"], "properties": { "op": { "const": "not_equals" }, "value": evidence_value_schema(false) }, "additionalProperties": false },
+                            ]
+                        }
+                    },
+                    "additionalProperties": false,
+                },
+                {
+                    "title": "event",
+                    "type": "object",
+                    "required": ["type", "id", "source_key", "event", "expectation"],
+                    "properties": {
+                        "type": { "const": "event" },
+                        "id": bounded_string_schema(MAX_ID_BYTES),
+                        "source_key": bounded_string_schema(MAX_SOURCE_KEY_BYTES),
+                        "memory_id": bounded_string_schema(MAX_ID_BYTES),
+                        "event": bounded_string_schema(MAX_ID_BYTES),
+                        "expectation": { "enum": ["occurred", "absent"] },
+                        "window_start": { "type": "string", "format": "date-time" },
+                        "window_end": { "type": "string", "format": "date-time" },
+                        "grace_seconds": { "type": "integer", "minimum": 0, "maximum": MAX_ATTENTION_INTERVAL_SECONDS },
+                    },
+                    "additionalProperties": false,
+                },
+                {
+                    "title": "plan_fulfilled",
+                    "type": "object",
+                    "required": ["type", "id", "plan_id"],
+                    "properties": {
+                        "type": { "const": "plan_fulfilled" },
+                        "id": bounded_string_schema(MAX_ID_BYTES),
+                        "plan_id": bounded_string_schema(MAX_ID_BYTES),
+                    },
+                    "additionalProperties": false,
+                }
+            ]
+        }
+    })
+}
+
+fn priority_schema() -> Value {
+    json!({ "enum": ["low", "normal", "high", "critical"] })
+}
+
+fn evidence_value_schema(nullable: bool) -> Value {
+    let mut variants = vec![
+        json!({ "type": "boolean" }),
+        json!({ "type": "integer", "minimum": i64::MIN, "maximum": i64::MAX }),
+        bounded_string_schema(MAX_TEXT_BYTES),
+    ];
+    if nullable {
+        variants.push(json!({ "type": "null" }));
+    }
+    json!({ "oneOf": variants })
+}
+
+fn bounded_string_schema(max_length: usize) -> Value {
+    json!({ "type": "string", "minLength": 1, "maxLength": max_length })
+}
+
+fn bounded_string_array_schema(max_items: usize, max_length: usize) -> Value {
+    json!({
+        "type": "array",
+        "maxItems": max_items,
+        "uniqueItems": true,
+        "items": bounded_string_schema(max_length),
+    })
+}
+
+fn validate_plan_fields(
+    plan_id: &str,
+    requirements: &[Requirement],
+    min_attention_interval_seconds: u64,
+    conflict_keys: &[String],
+) -> Result<(), String> {
+    if requirements.len() > MAX_REQUIREMENTS_PER_PLAN {
+        return Err(format!(
+            "plan '{plan_id}' has {} requirements; maximum is {MAX_REQUIREMENTS_PER_PLAN}",
+            requirements.len()
+        ));
+    }
+    if min_attention_interval_seconds > MAX_ATTENTION_INTERVAL_SECONDS {
+        return Err(format!(
+            "min_attention_interval_seconds exceeds {MAX_ATTENTION_INTERVAL_SECONDS}"
+        ));
+    }
+    if conflict_keys.len() > MAX_CONFLICT_KEYS {
+        return Err(format!(
+            "plan '{plan_id}' has {} conflict keys; maximum is {MAX_CONFLICT_KEYS}",
+            conflict_keys.len()
+        ));
+    }
+    let mut requirement_ids = BTreeSet::new();
+    for requirement in requirements {
+        validate_requirement(plan_id, requirement)?;
+        if !requirement_ids.insert(requirement.id()) {
+            return Err(format!(
+                "duplicate requirement id '{}' in plan '{plan_id}'",
+                requirement.id()
+            ));
+        }
+    }
+    validate_unique_strings("conflict_keys", conflict_keys, MAX_ID_BYTES)?;
+    Ok(())
+}
+
+fn validate_requirement(plan_id: &str, requirement: &Requirement) -> Result<(), String> {
+    validate_id("requirement id", requirement.id())?;
+    match requirement {
+        Requirement::Evidence {
+            source_key,
+            memory_id,
+            condition,
+            ..
+        } => {
+            validate_source_key(source_key)?;
+            if let Some(memory_id) = memory_id {
+                validate_id("memory id", memory_id)?;
+            }
+            validate_memory_binding(source_key, memory_id.as_deref())?;
+            match condition {
+                EvidenceCondition::Exists => {}
+                EvidenceCondition::Equals { value } | EvidenceCondition::NotEquals { value } => {
+                    validate_evidence_value(Some(value))?;
+                }
+            }
+        }
+        Requirement::Event {
+            source_key,
+            memory_id,
+            event,
+            expectation,
+            window_start,
+            window_end,
+            grace_seconds,
+            ..
+        } => {
+            validate_source_key(source_key)?;
+            if let Some(memory_id) = memory_id {
+                validate_id("memory id", memory_id)?;
+            }
+            validate_memory_binding(source_key, memory_id.as_deref())?;
+            validate_bounded_nonempty("event name", event, MAX_ID_BYTES)?;
+            validate_window(*window_start, *window_end, "event requirement")?;
+            if *grace_seconds > MAX_ATTENTION_INTERVAL_SECONDS {
+                return Err(format!(
+                    "event grace_seconds exceeds {MAX_ATTENTION_INTERVAL_SECONDS}"
+                ));
+            }
+            if *expectation == EventExpectation::Absent
+                && (window_start.is_none() || window_end.is_none())
+            {
+                return Err(
+                    "an absent event requirement needs window_start and window_end".to_owned(),
+                );
+            }
+        }
+        Requirement::PlanFulfilled {
+            plan_id: prerequisite_plan_id,
+            ..
+        } => {
+            validate_id("prerequisite plan id", prerequisite_plan_id)?;
+            if prerequisite_plan_id == plan_id {
+                return Err(format!("plan '{plan_id}' cannot require itself"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_completion_basis(basis: &CompletionBasis) -> Result<(), String> {
+    match basis {
+        CompletionBasis::UserReport { report } => {
+            validate_bounded_nonempty("completion report", report, MAX_TEXT_BYTES)
+        }
+        CompletionBasis::Evidence { requirement_ids } => {
+            if requirement_ids.is_empty() {
+                return Err("evidence completion needs at least one requirement id".to_owned());
+            }
+            if requirement_ids.len() > MAX_REQUIREMENTS_PER_PLAN {
+                return Err(format!(
+                    "evidence completion has too many requirement ids; maximum is {MAX_REQUIREMENTS_PER_PLAN}"
+                ));
+            }
+            validate_unique_strings("completion requirement_ids", requirement_ids, MAX_ID_BYTES)
+        }
+    }
+}
+
+fn validate_evidence_value(value: Option<&EvidenceValue>) -> Result<(), String> {
+    if let Some(EvidenceValue::Text(text)) = value {
+        validate_bounded_nonempty("evidence text", text, MAX_TEXT_BYTES)?;
+    }
+    Ok(())
+}
+
+fn validate_event_list(label: &str, events: &[String]) -> Result<(), String> {
+    if events.len() > MAX_EVENTS_PER_OBSERVATION {
+        return Err(format!(
+            "{label} has {} entries; maximum is {MAX_EVENTS_PER_OBSERVATION}",
+            events.len()
+        ));
+    }
+    validate_unique_strings(label, events, MAX_ID_BYTES)
+}
+
+fn validate_unique_strings(label: &str, values: &[String], max_bytes: usize) -> Result<(), String> {
+    let mut unique = BTreeSet::new();
+    for value in values {
+        validate_bounded_nonempty(label, value, max_bytes)?;
+        if !unique.insert(value) {
+            return Err(format!("{label} contains duplicate value '{value}'"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_window(
+    start: Option<DateTime<Utc>>,
+    end: Option<DateTime<Utc>>,
+    label: &str,
+) -> Result<(), String> {
+    match (start, end) {
+        (None, None) => Ok(()),
+        (Some(start), Some(end)) if start < end => Ok(()),
+        (Some(_), Some(_)) => Err(format!("{label} start must be before end")),
+        _ => Err(format!("{label} requires both start and end")),
+    }
+}
+
+fn validate_id(label: &str, value: &str) -> Result<(), String> {
+    validate_bounded_nonempty(label, value, MAX_ID_BYTES)
+}
+
+fn validate_source_key(value: &str) -> Result<(), String> {
+    validate_bounded_nonempty("source key", value, MAX_SOURCE_KEY_BYTES)
+}
+
+fn validate_memory_binding(source_key: &str, memory_id: Option<&str>) -> Result<(), String> {
+    if let Some(memory_id) = memory_id {
+        let expected = format!("memory:{memory_id}");
+        if source_key != expected {
+            return Err(format!(
+                "memory_id '{memory_id}' must use source_key '{expected}'"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_description(value: &str) -> Result<(), String> {
+    validate_bounded_nonempty("description", value, MAX_DESCRIPTION_BYTES)
+}
+
+fn validate_bounded_nonempty(label: &str, value: &str, max_bytes: usize) -> Result<(), String> {
+    if value.trim().is_empty() {
+        return Err(format!("{label} must not be empty"));
+    }
+    if value.len() > max_bytes {
+        return Err(format!(
+            "{label} is {} bytes; maximum is {max_bytes}",
+            value.len()
+        ));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(format!("{label} must not contain control characters"));
+    }
+    Ok(())
+}
+
+fn normalized_unique(mut values: Vec<String>) -> Vec<String> {
+    values.sort();
+    values.dedup();
+    values
+}
+
+fn stable_digest<T: Serialize>(value: &T) -> Result<String, String> {
+    let bytes = serde_json::to_vec(value)
+        .map_err(|error| format!("failed to serialize deterministic digest input: {error}"))?;
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn requirement_signature(requirement: &Requirement) -> Result<String, String> {
+    let material = match requirement {
+        Requirement::Evidence {
+            source_key,
+            memory_id,
+            condition,
+            ..
+        } => json!({
+            "type": "evidence",
+            "source_key": source_key,
+            "memory_id": memory_id,
+            "condition": condition,
+        }),
+        Requirement::Event {
+            source_key,
+            memory_id,
+            event,
+            expectation,
+            window_start,
+            window_end,
+            grace_seconds,
+            ..
+        } => json!({
+            "type": "event",
+            "source_key": source_key,
+            "memory_id": memory_id,
+            "event": event,
+            "expectation": expectation,
+            "window_start": window_start,
+            "window_end": window_end,
+            "grace_seconds": grace_seconds,
+        }),
+        Requirement::PlanFulfilled { plan_id, .. } => json!({
+            "type": "plan_fulfilled",
+            "plan_id": plan_id,
+        }),
+    };
+    Ok(format!("req_{}", stable_digest(&material)?))
+}
+
+fn requirement_evaluation(
+    requirement_id: &str,
+    state: RequirementState,
+    detail: &str,
+    source_key: Option<&String>,
+    source_revision: Option<u64>,
+) -> RequirementEvaluation {
+    RequirementEvaluation {
+        requirement_id: requirement_id.to_owned(),
+        state,
+        detail: detail.to_owned(),
+        source_key: source_key.cloned(),
+        source_revision,
+    }
+}
+
+fn event_coverage_complete(
+    source: &EvidenceSource,
+    event: &str,
+    window_start: Option<DateTime<Utc>>,
+    window_end: Option<DateTime<Utc>>,
+    grace_seconds: u64,
+    now: DateTime<Utc>,
+) -> bool {
+    if !source.covered_events.contains(event) {
+        return false;
+    }
+    match (window_start, window_end) {
+        (Some(required_start), Some(required_end)) => {
+            let grace_elapsed = required_end
+                .checked_add_signed(Duration::seconds(grace_seconds as i64))
+                .is_some_and(|deadline| now >= deadline);
+            let covers_window = source.coverage_start.zip(source.coverage_end).is_some_and(
+                |(actual_start, actual_end)| {
+                    actual_start <= required_start && actual_end >= required_end
+                },
+            );
+            grace_elapsed && covers_window
+        }
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+fn event_occurrence_applies(
+    source: &EvidenceSource,
+    window_start: Option<DateTime<Utc>>,
+    window_end: Option<DateTime<Utc>>,
+) -> bool {
+    match (window_start, window_end) {
+        (Some(required_start), Some(required_end)) => source
+            .coverage_start
+            .zip(source.coverage_end)
+            .is_some_and(|(observed_start, observed_end)| {
+                observed_start >= required_start && observed_end <= required_end
+            }),
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+fn update_latest(latest: &mut Option<DateTime<Utc>>, candidate: DateTime<Utc>) {
+    if latest.is_none_or(|current| candidate > current) {
+        *latest = Some(candidate);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn t(hour: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 9, 8, hour, 0, 0)
+            .single()
+            .unwrap()
+    }
+
+    fn evidence_requirement(id: &str, source_key: &str, expected: bool) -> Requirement {
+        Requirement::Evidence {
+            id: id.to_owned(),
+            source_key: source_key.to_owned(),
+            memory_id: None,
+            condition: EvidenceCondition::Equals {
+                value: EvidenceValue::Bool(expected),
+            },
+        }
+    }
+
+    fn plan_command(id: &str, requirements: Vec<Requirement>) -> Command {
+        Command::Plan {
+            id: id.to_owned(),
+            description: format!("Plan {id}"),
+            priority: Priority::High,
+            requirements,
+            min_attention_interval_seconds: 3_600,
+            conflict_keys: vec![],
+        }
+    }
+
+    fn observe_bool(event_id: &str, source_key: &str, revision: u64, value: bool) -> Command {
+        Command::Observe {
+            event_id: event_id.to_owned(),
+            source_key: source_key.to_owned(),
+            source_revision: revision,
+            value: Some(EvidenceValue::Bool(value)),
+            observed_events: vec![],
+            covered_events: vec![],
+            coverage_start: None,
+            coverage_end: None,
+        }
+    }
+
+    fn lifecycle(graph: &IntentionGraph, id: &str) -> PlanLifecycle {
+        graph.plans.get(id).unwrap().lifecycle
+    }
+
+    #[test]
+    fn coverage_grace_at_timestamp_limit_remains_unknown() {
+        let end = DateTime::<Utc>::MAX_UTC;
+        let start = end - Duration::hours(1);
+        let source = EvidenceSource {
+            source_key: "calendar".into(),
+            revision: 1,
+            value: None,
+            observed_events: BTreeSet::new(),
+            covered_events: ["arrival".into()].into_iter().collect(),
+            coverage_start: Some(start),
+            coverage_end: Some(end),
+            observed_at: end,
+            provenance: EvidenceProvenance::CallerAsserted,
+        };
+        assert!(!event_coverage_complete(
+            &source,
+            "arrival",
+            Some(start),
+            Some(end),
+            1,
+            end
+        ));
+        assert!(event_coverage_complete(
+            &source,
+            "arrival",
+            Some(start),
+            Some(end),
+            0,
+            end
+        ));
+    }
+
+    #[test]
+    fn oversized_affected_response_fails_atomically_without_poisoning_graph() {
+        let mut graph = IntentionGraph::default();
+        for index in 0..64 {
+            let requirements = (0..32)
+                .map(|r| evidence_requirement(&format!("r{r}"), "shared", true))
+                .collect();
+            graph
+                .apply(plan_command(&format!("p{index}"), requirements), t(0))
+                .unwrap();
+        }
+        let before = serde_json::to_value(&graph).unwrap();
+        let error = graph
+            .apply(observe_bool("large", "shared", 1, true), t(1))
+            .unwrap_err();
+        assert!(error.contains("response"), "{error}");
+        assert_eq!(serde_json::to_value(&graph).unwrap(), before);
+        graph.validate_state().unwrap();
+        assert!(graph.apply(Command::Portfolio, t(1)).is_ok());
+    }
+
+    #[test]
+    fn premise_reversal_disputes_evidence_completion() {
+        let mut graph = IntentionGraph::default();
+        graph
+            .apply(
+                plan_command("ship", vec![evidence_requirement("tests", "ci", true)]),
+                t(0),
+            )
+            .unwrap();
+        graph
+            .apply(observe_bool("ci-1", "ci", 1, true), t(1))
+            .unwrap();
+        graph
+            .apply(
+                Command::Complete {
+                    id: "ship".to_owned(),
+                    expected_version: 1,
+                    basis: CompletionBasis::Evidence {
+                        requirement_ids: vec!["tests".to_owned()],
+                    },
+                },
+                t(2),
+            )
+            .unwrap();
+        assert_eq!(lifecycle(&graph, "ship"), PlanLifecycle::Fulfilled);
+
+        graph
+            .apply(observe_bool("ci-2", "ci", 2, false), t(3))
+            .unwrap();
+        assert_eq!(lifecycle(&graph, "ship"), PlanLifecycle::Disputed);
+        assert!(
+            graph
+                .plans
+                .get("ship")
+                .unwrap()
+                .completion
+                .as_ref()
+                .unwrap()
+                .dispute_reason
+                .as_deref()
+                .unwrap()
+                .contains("tests")
+        );
+    }
+
+    #[test]
+    fn unrelated_observation_does_not_reevaluate_plan() {
+        let mut graph = IntentionGraph::default();
+        graph
+            .apply(
+                plan_command("ship", vec![evidence_requirement("tests", "ci", true)]),
+                t(0),
+            )
+            .unwrap();
+        let before = graph.evaluations.len();
+        let response = graph
+            .apply(observe_bool("weather-1", "weather", 1, true), t(1))
+            .unwrap();
+        assert_eq!(response["affected_plan_ids"], json!([]));
+        assert_eq!(graph.evaluations.len(), before);
+    }
+
+    #[test]
+    fn stale_revision_and_conflicting_event_reuse_are_rejected_atomically() {
+        let mut graph = IntentionGraph::default();
+        graph
+            .apply(observe_bool("ci-1", "ci", 2, true), t(0))
+            .unwrap();
+        let snapshot = serde_json::to_value(&graph).unwrap();
+
+        let stale = graph.apply(observe_bool("ci-stale", "ci", 1, false), t(1));
+        assert!(stale.unwrap_err().contains("stale source revision"));
+        assert_eq!(serde_json::to_value(&graph).unwrap(), snapshot);
+
+        let conflicting = graph.apply(observe_bool("ci-1", "ci", 3, false), t(2));
+        assert!(conflicting.unwrap_err().contains("different observation"));
+        assert_eq!(serde_json::to_value(&graph).unwrap(), snapshot);
+    }
+
+    #[test]
+    fn exact_observation_replay_is_idempotent_and_attention_is_deduplicated() {
+        let mut graph = IntentionGraph::default();
+        graph
+            .apply(
+                plan_command("ship", vec![evidence_requirement("tests", "ci", true)]),
+                t(0),
+            )
+            .unwrap();
+        let command = observe_bool("ci-1", "ci", 1, false);
+        graph.apply(command.clone(), t(1)).unwrap();
+        let receipts = graph.observation_receipts.len();
+        let queue = graph.attention_queue.len();
+        let response = graph.apply(command, t(4)).unwrap();
+        assert_eq!(response["idempotent"], true);
+        assert_eq!(graph.observation_receipts.len(), receipts);
+        assert_eq!(graph.attention_queue.len(), queue);
+
+        graph
+            .apply(observe_bool("ci-2", "ci", 2, false), t(5))
+            .unwrap();
+        assert_eq!(
+            graph.attention_queue.len(),
+            queue,
+            "a newer source revision with the same logical result must not flood attention"
+        );
+    }
+
+    #[test]
+    fn offline_event_is_unknown_and_covered_absence_is_missing() {
+        let start = t(0);
+        let end = t(1);
+        let requirement = Requirement::Event {
+            id: "deploy_seen".to_owned(),
+            source_key: "audit".to_owned(),
+            memory_id: None,
+            event: "deployed".to_owned(),
+            expectation: EventExpectation::Occurred,
+            window_start: Some(start),
+            window_end: Some(end),
+            grace_seconds: 60,
+        };
+        let mut graph = IntentionGraph::default();
+        graph
+            .apply(plan_command("release", vec![requirement]), t(0))
+            .unwrap();
+        let offline = graph
+            .apply(
+                Command::Explain {
+                    id: "release".to_owned(),
+                },
+                t(2),
+            )
+            .unwrap();
+        assert_eq!(offline["evaluation"]["requirements"][0]["state"], "unknown");
+
+        graph
+            .apply(
+                Command::Observe {
+                    event_id: "audit-1".to_owned(),
+                    source_key: "audit".to_owned(),
+                    source_revision: 1,
+                    value: None,
+                    observed_events: vec![],
+                    covered_events: vec!["deployed".to_owned()],
+                    coverage_start: Some(start),
+                    coverage_end: Some(end),
+                },
+                t(2),
+            )
+            .unwrap();
+        let covered = graph
+            .apply(
+                Command::Explain {
+                    id: "release".to_owned(),
+                },
+                t(2),
+            )
+            .unwrap();
+        assert_eq!(covered["evaluation"]["requirements"][0]["state"], "missing");
+    }
+
+    #[test]
+    fn absence_requires_elapsed_explicit_window_and_complete_coverage() {
+        let requirement = Requirement::Event {
+            id: "no_failure".to_owned(),
+            source_key: "audit".to_owned(),
+            memory_id: None,
+            event: "failed".to_owned(),
+            expectation: EventExpectation::Absent,
+            window_start: Some(t(0)),
+            window_end: Some(t(2)),
+            grace_seconds: 3_600,
+        };
+        let mut graph = IntentionGraph::default();
+        graph
+            .apply(plan_command("stable", vec![requirement]), t(0))
+            .unwrap();
+        graph
+            .apply(
+                Command::Observe {
+                    event_id: "audit-1".to_owned(),
+                    source_key: "audit".to_owned(),
+                    source_revision: 1,
+                    value: None,
+                    observed_events: vec![],
+                    covered_events: vec!["failed".to_owned()],
+                    coverage_start: Some(t(0)),
+                    coverage_end: Some(t(2)),
+                },
+                t(2),
+            )
+            .unwrap();
+        let before_grace = graph
+            .apply(
+                Command::Explain {
+                    id: "stable".to_owned(),
+                },
+                t(2),
+            )
+            .unwrap();
+        assert_eq!(
+            before_grace["evaluation"]["requirements"][0]["state"],
+            "unknown"
+        );
+        let after_grace = graph
+            .apply(
+                Command::Explain {
+                    id: "stable".to_owned(),
+                },
+                t(3),
+            )
+            .unwrap();
+        assert_eq!(
+            after_grace["evaluation"]["requirements"][0]["state"],
+            "satisfied"
+        );
+    }
+
+    #[test]
+    fn user_completion_and_cancellation_are_explicit_lifecycle_states() {
+        let mut graph = IntentionGraph::default();
+        graph.apply(plan_command("a", vec![]), t(0)).unwrap();
+        graph
+            .apply(
+                Command::Complete {
+                    id: "a".to_owned(),
+                    expected_version: 1,
+                    basis: CompletionBasis::UserReport {
+                        report: "User confirmed the work is complete".to_owned(),
+                    },
+                },
+                t(1),
+            )
+            .unwrap();
+        assert_eq!(lifecycle(&graph, "a"), PlanLifecycle::Fulfilled);
+
+        graph.apply(plan_command("b", vec![]), t(1)).unwrap();
+        graph
+            .apply(
+                Command::Cancel {
+                    id: "b".to_owned(),
+                    expected_version: 1,
+                    reason: "No longer wanted".to_owned(),
+                },
+                t(2),
+            )
+            .unwrap();
+        assert_eq!(lifecycle(&graph, "b"), PlanLifecycle::Cancelled);
+    }
+
+    #[test]
+    fn evidence_completion_requires_every_requirement_and_exact_retry_is_noop() {
+        let mut graph = IntentionGraph::default();
+        graph
+            .apply(
+                plan_command(
+                    "ship",
+                    vec![
+                        evidence_requirement("tests", "ci", true),
+                        evidence_requirement("approval", "review", true),
+                    ],
+                ),
+                t(0),
+            )
+            .unwrap();
+        graph
+            .apply(observe_bool("ci-1", "ci", 1, true), t(1))
+            .unwrap();
+        graph
+            .apply(observe_bool("review-1", "review", 1, false), t(2))
+            .unwrap();
+        let rejected = graph.apply(
+            Command::Complete {
+                id: "ship".to_owned(),
+                expected_version: 1,
+                basis: CompletionBasis::Evidence {
+                    requirement_ids: vec!["tests".to_owned()],
+                },
+            },
+            t(3),
+        );
+        assert!(rejected.unwrap_err().contains("all current requirements"));
+
+        graph
+            .apply(observe_bool("review-2", "review", 2, true), t(3))
+            .unwrap();
+        let complete = Command::Complete {
+            id: "ship".to_owned(),
+            expected_version: 1,
+            basis: CompletionBasis::Evidence {
+                requirement_ids: vec!["tests".to_owned()],
+            },
+        };
+        graph.apply(complete.clone(), t(4)).unwrap();
+        let frozen = serde_json::to_value(&graph).unwrap();
+        let retry = graph.apply(complete, t(5)).unwrap();
+        assert_eq!(retry["idempotent"], true);
+        assert_eq!(serde_json::to_value(&graph).unwrap(), frozen);
+
+        graph
+            .apply(observe_bool("review-3", "review", 3, false), t(6))
+            .unwrap();
+        assert_eq!(lifecycle(&graph, "ship"), PlanLifecycle::Disputed);
+    }
+
+    #[test]
+    fn identical_cancel_retry_preserves_original_cancellation() {
+        let mut graph = IntentionGraph::default();
+        graph.apply(plan_command("stop", vec![]), t(0)).unwrap();
+        let cancel = Command::Cancel {
+            id: "stop".to_owned(),
+            expected_version: 1,
+            reason: "User cancelled".to_owned(),
+        };
+        graph.apply(cancel.clone(), t(1)).unwrap();
+        let frozen = serde_json::to_value(&graph).unwrap();
+        let retry = graph.apply(cancel, t(2)).unwrap();
+        assert_eq!(retry["idempotent"], true);
+        assert_eq!(serde_json::to_value(&graph).unwrap(), frozen);
+
+        let conflicting = graph.apply(
+            Command::Cancel {
+                id: "stop".to_owned(),
+                expected_version: 1,
+                reason: "Different reason".to_owned(),
+            },
+            t(3),
+        );
+        assert!(conflicting.unwrap_err().contains("different reason"));
+        assert_eq!(serde_json::to_value(&graph).unwrap(), frozen);
+    }
+
+    #[test]
+    fn attention_withholding_retains_pending_event() {
+        let mut graph = IntentionGraph::default();
+        graph
+            .apply(
+                plan_command("ship", vec![evidence_requirement("tests", "ci", true)]),
+                t(0),
+            )
+            .unwrap();
+        let first_id = graph.attention_queue.keys().next().cloned().unwrap();
+        graph
+            .apply(Command::Acknowledge { queue_id: first_id }, t(1))
+            .unwrap();
+        let response = graph
+            .apply(observe_bool("ci-1", "ci", 1, false), t(1))
+            .unwrap();
+        let withheld = response["attention"]["withheld_queue_ids"]
+            .as_array()
+            .unwrap();
+        assert_eq!(withheld.len(), 1);
+        let withheld_id = withheld[0].as_str().unwrap();
+        assert!(graph.attention_queue.contains_key(withheld_id));
+
+        graph
+            .apply(
+                Command::Evaluate {
+                    id: Some("ship".to_owned()),
+                },
+                t(1),
+            )
+            .unwrap();
+        assert_eq!(
+            graph
+                .attention_queue
+                .values()
+                .filter(|event| event.acknowledged_at.is_none())
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn attention_requeues_a_returned_state_but_dedupes_unchanged_revisions() {
+        let mut graph = IntentionGraph::default();
+        graph
+            .apply(
+                plan_command("ship", vec![evidence_requirement("tests", "ci", true)]),
+                t(0),
+            )
+            .unwrap();
+        graph
+            .apply(observe_bool("ci-1", "ci", 1, false), t(1))
+            .unwrap();
+        let first_unmet = graph
+            .attention_queue
+            .values()
+            .find(|event| event.superseded_at.is_none())
+            .unwrap()
+            .clone();
+        graph
+            .apply(observe_bool("ci-2", "ci", 2, true), t(2))
+            .unwrap();
+        graph
+            .apply(observe_bool("ci-3", "ci", 3, false), t(3))
+            .unwrap();
+        let returned_unmet = graph
+            .attention_queue
+            .values()
+            .find(|event| event.superseded_at.is_none())
+            .unwrap()
+            .clone();
+        assert_eq!(returned_unmet.fingerprint, first_unmet.fingerprint);
+        assert_ne!(returned_unmet.queue_id, first_unmet.queue_id);
+
+        let count = graph.attention_queue.len();
+        graph
+            .apply(observe_bool("ci-4", "ci", 4, false), t(4))
+            .unwrap();
+        assert_eq!(graph.attention_queue.len(), count);
+    }
+
+    #[test]
+    fn portfolio_reports_shared_requirements_prerequisites_and_conflicts() {
+        let shared_a = evidence_requirement("shared-a", "budget", true);
+        let shared_b = evidence_requirement("shared-b", "budget", true);
+        let mut graph = IntentionGraph::default();
+        graph
+            .apply(
+                Command::Plan {
+                    id: "foundation".to_owned(),
+                    description: "Foundation".to_owned(),
+                    priority: Priority::Critical,
+                    requirements: vec![shared_a],
+                    min_attention_interval_seconds: 0,
+                    conflict_keys: vec!["exclusive:gpu".to_owned()],
+                },
+                t(0),
+            )
+            .unwrap();
+        graph
+            .apply(
+                Command::Plan {
+                    id: "dependent".to_owned(),
+                    description: "Dependent".to_owned(),
+                    priority: Priority::Normal,
+                    requirements: vec![
+                        shared_b,
+                        Requirement::PlanFulfilled {
+                            id: "foundation_done".to_owned(),
+                            plan_id: "foundation".to_owned(),
+                        },
+                    ],
+                    min_attention_interval_seconds: 0,
+                    conflict_keys: vec!["exclusive:gpu".to_owned()],
+                },
+                t(0),
+            )
+            .unwrap();
+        let portfolio = graph.apply(Command::Portfolio, t(1)).unwrap();
+        assert_eq!(
+            portfolio["shared_requirements"].as_array().unwrap().len(),
+            1
+        );
+        assert_eq!(portfolio["conflicts"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            portfolio["unmet_prerequisites"].as_array().unwrap().len(),
+            1
+        );
+        assert_eq!(portfolio["plans"][0]["id"], "foundation");
+    }
+
+    #[test]
+    fn replay_is_deterministic_and_preserves_original_description() {
+        let entries = vec![
+            TimedCommand {
+                command: plan_command("ship", vec![]),
+                now: t(0),
+            },
+            TimedCommand {
+                command: Command::Revise {
+                    id: "ship".to_owned(),
+                    expected_version: 1,
+                    description: Some("Revised ship plan".to_owned()),
+                    priority: None,
+                    requirements: None,
+                    min_attention_interval_seconds: None,
+                    conflict_keys: None,
+                },
+                now: t(1),
+            },
+        ];
+        let first = replay(&entries).unwrap();
+        let second = replay(&entries).unwrap();
+        assert_eq!(
+            serde_json::to_value(&first).unwrap(),
+            serde_json::to_value(&second).unwrap()
+        );
+        let plan = first.plans.get("ship").unwrap();
+        assert_eq!(plan.original_description, "Plan ship");
+        assert_eq!(plan.current().description, "Revised ship plan");
+        assert_eq!(plan.versions.len(), 2);
+    }
+
+    #[test]
+    fn reverse_lexical_dependency_chain_is_disputed_prerequisite_first() {
+        let mut graph = IntentionGraph::default();
+        graph
+            .apply(
+                plan_command(
+                    "z-source",
+                    vec![evidence_requirement("source_ok", "source", true)],
+                ),
+                t(0),
+            )
+            .unwrap();
+        graph
+            .apply(observe_bool("source-1", "source", 1, true), t(1))
+            .unwrap();
+        graph
+            .apply(
+                Command::Complete {
+                    id: "z-source".to_owned(),
+                    expected_version: 1,
+                    basis: CompletionBasis::Evidence {
+                        requirement_ids: vec!["source_ok".to_owned()],
+                    },
+                },
+                t(2),
+            )
+            .unwrap();
+        graph
+            .apply(
+                plan_command(
+                    "a-dependent",
+                    vec![Requirement::PlanFulfilled {
+                        id: "source_done".to_owned(),
+                        plan_id: "z-source".to_owned(),
+                    }],
+                ),
+                t(3),
+            )
+            .unwrap();
+        graph
+            .apply(
+                Command::Complete {
+                    id: "a-dependent".to_owned(),
+                    expected_version: 1,
+                    basis: CompletionBasis::Evidence {
+                        requirement_ids: vec!["source_done".to_owned()],
+                    },
+                },
+                t(4),
+            )
+            .unwrap();
+
+        let response = graph
+            .apply(observe_bool("source-2", "source", 2, false), t(5))
+            .unwrap();
+        assert_eq!(
+            response["affected_plan_ids"],
+            json!(["a-dependent", "z-source"])
+        );
+        assert_eq!(lifecycle(&graph, "z-source"), PlanLifecycle::Disputed);
+        assert_eq!(lifecycle(&graph, "a-dependent"), PlanLifecycle::Disputed);
+        let labels: Vec<&str> = response["evaluations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|record| record["snapshot"]["plan_id"].as_str().unwrap())
+            .collect();
+        assert_eq!(labels, vec!["z-source", "a-dependent"]);
+    }
+
+    #[test]
+    fn prerequisite_references_and_cycles_are_rejected_atomically() {
+        let mut graph = IntentionGraph::default();
+        let unknown = graph.apply(
+            plan_command(
+                "a",
+                vec![Requirement::PlanFulfilled {
+                    id: "b_done".to_owned(),
+                    plan_id: "b".to_owned(),
+                }],
+            ),
+            t(0),
+        );
+        assert!(unknown.unwrap_err().contains("unknown prerequisite"));
+        assert!(graph.plans.is_empty());
+
+        graph.apply(plan_command("a", vec![]), t(0)).unwrap();
+        graph
+            .apply(
+                plan_command(
+                    "b",
+                    vec![Requirement::PlanFulfilled {
+                        id: "a_done".to_owned(),
+                        plan_id: "a".to_owned(),
+                    }],
+                ),
+                t(1),
+            )
+            .unwrap();
+        let before = serde_json::to_value(&graph).unwrap();
+        let cycle = graph.apply(
+            Command::Revise {
+                id: "a".to_owned(),
+                expected_version: 1,
+                description: None,
+                priority: None,
+                requirements: Some(vec![Requirement::PlanFulfilled {
+                    id: "b_done".to_owned(),
+                    plan_id: "b".to_owned(),
+                }]),
+                min_attention_interval_seconds: None,
+                conflict_keys: None,
+            },
+            t(2),
+        );
+        assert!(cycle.unwrap_err().contains("prerequisite cycle"));
+        assert_eq!(serde_json::to_value(&graph).unwrap(), before);
+    }
+
+    #[test]
+    fn memory_id_requires_exact_memory_source_key() {
+        let mut graph = IntentionGraph::default();
+        let bad = graph.apply(
+            plan_command(
+                "remember",
+                vec![Requirement::Evidence {
+                    id: "memory_current".to_owned(),
+                    source_key: "memory:other".to_owned(),
+                    memory_id: Some("abc".to_owned()),
+                    condition: EvidenceCondition::Exists,
+                }],
+            ),
+            t(0),
+        );
+        assert!(
+            bad.unwrap_err()
+                .contains("must use source_key 'memory:abc'")
+        );
+        assert!(graph.plans.is_empty());
+    }
+
+    #[test]
+    fn unsupported_versions_and_out_of_order_mutations_are_rejected() {
+        let mut incompatible = IntentionGraph {
+            algorithm_version: "future-algorithm".to_owned(),
+            ..IntentionGraph::default()
+        };
+        let error = incompatible.apply(Command::Portfolio, t(0)).unwrap_err();
+        assert!(error.contains("unsupported intention graph algorithm version"));
+
+        let mut graph = IntentionGraph::default();
+        graph.apply(plan_command("a", vec![]), t(2)).unwrap();
+        let before = serde_json::to_value(&graph).unwrap();
+        let error = graph
+            .apply(
+                Command::Evaluate {
+                    id: Some("a".to_owned()),
+                },
+                t(1),
+            )
+            .unwrap_err();
+        assert!(error.contains("out-of-order mutation timestamp"));
+        assert_eq!(serde_json::to_value(&graph).unwrap(), before);
+    }
+
+    #[test]
+    fn plan_priority_defaults_to_normal_during_deserialization() {
+        let command: Command = serde_json::from_value(json!({
+            "action": "plan",
+            "id": "p",
+            "description": "Default priority"
+        }))
+        .unwrap();
+        let Command::Plan { priority, .. } = command else {
+            panic!("expected plan command")
+        };
+        assert_eq!(priority, Priority::Normal);
+    }
+
+    #[test]
+    fn corrupted_empty_version_state_returns_error_instead_of_panicking() {
+        let mut graph = IntentionGraph::default();
+        graph.apply(plan_command("p", vec![]), t(0)).unwrap();
+        graph.plans.get_mut("p").unwrap().versions.clear();
+        let error = graph.apply(Command::Portfolio, t(1)).unwrap_err();
+        assert!(error.contains("has no versions"));
+    }
+
+    #[test]
+    fn future_coverage_is_rejected_and_windowed_occurrence_must_be_inside_window() {
+        let mut graph = IntentionGraph::default();
+        graph
+            .apply(
+                plan_command(
+                    "watch",
+                    vec![Requirement::Event {
+                        id: "event_seen".to_owned(),
+                        source_key: "audit".to_owned(),
+                        memory_id: None,
+                        event: "done".to_owned(),
+                        expectation: EventExpectation::Occurred,
+                        window_start: Some(t(0)),
+                        window_end: Some(t(3)),
+                        grace_seconds: 0,
+                    }],
+                ),
+                t(0),
+            )
+            .unwrap();
+        let frozen = serde_json::to_value(&graph).unwrap();
+        let future = graph.apply(
+            Command::Observe {
+                event_id: "future".to_owned(),
+                source_key: "audit".to_owned(),
+                source_revision: 1,
+                value: None,
+                observed_events: vec!["done".to_owned()],
+                covered_events: vec!["done".to_owned()],
+                coverage_start: Some(t(0)),
+                coverage_end: Some(t(2)),
+            },
+            t(1),
+        );
+        assert!(future.unwrap_err().contains("coverage_end"));
+        assert_eq!(serde_json::to_value(&graph).unwrap(), frozen);
+
+        graph
+            .apply(
+                Command::Observe {
+                    event_id: "outside".to_owned(),
+                    source_key: "audit".to_owned(),
+                    source_revision: 1,
+                    value: None,
+                    observed_events: vec!["done".to_owned()],
+                    covered_events: vec!["done".to_owned()],
+                    coverage_start: Some(t(3)),
+                    coverage_end: Some(t(4)),
+                },
+                t(4),
+            )
+            .unwrap();
+        let outside = graph
+            .apply(
+                Command::Explain {
+                    id: "watch".to_owned(),
+                },
+                t(4),
+            )
+            .unwrap();
+        assert_eq!(outside["evaluation"]["requirements"][0]["state"], "unknown");
+
+        graph
+            .apply(
+                Command::Observe {
+                    event_id: "inside".to_owned(),
+                    source_key: "audit".to_owned(),
+                    source_revision: 2,
+                    value: None,
+                    observed_events: vec!["done".to_owned()],
+                    covered_events: vec!["done".to_owned()],
+                    coverage_start: Some(t(1)),
+                    coverage_end: Some(t(2)),
+                },
+                t(5),
+            )
+            .unwrap();
+        let inside = graph
+            .apply(
+                Command::Explain {
+                    id: "watch".to_owned(),
+                },
+                t(5),
+            )
+            .unwrap();
+        assert_eq!(
+            inside["evaluation"]["requirements"][0]["state"],
+            "satisfied"
+        );
+    }
+
+    #[test]
+    fn revising_a_fulfilled_plan_reopens_it_and_invalidates_prior_completion() {
+        let mut graph = IntentionGraph::default();
+        graph.apply(plan_command("p", vec![]), t(0)).unwrap();
+        graph
+            .apply(
+                Command::Complete {
+                    id: "p".to_owned(),
+                    expected_version: 1,
+                    basis: CompletionBasis::UserReport {
+                        report: "Done".to_owned(),
+                    },
+                },
+                t(1),
+            )
+            .unwrap();
+        graph
+            .apply(
+                Command::Revise {
+                    id: "p".to_owned(),
+                    expected_version: 1,
+                    description: Some("Reopened plan".to_owned()),
+                    priority: None,
+                    requirements: None,
+                    min_attention_interval_seconds: None,
+                    conflict_keys: None,
+                },
+                t(2),
+            )
+            .unwrap();
+        let plan = graph.plans.get("p").unwrap();
+        assert_eq!(plan.lifecycle, PlanLifecycle::Active);
+        assert_eq!(plan.current().version, 2);
+        assert!(plan.completion.as_ref().unwrap().disputed_at.is_some());
+    }
+
+    #[test]
+    fn schema_exposes_all_commands_and_evidence_boundary() {
+        let schema = schema();
+        let serialized = serde_json::to_string(&schema).unwrap();
+        for action in [
+            "plan",
+            "revise",
+            "observe",
+            "evaluate",
+            "explain",
+            "portfolio",
+            "complete",
+            "cancel",
+            "acknowledge",
+        ] {
+            assert!(serialized.contains(&format!("\"{action}\"")));
+        }
+        assert!(serialized.contains("not cryptographic proof or authorization"));
+    }
+}

--- a/crates/vestige-core/src/lib.rs
+++ b/crates/vestige-core/src/lib.rs
@@ -90,6 +90,8 @@ pub mod embedding;
 pub mod fsrs;
 pub mod fts;
 pub mod memory;
+/// Evidence-aware future intentions with deterministic local evaluation.
+pub mod intention_graph;
 pub mod security;
 pub mod storage;
 

--- a/crates/vestige-core/src/neuroscience/prospective_memory.rs
+++ b/crates/vestige-core/src/neuroscience/prospective_memory.rs
@@ -389,8 +389,20 @@ impl IntentionTrigger {
 
     /// Check if this trigger matches the current state
     pub fn is_triggered(&self, context: &Context, events: &[String]) -> bool {
-        let now = Utc::now();
+        self.is_triggered_at(context, events, context.timestamp)
+    }
 
+    /// Check if this trigger matches at an explicitly supplied time.
+    ///
+    /// Keeping time injectable makes trigger checks deterministic and lets the
+    /// MCP layer evaluate stored intentions against its public `current_time`
+    /// check context without consulting the wall clock again.
+    pub fn is_triggered_at(
+        &self,
+        context: &Context,
+        events: &[String],
+        now: DateTime<Utc>,
+    ) -> bool {
         match self {
             Self::TimeBased { at } => now >= *at,
             Self::DurationBased { trigger_at, .. } => trigger_at.map(|t| now >= t).unwrap_or(false),
@@ -400,15 +412,39 @@ impl IntentionTrigger {
                 completion_pattern, ..
             } => events.iter().any(|e| completion_pattern.matches(e)),
             Self::Recurring {
-                next_occurrence, ..
-            } => next_occurrence.map(|t| now >= t).unwrap_or(false),
+                base,
+                next_occurrence,
+                ..
+            } => {
+                next_occurrence.map(|t| now >= t).unwrap_or(false)
+                    && base.is_triggered_at(context, events, now)
+            }
             Self::Compound { all_of, any_of } => {
-                let all_match =
-                    all_of.is_empty() || all_of.iter().all(|t| t.is_triggered(context, events));
-                let any_match =
-                    any_of.is_empty() || any_of.iter().any(|t| t.is_triggered(context, events));
+                if all_of.is_empty() && any_of.is_empty() {
+                    return false;
+                }
+                let all_match = all_of.is_empty()
+                    || all_of
+                        .iter()
+                        .all(|t| t.is_triggered_at(context, events, now));
+                let any_match = any_of.is_empty()
+                    || any_of
+                        .iter()
+                        .any(|t| t.is_triggered_at(context, events, now));
                 all_match && any_match
             }
+        }
+    }
+
+    /// Whether this trigger contains a recurring schedule at any depth.
+    pub fn contains_recurrence(&self) -> bool {
+        match self {
+            Self::Recurring { .. } => true,
+            Self::Compound { all_of, any_of } => all_of
+                .iter()
+                .chain(any_of.iter())
+                .any(Self::contains_recurrence),
+            _ => false,
         }
     }
 
@@ -424,10 +460,72 @@ impl IntentionTrigger {
                 next_occurrence,
                 ..
             } => {
-                // Advance from the later of "now" and the slot that just fired,
-                // so we never re-arm into an already-past occurrence.
-                let from = next_occurrence.map(|t| t.max(now)).unwrap_or(now);
-                *next_occurrence = Some(recurrence.next_occurrence(from));
+                let Some(mut next) = *next_occurrence else {
+                    let candidate = recurrence.next_occurrence(now);
+                    if candidate <= now {
+                        return false;
+                    }
+                    *next_occurrence = Some(candidate);
+                    return true;
+                };
+
+                if next > now {
+                    return false;
+                }
+
+                // Fixed absolute intervals can catch up in constant time. A
+                // user may supply an old RFC3339 anchor with a one-minute
+                // cadence; iterating once per missed slot would make `check`
+                // unbounded even though trigger depth and count are bounded.
+                let fixed_seconds = match recurrence {
+                    RecurrencePattern::EveryMinutes(minutes) => {
+                        minutes.checked_mul(60).filter(|value| *value > 0)
+                    }
+                    RecurrencePattern::EveryHours(hours) => {
+                        hours.checked_mul(3_600).filter(|value| *value > 0)
+                    }
+                    RecurrencePattern::Custom { interval } => {
+                        let seconds = interval.num_seconds();
+                        (seconds > 0).then_some(seconds)
+                    }
+                    _ => None,
+                };
+                if let Some(interval_seconds) = fixed_seconds {
+                    let elapsed_seconds = (now - next).num_seconds();
+                    let steps = elapsed_seconds / interval_seconds + 1;
+                    let advance_seconds = interval_seconds.checked_mul(steps);
+                    let candidate = advance_seconds
+                        .and_then(Duration::try_seconds)
+                        .and_then(|advance| next.checked_add_signed(advance));
+                    let Some(candidate) = candidate else {
+                        return false;
+                    };
+                    *next_occurrence = Some(candidate);
+                    return true;
+                }
+
+                // Preserve the cadence anchored by the previous occurrence,
+                // while skipping missed slots. The strict progress check keeps
+                // invalid zero/negative custom intervals from looping forever.
+                for _ in 0..4_096 {
+                    if next > now {
+                        *next_occurrence = Some(next);
+                        return true;
+                    }
+                    let candidate = recurrence.next_occurrence(next);
+                    if candidate <= next {
+                        return false;
+                    }
+                    next = candidate;
+                }
+                // Calendar schedules older than the bounded catch-up horizon
+                // resume after `now`; this preserves safety without inventing
+                // a local timezone (all core timestamps are UTC).
+                let candidate = recurrence.next_occurrence(now);
+                if candidate <= now {
+                    return false;
+                }
+                *next_occurrence = Some(candidate);
                 true
             }
             Self::Compound { all_of, any_of } => {
@@ -436,6 +534,36 @@ impl IntentionTrigger {
                     any |= t.re_arm(now);
                 }
                 any
+            }
+            _ => false,
+        }
+    }
+
+    /// Re-arm only recurring branches that actually matched this check.
+    /// This matters for `any_of`: a due but context-mismatched sibling must keep
+    /// its occurrence instead of being consumed when another branch fires.
+    pub fn re_arm_triggered(
+        &mut self,
+        context: &Context,
+        events: &[String],
+        now: DateTime<Utc>,
+    ) -> bool {
+        // A matching descendant of a false compound did not contribute to
+        // this occurrence and must not be consumed by a matching sibling.
+        if !self.is_triggered_at(context, events, now) {
+            return false;
+        }
+        match self {
+            Self::Recurring { base, .. } => {
+                let base_rearmed = base.re_arm_triggered(context, events, now);
+                self.re_arm(now) || base_rearmed
+            }
+            Self::Compound { all_of, any_of } => {
+                let mut rearmed = false;
+                for trigger in all_of.iter_mut().chain(any_of.iter_mut()) {
+                    rearmed |= trigger.re_arm_triggered(context, events, now);
+                }
+                rearmed
             }
             _ => false,
         }
@@ -695,7 +823,12 @@ impl Intention {
 
     /// Check if the intention is overdue
     pub fn is_overdue(&self) -> bool {
-        self.deadline.map(|d| Utc::now() > d).unwrap_or(false)
+        self.is_overdue_at(Utc::now())
+    }
+
+    /// Check if the intention is overdue at an explicitly supplied time.
+    pub fn is_overdue_at(&self, now: DateTime<Utc>) -> bool {
+        self.deadline.map(|d| now > d).unwrap_or(false)
     }
 
     /// Check if deadline is approaching
@@ -710,24 +843,36 @@ impl Intention {
 
     /// Check if should remind again
     pub fn should_remind(&self) -> bool {
+        self.should_remind_at(Utc::now())
+    }
+
+    /// Check reminder limits at an explicitly supplied time.
+    ///
+    /// Recurring intentions use their schedule as the rate limiter. Applying
+    /// the one-shot five-reminder cap or 30-minute retry delay to them would
+    /// silently disable a perpetual schedule (and make sub-30-minute public
+    /// recurrence intervals impossible).
+    pub fn should_remind_at(&self, now: DateTime<Utc>) -> bool {
         if self.status != IntentionStatus::Active && self.status != IntentionStatus::Triggered {
             return false;
         }
 
-        if self.reminder_count >= MAX_REMINDERS_PER_INTENTION {
+        let recurring = self.trigger.contains_recurrence();
+        if !recurring && self.reminder_count >= MAX_REMINDERS_PER_INTENTION {
             return false;
         }
 
         // Check snoozed
         if let Some(snoozed_until) = self.snoozed_until
-            && Utc::now() < snoozed_until
+            && now < snoozed_until
         {
             return false;
         }
 
         // Check minimum interval
         if let Some(last) = self.last_reminded_at
-            && (Utc::now() - last) < Duration::minutes(MIN_REMINDER_INTERVAL_MINUTES)
+            && !recurring
+            && (now - last) < Duration::minutes(MIN_REMINDER_INTERVAL_MINUTES)
         {
             return false;
         }
@@ -737,7 +882,11 @@ impl Intention {
 
     /// Mark as triggered
     pub fn mark_triggered(&mut self) {
-        let now = Utc::now();
+        self.mark_triggered_at(Utc::now());
+    }
+
+    /// Mark as triggered at an explicitly supplied time.
+    pub fn mark_triggered_at(&mut self, now: DateTime<Utc>) {
         self.reminder_count += 1;
         self.last_reminded_at = Some(now);
         // A recurring intention re-arms to its next occurrence and returns to
@@ -745,6 +894,23 @@ impl Intention {
         // Previously recurring intentions never advanced next_occurrence, so they
         // fired once and never again (or stayed perpetually triggered).
         if self.trigger.re_arm(now) {
+            self.status = IntentionStatus::Active;
+        } else {
+            self.status = IntentionStatus::Triggered;
+        }
+    }
+
+    /// Mark as triggered while retaining the context needed to advance only
+    /// the recurring compound branches that matched.
+    pub fn mark_triggered_with_context(
+        &mut self,
+        now: DateTime<Utc>,
+        context: &Context,
+        events: &[String],
+    ) {
+        self.reminder_count += 1;
+        self.last_reminded_at = Some(now);
+        if self.trigger.re_arm_triggered(context, events, now) {
             self.status = IntentionStatus::Active;
         } else {
             self.status = IntentionStatus::Triggered;
@@ -823,7 +989,7 @@ pub enum IntentionSource {
 // ============================================================================
 
 /// Current context for trigger matching
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Context {
     /// Current time
     pub timestamp: DateTime<Utc>,
@@ -845,13 +1011,26 @@ pub struct Context {
     pub conversation_context: Option<String>,
 }
 
+impl Default for Context {
+    fn default() -> Self {
+        Self {
+            timestamp: Utc::now(),
+            project_name: None,
+            project_path: None,
+            active_files: Vec::new(),
+            active_topics: Vec::new(),
+            user_mode: None,
+            recent_events: Vec::new(),
+            mentioned_entities: Vec::new(),
+            conversation_context: None,
+        }
+    }
+}
+
 impl Context {
     /// Create a new context
     pub fn new() -> Self {
-        Self {
-            timestamp: Utc::now(),
-            ..Default::default()
-        }
+        Self::default()
     }
 
     /// Set project
@@ -960,7 +1139,7 @@ impl IntentionParser {
         let text_lower = text.to_lowercase();
 
         // Detect trigger type and extract content
-        let (trigger, content) = self.extract_trigger_and_content(&text_lower, text)?;
+        let (trigger, content) = self.extract_trigger_and_content(&text_lower, text, 0)?;
 
         let mut intention = Intention::new(content, trigger);
         intention.source = IntentionSource::NaturalLanguage {
@@ -985,7 +1164,48 @@ impl IntentionParser {
         &self,
         text_lower: &str,
         original: &str,
+        depth: usize,
     ) -> Result<(IntentionTrigger, String)> {
+        if depth >= 5 {
+            return Err(ProspectiveMemoryError::ParseError(
+                "Recurrence nesting exceeds five levels".into(),
+            ));
+        }
+        // Recurrence must be recognized before generic time/event phrases so
+        // the parser does not reduce "every 15 minutes" or "every fortnight"
+        // to a one-shot duration. If the remaining text contains an event
+        // clause, preserve it as the recurring base condition.
+        if let Some((recurrence, interval, start, end)) = Self::parse_recurrence(original) {
+            let without_recurrence = format!("{}{}", &original[..start], &original[end..]);
+            let cleaned = Self::clean_intention_content(&without_recurrence);
+            let next = Utc::now().checked_add_signed(interval).ok_or_else(|| {
+                ProspectiveMemoryError::ParseError("Recurrence exceeds timestamp range".into())
+            })?;
+            let base = self
+                .extract_trigger_and_content(
+                    &without_recurrence.to_lowercase(),
+                    &without_recurrence,
+                    depth + 1,
+                )
+                .map(|(trigger, _)| trigger)
+                .or_else(|error| {
+                    if Self::parse_recurrence(&without_recurrence).is_some() {
+                        Err(error)
+                    } else {
+                        Ok(IntentionTrigger::TimeBased { at: next })
+                    }
+                })?;
+
+            return Ok((
+                IntentionTrigger::Recurring {
+                    base: Box::new(base),
+                    recurrence,
+                    next_occurrence: Some(next),
+                },
+                cleaned,
+            ));
+        }
+
         // Check for "remind me to X when Y" pattern
         if let Some(when_byte_idx) = text_lower.find(" when ") {
             // Convert byte index to char index for safe slicing
@@ -1099,6 +1319,108 @@ impl IntentionParser {
         Err(ProspectiveMemoryError::ParseError(
             "Could not parse intention from text".to_string(),
         ))
+    }
+
+    /// Parse bounded, calendar-independent recurrence phrases. Fortnights are
+    /// represented as the exact absolute interval 20,160 minutes; no local
+    /// timezone or daylight-saving assumption is introduced.
+    fn parse_recurrence(original: &str) -> Option<(RecurrencePattern, Duration, usize, usize)> {
+        let lower = original.to_ascii_lowercase();
+        let named = [
+            ("every fortnight", 20_160_i64),
+            ("fortnightly", 20_160_i64),
+            ("every two weeks", 20_160_i64),
+            ("every other week", 20_160_i64),
+            ("every 2 weeks", 20_160_i64),
+            ("every week", 10_080_i64),
+            ("weekly", 10_080_i64),
+            ("every day", 1_440_i64),
+            ("daily", 1_440_i64),
+            ("every hour", 60_i64),
+            ("hourly", 60_i64),
+        ];
+        for (phrase, minutes) in named {
+            if let Some(start) = lower.find(phrase) {
+                let interval = Duration::minutes(minutes);
+                return Some((
+                    RecurrencePattern::EveryMinutes(minutes),
+                    interval,
+                    start,
+                    start + phrase.len(),
+                ));
+            }
+        }
+
+        let mut search_from = 0;
+        while let Some(relative) = lower[search_from..].find("every ") {
+            let start = search_from + relative;
+            let number_start = start + "every ".len();
+            let tail = &lower[number_start..];
+            let digit_count = tail
+                .bytes()
+                .take_while(|byte| byte.is_ascii_digit())
+                .count();
+            if digit_count == 0 {
+                search_from = number_start;
+                continue;
+            }
+            let amount = tail[..digit_count].parse::<i64>().ok()?;
+            if amount <= 0 {
+                return None;
+            }
+            let unit_start = number_start + digit_count;
+            let unit_tail = lower[unit_start..].trim_start();
+            let whitespace = lower[unit_start..].len() - unit_tail.len();
+            let (unit_len, minutes) = if unit_tail.starts_with("minutes") {
+                ("minutes".len(), amount.checked_mul(1)?)
+            } else if unit_tail.starts_with("minute") {
+                ("minute".len(), amount.checked_mul(1)?)
+            } else if unit_tail.starts_with("hours") {
+                ("hours".len(), amount.checked_mul(60)?)
+            } else if unit_tail.starts_with("hour") {
+                ("hour".len(), amount.checked_mul(60)?)
+            } else if unit_tail.starts_with("days") {
+                ("days".len(), amount.checked_mul(1_440)?)
+            } else if unit_tail.starts_with("day") {
+                ("day".len(), amount.checked_mul(1_440)?)
+            } else if unit_tail.starts_with("weeks") {
+                ("weeks".len(), amount.checked_mul(10_080)?)
+            } else if unit_tail.starts_with("week") {
+                ("week".len(), amount.checked_mul(10_080)?)
+            } else if unit_tail.starts_with("fortnights") {
+                ("fortnights".len(), amount.checked_mul(20_160)?)
+            } else if unit_tail.starts_with("fortnight") {
+                ("fortnight".len(), amount.checked_mul(20_160)?)
+            } else {
+                search_from = number_start;
+                continue;
+            };
+            // Match the public adapter's ten-year bound before constructing a
+            // timestamp; TimeDelta accepts values larger than DateTime can.
+            if !(1..=5_256_000).contains(&minutes) {
+                return None;
+            }
+            let interval = Duration::try_minutes(minutes)?;
+            let end = unit_start + whitespace + unit_len;
+            return Some((
+                RecurrencePattern::EveryMinutes(minutes),
+                interval,
+                start,
+                end,
+            ));
+        }
+        None
+    }
+
+    fn clean_intention_content(text: &str) -> String {
+        let mut cleaned = text.trim().to_string();
+        for prefix in ["remind me to ", "remind me ", "remember to "] {
+            if cleaned.to_ascii_lowercase().starts_with(prefix) {
+                cleaned = cleaned[prefix.len()..].trim().to_string();
+                break;
+            }
+        }
+        cleaned.split_whitespace().collect::<Vec<_>>().join(" ")
     }
 
     /// Extract content from text, removing trigger keywords
@@ -1315,27 +1637,30 @@ impl ProspectiveMemory {
 
         let mut triggered = Vec::new();
 
+        let now = context.timestamp;
+
         for intention in intentions.values_mut() {
             // Skip non-active intentions
             if intention.status != IntentionStatus::Active {
                 // Check if snoozed intention should wake
                 if intention.status == IntentionStatus::Snoozed
                     && let Some(until) = intention.snoozed_until
-                    && Utc::now() >= until
+                    && now >= until
                 {
                     intention.wake();
+                } else {
+                    continue;
                 }
-                continue;
             }
 
             // Check if triggered
             let mut just_triggered = false;
             if intention
                 .trigger
-                .is_triggered(context, &context.recent_events)
-                && intention.should_remind()
+                .is_triggered_at(context, &context.recent_events, now)
+                && intention.should_remind_at(now)
             {
-                intention.mark_triggered();
+                intention.mark_triggered_with_context(now, context, &context.recent_events);
                 triggered.push(intention.clone());
                 just_triggered = true;
             }
@@ -1354,7 +1679,7 @@ impl ProspectiveMemory {
 
             // Auto-expire overdue intentions — but never clobber one we JUST
             // triggered this iteration (it should fire before it expires).
-            if self.config.auto_expire && intention.is_overdue() && !just_triggered {
+            if self.config.auto_expire && intention.is_overdue_at(now) && !just_triggered {
                 intention.status = IntentionStatus::Expired;
             }
         }
@@ -1620,6 +1945,22 @@ mod tests {
     }
 
     #[test]
+    fn test_context_composite_requires_every_all_condition() {
+        let context = Context::new()
+            .with_project("vestige", "/code/vestige")
+            .with_file("/code/vestige/src/lib.rs");
+        let pattern = ContextPattern::Composite {
+            all: vec![
+                ContextPattern::in_codebase("vestige"),
+                ContextPattern::topic_active("release"),
+            ],
+            any: Vec::new(),
+        };
+        assert!(!pattern.matches(&context));
+        assert!(pattern.matches(&context.with_topic("release readiness")));
+    }
+
+    #[test]
     fn test_intention_creation() {
         let intention = Intention::new(
             "Review code",
@@ -1676,6 +2017,82 @@ mod tests {
     }
 
     #[test]
+    fn intention_nlp_recurrence_rejects_out_of_range_intervals() {
+        assert_eq!(
+            IntentionParser::parse_recurrence("every other week")
+                .unwrap()
+                .1
+                .num_minutes(),
+            20_160
+        );
+        assert!(IntentionParser::parse_recurrence("every 5256001 minutes").is_none());
+        assert!(IntentionParser::parse_recurrence("every 100000000 days").is_none());
+        assert!(IntentionParser::parse_recurrence("every 5256000 minutes").is_some());
+        let parser = IntentionParser::new();
+        assert!(parser.parse("remind me every 100000000 days").is_err());
+        assert!(
+            parser
+                .parse(&format!("remind me {}", "every hour ".repeat(100)))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn intention_false_nested_compound_does_not_consume_recurrence() {
+        let now = Utc::now();
+        let mut trigger = IntentionTrigger::Compound {
+            all_of: vec![],
+            any_of: vec![
+                IntentionTrigger::on_event("ping", TriggerPattern::contains("ping")),
+                IntentionTrigger::Compound {
+                    all_of: vec![
+                        IntentionTrigger::Recurring {
+                            base: Box::new(IntentionTrigger::at_time(now)),
+                            recurrence: RecurrencePattern::EveryMinutes(60),
+                            next_occurrence: Some(now),
+                        },
+                        IntentionTrigger::ContextBased {
+                            context_match: ContextPattern::InCodebase("missing".into()),
+                        },
+                    ],
+                    any_of: vec![],
+                },
+            ],
+        };
+        let context = Context {
+            timestamp: now,
+            ..Default::default()
+        };
+        let events = vec!["ping".into()];
+        let before = serde_json::to_value(&trigger).unwrap();
+        assert!(trigger.is_triggered_at(&context, &events, now));
+        assert!(!trigger.re_arm_triggered(&context, &events, now));
+        assert_eq!(serde_json::to_value(&trigger).unwrap(), before);
+    }
+
+    #[test]
+    fn intention_nested_recurring_base_preserves_both_cadences() {
+        let now = Utc::now();
+        let inner = IntentionTrigger::Recurring {
+            base: Box::new(IntentionTrigger::at_time(now)),
+            recurrence: RecurrencePattern::EveryMinutes(1440),
+            next_occurrence: Some(now),
+        };
+        let mut outer = IntentionTrigger::Recurring {
+            base: Box::new(inner),
+            recurrence: RecurrencePattern::EveryMinutes(60),
+            next_occurrence: Some(now),
+        };
+        let context = Context {
+            timestamp: now,
+            ..Default::default()
+        };
+        assert!(outer.re_arm_triggered(&context, &[], now));
+        assert!(!outer.is_triggered_at(&context, &[], now + Duration::hours(1)));
+        assert!(outer.is_triggered_at(&context, &[], now + Duration::days(1)));
+    }
+
+    #[test]
     fn test_parse_natural_language() {
         let parser = IntentionParser::new();
 
@@ -1690,6 +2107,21 @@ mod tests {
         // Test implicit intention
         let result = parser.parse("I should tell Sarah about the bug");
         assert!(result.is_ok());
+
+        let recurring = parser
+            .parse("remind me to review the roadmap every fortnight")
+            .unwrap();
+        match recurring.trigger {
+            IntentionTrigger::Recurring {
+                recurrence: RecurrencePattern::EveryMinutes(minutes),
+                next_occurrence: Some(next),
+                ..
+            } => {
+                assert_eq!(minutes, 20_160);
+                assert!(next > recurring.created_at);
+            }
+            other => panic!("expected preserved recurring trigger, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1759,6 +2191,51 @@ mod tests {
             !intention.trigger.is_triggered(&Context::default(), &[]),
             "recurring trigger must not stay perpetually due after re-arming"
         );
+    }
+
+    #[test]
+    fn test_recurring_event_requires_schedule_and_base_event() {
+        let now = Utc::now();
+        let trigger = IntentionTrigger::Recurring {
+            base: Box::new(IntentionTrigger::on_event(
+                "deployment completed",
+                TriggerPattern::contains("deployment completed"),
+            )),
+            recurrence: RecurrencePattern::EveryMinutes(5),
+            next_occurrence: Some(now - Duration::minutes(1)),
+        };
+        let context = Context {
+            timestamp: now,
+            ..Context::default()
+        };
+
+        assert!(!trigger.is_triggered_at(&context, &[], now));
+        assert!(trigger.is_triggered_at(
+            &context,
+            &["deployment completed successfully".to_string()],
+            now
+        ));
+    }
+
+    #[test]
+    fn test_check_uses_injected_time_and_wakes_snooze_immediately() {
+        let pm = ProspectiveMemory::new();
+        let now = Utc::now();
+        let mut intention = Intention::new(
+            "wake on first post-snooze check",
+            IntentionTrigger::at_time(now - Duration::minutes(1)),
+        );
+        intention.status = IntentionStatus::Snoozed;
+        intention.snoozed_until = Some(now + Duration::minutes(30));
+        pm.create_intention(intention).unwrap();
+
+        let context = Context {
+            timestamp: now + Duration::minutes(31),
+            ..Context::default()
+        };
+        let triggered = pm.check_triggers(&context).unwrap();
+        assert_eq!(triggered.len(), 1);
+        assert_eq!(triggered[0].status, IntentionStatus::Triggered);
     }
 
     #[test]

--- a/crates/vestige-core/src/storage/intention_claim.rs
+++ b/crates/vestige-core/src/storage/intention_claim.rs
@@ -1,0 +1,137 @@
+//! Atomic compare-and-swap of reminder occurrences selected by a check.
+use super::sqlite::{IntentionRecord, SqliteMemoryStore};
+use rusqlite::{TransactionBehavior, params};
+
+impl SqliteMemoryStore {
+    /// Commit a complete check batch or none of it. A concurrent check or user
+    /// edit invalidates the old snapshot and asks the caller to retry. This
+    /// claims local occurrences; it cannot guarantee external delivery.
+    pub fn commit_intention_check(
+        &self,
+        changes: &[(IntentionRecord, IntentionRecord)],
+    ) -> Result<(), String> {
+        if changes.is_empty() {
+            return Ok(());
+        }
+        let mut writer = self.writer.lock().map_err(|e| e.to_string())?;
+        let tx = writer
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|e| e.to_string())?;
+        for (old, new) in changes {
+            if old.id != new.id {
+                return Err("intention check cannot change record identity".into());
+            }
+            let changed = tx
+                .execute(
+                    "UPDATE intentions SET trigger_type=?1,trigger_data=?2,status=?3,
+                    reminder_count=?4,last_reminded_at=?5,snoozed_until=?6
+                 WHERE id=?7 AND trigger_type=?8 AND trigger_data=?9 AND status=?10
+                    AND reminder_count=?11 AND last_reminded_at IS ?12
+                    AND snoozed_until IS ?13 AND content=?14 AND priority=?15
+                    AND deadline IS ?16 AND fulfilled_at IS ?17",
+                    params![
+                        new.trigger_type,
+                        new.trigger_data,
+                        new.status,
+                        new.reminder_count,
+                        new.last_reminded_at.map(|t| t.to_rfc3339()),
+                        new.snoozed_until.map(|t| t.to_rfc3339()),
+                        old.id,
+                        old.trigger_type,
+                        old.trigger_data,
+                        old.status,
+                        old.reminder_count,
+                        old.last_reminded_at.map(|t| t.to_rfc3339()),
+                        old.snoozed_until.map(|t| t.to_rfc3339()),
+                        old.content,
+                        old.priority,
+                        old.deadline.map(|t| t.to_rfc3339()),
+                        old.fulfilled_at.map(|t| t.to_rfc3339())
+                    ],
+                )
+                .map_err(|e| format!("Intention check commit failed: {e}"))?;
+            if changed != 1 {
+                return Err(format!(
+                    "Intention '{}' changed during check; retry the check",
+                    old.id
+                ));
+            }
+        }
+        tx.commit().map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(id: &str) -> IntentionRecord {
+        IntentionRecord {
+            id: id.into(),
+            content: "Synthetic reminder".into(),
+            trigger_type: "time".into(),
+            trigger_data: "{}".into(),
+            priority: 2,
+            status: "active".into(),
+            created_at: "2026-10-01T09:00:00Z".parse().unwrap(),
+            deadline: None,
+            fulfilled_at: None,
+            reminder_count: 0,
+            last_reminded_at: None,
+            notes: None,
+            tags: vec![],
+            related_memories: vec![],
+            snoozed_until: None,
+            source_type: "user".into(),
+            source_data: None,
+        }
+    }
+
+    fn delivered(old: &IntentionRecord) -> IntentionRecord {
+        let mut new = old.clone();
+        new.reminder_count += 1;
+        new.last_reminded_at = Some(old.created_at);
+        new
+    }
+
+    #[test]
+    fn intention_claim_has_one_winner_across_connections() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let a = SqliteMemoryStore::new(Some(path.clone())).unwrap();
+        let b = SqliteMemoryStore::new(Some(path)).unwrap();
+        let old = record("a");
+        a.save_intention(&old).unwrap();
+        let changes = vec![(old.clone(), delivered(&old))];
+        let outcomes = std::thread::scope(|s| {
+            let first = s.spawn(|| a.commit_intention_check(&changes));
+            let second = s.spawn(|| b.commit_intention_check(&changes));
+            [first.join().unwrap(), second.join().unwrap()]
+        });
+        assert_eq!(outcomes.iter().filter(|r| r.is_ok()).count(), 1);
+        assert_eq!(a.get_intention("a").unwrap().unwrap().reminder_count, 1);
+    }
+
+    #[test]
+    fn intention_claim_batch_conflict_rolls_back_prior_claims() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteMemoryStore::new(Some(dir.path().join("test.db"))).unwrap();
+        let a = record("a");
+        let b = record("b");
+        store.save_intention(&a).unwrap();
+        store.save_intention(&b).unwrap();
+        let mut cancelled = b.clone();
+        cancelled.status = "cancelled".into();
+        store.save_intention(&cancelled).unwrap();
+        assert!(
+            store
+                .commit_intention_check(&[(a.clone(), delivered(&a)), (b.clone(), delivered(&b))])
+                .is_err()
+        );
+        assert_eq!(store.get_intention("a").unwrap().unwrap().reminder_count, 0);
+        assert_eq!(
+            store.get_intention("b").unwrap().unwrap().status,
+            "cancelled"
+        );
+    }
+}

--- a/crates/vestige-core/src/storage/intention_graph_store.rs
+++ b/crates/vestige-core/src/storage/intention_graph_store.rs
@@ -1,0 +1,411 @@
+//! Atomic local persistence and reproducible replay for evidence-aware intentions.
+//!
+//! The journal records caller assertions, not externally verified truth. It never
+//! invokes providers or performs the action described by an intention.
+
+use chrono::{DateTime, Utc};
+use rusqlite::{OptionalExtension, TransactionBehavior, params};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use super::sqlite::SqliteMemoryStore;
+use crate::intention_graph::{Command, IntentionGraph};
+
+type MemoryCommitmentRow = (String, Option<String>, Option<String>, Option<String>, i64);
+
+const MAX_GRAPH_BYTES: usize = 16 * 1024 * 1024;
+const MAX_COMMAND_BYTES: usize = 128 * 1024;
+const MAX_JOURNAL_ENTRIES: i64 = 20_000;
+
+fn digest(value: &str) -> String {
+    format!("{:x}", Sha256::digest(value.as_bytes()))
+}
+
+fn validate_scope(scope: &str) -> Result<(), String> {
+    if scope.is_empty()
+        || scope.len() > 128
+        || !scope
+            .bytes()
+            .all(|c| c.is_ascii_alphanumeric() || b"._-/".contains(&c))
+    {
+        return Err(
+            "scope must contain 1..128 ASCII letters, digits, '.', '_', '-', or '/'".into(),
+        );
+    }
+    Ok(())
+}
+
+fn storage_error(error: impl std::fmt::Display) -> String {
+    format!("Intention graph storage: {error}")
+}
+
+impl SqliteMemoryStore {
+    /// Read a content commitment for an available memory in the same scope.
+    /// Raw memory text is never copied into intention history. A commitment
+    /// proves a local snapshot changed, not that the memory's claim is true.
+    pub fn intention_memory_snapshot(
+        &self,
+        scope: &str,
+        memory_id: &str,
+        now: DateTime<Utc>,
+    ) -> Result<Value, String> {
+        validate_scope(scope)?;
+        uuid::Uuid::parse_str(memory_id).map_err(|_| "memory_id must be a UUID")?;
+        let reader = self.reader.lock().map_err(storage_error)?;
+        let row: Option<MemoryCommitmentRow> = reader.query_row(
+            "SELECT content,valid_from,valid_until,superseded_by,suppression_count FROM knowledge_nodes
+             WHERE id=?1 AND COALESCE(NULLIF(trim(scope),''),'user')=?2",
+            params![memory_id, scope],
+            |r| Ok((r.get(0)?,r.get(1)?,r.get(2)?,r.get(3)?,r.get(4)?)),
+        ).optional().map_err(storage_error)?;
+        let mut value = None;
+        if let Some((content, from, until, superseded, suppressed)) = row {
+            let parse = |raw: &str| -> Result<DateTime<Utc>, String> {
+                DateTime::parse_from_rfc3339(raw)
+                    .map(|t| t.with_timezone(&Utc))
+                    .or_else(|_| {
+                        chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S%.f")
+                            .map(|t| t.and_utc())
+                    })
+                    .map_err(|_| "memory validity timestamp is malformed".into())
+            };
+            let from = from.as_deref().map(parse).transpose()?;
+            let until = until.as_deref().map(parse).transpose()?;
+            if superseded.is_none()
+                && suppressed == 0
+                && from.is_none_or(|at| at <= now)
+                && until.is_none_or(|at| at > now)
+            {
+                value = Some(digest(&content));
+            }
+        }
+        Ok(
+            json!({"source_key":format!("memory:{memory_id}"),"memory_id":memory_id,
+            "value":value,"observed_at":now,"boundary":"Local scoped content commitment; not external fact verification."}),
+        )
+    }
+
+    /// Apply a command to one scope, atomically committing snapshot and journal.
+    /// IMMEDIATE transactions serialize writers across processes using this DB.
+    /// Scope names are namespaces, not an authentication or tenancy boundary.
+    pub fn apply_intention_graph(
+        &self,
+        scope: &str,
+        command: Command,
+        now: DateTime<Utc>,
+    ) -> Result<Value, String> {
+        validate_scope(scope)?;
+        let command_json = serde_json::to_string(&command).map_err(storage_error)?;
+        if command_json.len() > MAX_COMMAND_BYTES {
+            return Err("intention graph command exceeds 128 KiB".into());
+        }
+        let mut writer = self.writer.lock().map_err(storage_error)?;
+        let tx = writer
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(storage_error)?;
+        let prior: Option<String> = tx
+            .query_row(
+                "SELECT state_json FROM intention_graph_state WHERE scope = ?1",
+                params![scope],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(storage_error)?;
+        let mut graph: IntentionGraph = match &prior {
+            Some(state) => serde_json::from_str(state).map_err(storage_error)?,
+            None => IntentionGraph::default(),
+        };
+        let before = serde_json::to_string(&graph).map_err(storage_error)?;
+        let output = graph.apply(command, now)?;
+        let after = serde_json::to_string(&graph).map_err(storage_error)?;
+        if after.len() > MAX_GRAPH_BYTES {
+            return Err("intention graph exceeds the 16 MiB local scope limit".into());
+        }
+        let mut committed_seq = None;
+        if before != after {
+            let seq: i64 = tx.query_row(
+                "SELECT COALESCE(MAX(seq), 0) + 1 FROM intention_graph_journal WHERE scope = ?1",
+                params![scope], |row| row.get(0),
+            ).map_err(storage_error)?;
+            if seq > MAX_JOURNAL_ENTRIES {
+                return Err("intention graph journal limit reached; preserve this scope and create a new scope with reviewed plan definitions".into());
+            }
+            let at = now.to_rfc3339();
+            let output_json = serde_json::to_string(&output).map_err(storage_error)?;
+            tx.execute(
+                "INSERT INTO intention_graph_journal(scope,seq,command_json,evaluated_at,output_digest,state_digest)
+                 VALUES (?1,?2,?3,?4,?5,?6)",
+                params![scope, seq, command_json, at, digest(&output_json), digest(&after)],
+            ).map_err(storage_error)?;
+            tx.execute(
+                "INSERT INTO intention_graph_state(scope,state_json,updated_at) VALUES (?1,?2,?3)
+                 ON CONFLICT(scope) DO UPDATE SET state_json=excluded.state_json, updated_at=excluded.updated_at",
+                params![scope, after, at],
+            ).map_err(storage_error)?;
+            committed_seq = Some(seq);
+        }
+        tx.commit().map_err(storage_error)?;
+        Ok(
+            json!({"scope": scope, "journal_seq": committed_seq, "result": output,
+            "boundary": "Local deterministic evaluation of supplied evidence; no external action or independent fact verification."}),
+        )
+    }
+
+    /// Replay the exact committed command history against an empty evaluator.
+    /// Digests detect divergence, not adversarial rewriting of the whole DB.
+    pub fn replay_intention_graph(&self, scope: &str) -> Result<Value, String> {
+        validate_scope(scope)?;
+        let mut writer = self.writer.lock().map_err(storage_error)?;
+        let tx = writer.transaction().map_err(storage_error)?;
+        let mut graph = IntentionGraph::default();
+        let mut count = 0_i64;
+        {
+            let mut stmt = tx
+                .prepare(
+                    "SELECT seq,command_json,evaluated_at,output_digest,state_digest
+                 FROM intention_graph_journal WHERE scope=?1 ORDER BY seq",
+                )
+                .map_err(storage_error)?;
+            let mut rows = stmt.query(params![scope]).map_err(storage_error)?;
+            while let Some(row) = rows.next().map_err(storage_error)? {
+                let seq: i64 = row.get(0).map_err(storage_error)?;
+                if seq != count + 1 || seq > MAX_JOURNAL_ENTRIES {
+                    return Err("intention graph journal sequence is invalid".into());
+                }
+                let command: String = row.get(1).map_err(storage_error)?;
+                let at: String = row.get(2).map_err(storage_error)?;
+                let expected_output: String = row.get(3).map_err(storage_error)?;
+                let expected_state: String = row.get(4).map_err(storage_error)?;
+                let command: Command = serde_json::from_str(&command).map_err(storage_error)?;
+                let now = DateTime::parse_from_rfc3339(&at)
+                    .map_err(storage_error)?
+                    .with_timezone(&Utc);
+                let output = graph.apply(command, now)?;
+                let actual_output = digest(&serde_json::to_string(&output).map_err(storage_error)?);
+                let actual_state = digest(&serde_json::to_string(&graph).map_err(storage_error)?);
+                if actual_output != expected_output || actual_state != expected_state {
+                    return Err(format!("intention graph replay diverged at sequence {seq}"));
+                }
+                count = seq;
+            }
+        }
+        let stored: Option<String> = tx
+            .query_row(
+                "SELECT state_json FROM intention_graph_state WHERE scope=?1",
+                params![scope],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(storage_error)?;
+        let replayed = serde_json::to_string(&graph).map_err(storage_error)?;
+        if stored.as_deref().is_some_and(|state| state != replayed)
+            || (stored.is_none() && count != 0)
+        {
+            return Err("intention graph replay differs from the current snapshot".into());
+        }
+        tx.commit().map_err(storage_error)?;
+        Ok(
+            json!({"scope":scope,"matched":true,"commands":count,"state_digest":digest(&replayed),
+            "boundary":"Deterministic local replay, not proof of external facts, delivery, or cryptographic authenticity."}),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at() -> DateTime<Utc> {
+        "2026-10-01T09:00:00Z".parse().unwrap()
+    }
+    fn plan(id: &str) -> Command {
+        serde_json::from_value(
+            json!({"action":"plan","id":id,"description":"Synthetic projector intention",
+            "requirements":[],"conflict_keys":[]}),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn graph_journal_failure_rolls_back_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteMemoryStore::new(Some(dir.path().join("test.db"))).unwrap();
+        store
+            .writer
+            .lock()
+            .unwrap()
+            .execute_batch(
+                "CREATE TRIGGER reject_intention_journal BEFORE INSERT ON intention_graph_journal
+             BEGIN SELECT RAISE(ABORT, 'injected journal failure'); END;",
+            )
+            .unwrap();
+        assert!(
+            store
+                .apply_intention_graph("user", plan("p1"), at())
+                .is_err()
+        );
+        let count: i64 = store
+            .reader
+            .lock()
+            .unwrap()
+            .query_row("SELECT count(*) FROM intention_graph_state", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(count, 0);
+        store
+            .writer
+            .lock()
+            .unwrap()
+            .execute_batch("DROP TRIGGER reject_intention_journal")
+            .unwrap();
+        assert!(
+            store
+                .apply_intention_graph("user", plan("p1"), at())
+                .is_ok()
+        );
+        assert_eq!(
+            store.replay_intention_graph("user").unwrap()["matched"],
+            true
+        );
+    }
+
+    #[test]
+    fn graph_two_connections_preserve_both_commands() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let a = SqliteMemoryStore::new(Some(path.clone())).unwrap();
+        let b = SqliteMemoryStore::new(Some(path)).unwrap();
+        std::thread::scope(|s| {
+            let first = s.spawn(|| a.apply_intention_graph("user", plan("a"), at()).unwrap());
+            let second = s.spawn(|| b.apply_intention_graph("user", plan("b"), at()).unwrap());
+            first.join().unwrap();
+            second.join().unwrap();
+        });
+        assert_eq!(a.replay_intention_graph("user").unwrap()["commands"], 2);
+        let output = a
+            .apply_intention_graph(
+                "user",
+                serde_json::from_value(json!({"action":"portfolio"})).unwrap(),
+                at(),
+            )
+            .unwrap();
+        assert!(output.to_string().contains("\"a\""));
+        assert!(output.to_string().contains("\"b\""));
+        assert_eq!(a.replay_intention_graph("other").unwrap()["commands"], 0);
+    }
+
+    #[test]
+    fn graph_replay_detects_recorded_output_tampering() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteMemoryStore::new(Some(dir.path().join("test.db"))).unwrap();
+        store
+            .apply_intention_graph("user", plan("p1"), at())
+            .unwrap();
+        store
+            .writer
+            .lock()
+            .unwrap()
+            .execute(
+                "UPDATE intention_graph_journal SET output_digest='changed'",
+                [],
+            )
+            .unwrap();
+        assert!(
+            store
+                .replay_intention_graph("user")
+                .unwrap_err()
+                .contains("diverged")
+        );
+    }
+
+    #[test]
+    fn graph_rejects_bad_scope_before_storage() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteMemoryStore::new(Some(dir.path().join("test.db"))).unwrap();
+        assert!(
+            store
+                .apply_intention_graph("user\nother", plan("p1"), at())
+                .is_err()
+        );
+        assert!(store.replay_intention_graph("").is_err());
+    }
+
+    #[test]
+    fn graph_corrupt_persisted_plan_returns_error_without_panicking() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteMemoryStore::new(Some(dir.path().join("test.db"))).unwrap();
+        store
+            .apply_intention_graph("user", plan("p1"), at())
+            .unwrap();
+        let writer = store.writer.lock().unwrap();
+        let raw: String = writer
+            .query_row(
+                "SELECT state_json FROM intention_graph_state WHERE scope='user'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let mut state: Value = serde_json::from_str(&raw).unwrap();
+        state["plans"]["p1"]["versions"] = json!([]);
+        writer
+            .execute(
+                "UPDATE intention_graph_state SET state_json=?1 WHERE scope='user'",
+                params![state.to_string()],
+            )
+            .unwrap();
+        drop(writer);
+        let command = serde_json::from_value(json!({"action":"explain","id":"p1"})).unwrap();
+        let error = store
+            .apply_intention_graph("user", command, at())
+            .unwrap_err();
+        assert!(error.contains("versions"), "{error}");
+        assert!(store.replay_intention_graph("user").is_err());
+    }
+
+    #[test]
+    fn memory_commitments_change_without_copying_content_or_crossing_scope() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SqliteMemoryStore::new(Some(dir.path().join("test.db"))).unwrap();
+        let node = store
+            .ingest_in_scope(
+                crate::IngestInput {
+                    content: "Synthetic projector requirement alpha".into(),
+                    ..Default::default()
+                },
+                "project-a",
+            )
+            .unwrap();
+        let first = store
+            .intention_memory_snapshot("project-a", &node.id, at())
+            .unwrap();
+        assert!(first["value"].is_string());
+        assert!(!first.to_string().contains("Synthetic projector"));
+        assert!(
+            store
+                .intention_memory_snapshot("project-b", &node.id, at())
+                .unwrap()["value"]
+                .is_null()
+        );
+        store.writer.lock().unwrap().execute("UPDATE knowledge_nodes SET content='Synthetic projector requirement beta' WHERE id=?1",params![node.id]).unwrap();
+        let changed = store
+            .intention_memory_snapshot("project-a", &node.id, at())
+            .unwrap();
+        assert_ne!(first["value"], changed["value"]);
+        store
+            .writer
+            .lock()
+            .unwrap()
+            .execute(
+                "UPDATE knowledge_nodes SET valid_until='2026-09-01T00:00:00Z' WHERE id=?1",
+                params![node.id],
+            )
+            .unwrap();
+        assert!(
+            store
+                .intention_memory_snapshot("project-a", &node.id, at())
+                .unwrap()["value"]
+                .is_null()
+        );
+    }
+}

--- a/crates/vestige-core/src/storage/migrations.rs
+++ b/crates/vestige-core/src/storage/migrations.rs
@@ -169,6 +169,11 @@ pub const MIGRATIONS: &[Migration] = &[
         description: "Post-retrieval failure feedback ledger: every accessibility delta applied because a failure followed a retrieval, so it can be audited and reverted",
         up: MIGRATION_V33_UP,
     },
+    Migration {
+        version: 34,
+        description: "Versioned intention graphs and atomic deterministic command journal",
+        up: MIGRATION_V34_UP,
+    },
 ];
 
 /// A database migration
@@ -2439,6 +2444,26 @@ CREATE INDEX IF NOT EXISTS idx_failure_feedback_failure ON failure_feedback(fail
 CREATE INDEX IF NOT EXISTS idx_failure_feedback_memory ON failure_feedback(memory_id);
 
 UPDATE schema_version SET version = 33, applied_at = datetime('now');
+"#;
+
+/// Each scope is an independent local intention graph. The snapshot and journal
+/// commit together under an IMMEDIATE transaction. No external action is run.
+const MIGRATION_V34_UP: &str = r#"
+CREATE TABLE IF NOT EXISTS intention_graph_state (
+    scope TEXT PRIMARY KEY,
+    state_json TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS intention_graph_journal (
+    scope TEXT NOT NULL,
+    seq INTEGER NOT NULL,
+    command_json TEXT NOT NULL,
+    evaluated_at TEXT NOT NULL,
+    output_digest TEXT NOT NULL,
+    state_digest TEXT NOT NULL,
+    PRIMARY KEY(scope, seq)
+);
+UPDATE schema_version SET version = 34, applied_at = datetime('now');
 "#;
 
 #[cfg(test)]

--- a/crates/vestige-core/src/storage/mod.rs
+++ b/crates/vestige-core/src/storage/mod.rs
@@ -7,6 +7,8 @@ mod attestation_store;
 mod cloud_crypto;
 #[cfg(feature = "cloud-sync")]
 mod cloud_sync;
+mod intention_claim;
+mod intention_graph_store;
 mod memory_store;
 mod migrations;
 mod portable;

--- a/crates/vestige-mcp/src/server.rs
+++ b/crates/vestige-mcp/src/server.rs
@@ -441,8 +441,8 @@ description: Some("Code memory. Actions: 'remember_pattern', 'remember_decision'
                     idempotent_hint: false,
                     open_world_hint: false,
                 }),
-description: Some("Intentions. Actions: 'set', 'check' (find triggered), 'update' (complete, snooze, cancel), 'list'.".to_string()),
-                input_schema: tools::intention_unified::schema(),
+description: Some("Intentions. Actions: 'set', 'check', 'update', 'list'; 'graph' evaluates evidence-aware plans, premises, attention, completion and replay through a nested command.".to_string()),
+                input_schema: tools::intention_graph::schema(),
                 ..Default::default()
             },
             // ================================================================
@@ -843,7 +843,7 @@ description: Some("Memory with hindsight. After a failure is recorded, reach bac
                 .await
             }
             "intention" => {
-                tools::intention_unified::execute(&self.storage, &self.cognitive, request.arguments)
+                tools::intention_graph::execute(&self.storage, &self.cognitive, request.arguments)
                     .await
             }
 

--- a/crates/vestige-mcp/src/tools/intention_graph.rs
+++ b/crates/vestige-mcp/src/tools/intention_graph.rs
@@ -1,0 +1,237 @@
+//! Public adapter for `intention action=graph`. All evidence is local or supplied
+//! by the caller. This module does not fetch URLs, execute tools, or send alerts.
+
+use crate::cognitive::CognitiveEngine;
+use chrono::{DateTime, Utc};
+use serde_json::{Value, json};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use vestige_core::{Storage, intention_graph::Command};
+
+/// Extend the compatible intention interface without adding another MCP tool.
+pub fn schema() -> Value {
+    let mut schema = super::intention_unified::schema();
+    schema["properties"]["action"]["enum"]
+        .as_array_mut()
+        .expect("action enum")
+        .push(json!("graph"));
+    schema["properties"]["scope"] = json!({"type":"string","default":"user","maxLength":128,
+        "description":"[graph] Local intention namespace, not an authorization boundary."});
+    schema["properties"]["at"] = json!({"type":"string","format":"date-time",
+        "description":"[graph] Explicit evaluation clock for reproducible fixtures; defaults to now."});
+    schema["properties"]["command"] = vestige_core::intention_graph::schema();
+    schema["properties"]["command"]["description"] = json!(
+        "[graph] Evidence-aware plan/revise/observe/evaluate/explain/portfolio/complete/cancel/acknowledge. replay checks committed history. memory_snapshot reads a scoped content digest; refresh_memory observes it using memory_id,event_id,source_revision. No external actions or fact verification."
+    );
+    // Adapter commands have disjoint action tags and never accept caller values
+    // for the reserved local-memory source namespace.
+    if let Some(variants) = schema["properties"]["command"]["oneOf"].as_array_mut() {
+        variants.extend([
+            json!({"type":"object","properties":{"action":{"const":"replay"}},"required":["action"],"additionalProperties":false}),
+            json!({"type":"object","properties":{"action":{"const":"memory_snapshot"},"memory_id":{"type":"string"}},"required":["action","memory_id"],"additionalProperties":false}),
+            json!({"type":"object","properties":{"action":{"const":"refresh_memory"},"memory_id":{"type":"string"},"event_id":{"type":"string"},"source_revision":{"type":"integer","minimum":1}},"required":["action","memory_id","event_id","source_revision"],"additionalProperties":false}),
+        ]);
+    }
+    schema
+}
+
+/// Route new graph commands while retaining all existing intention actions.
+pub async fn execute(
+    storage: &Arc<Storage>,
+    cognitive: &Arc<Mutex<CognitiveEngine>>,
+    args: Option<Value>,
+) -> Result<Value, String> {
+    if args
+        .as_ref()
+        .and_then(|a| a.get("action"))
+        .and_then(Value::as_str)
+        != Some("graph")
+    {
+        return super::intention_unified::execute(storage, cognitive, args).await;
+    }
+    execute_graph(storage, args.as_ref().ok_or("Missing arguments")?)
+}
+
+fn field<'a>(value: &'a Value, key: &str) -> Result<&'a str, String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("Missing string field '{key}'"))
+}
+
+fn execute_graph(storage: &Storage, args: &Value) -> Result<Value, String> {
+    if args.to_string().len() > 128 * 1024 {
+        return Err("graph arguments exceed 128 KiB".into());
+    }
+    let scope = match args.get("scope") {
+        None => "user",
+        Some(v) => v.as_str().ok_or("scope must be a string")?,
+    };
+    let now = match args.get("at") {
+        None => Utc::now(),
+        Some(v) => DateTime::parse_from_rfc3339(v.as_str().ok_or("at must be an RFC3339 string")?)
+            .map_err(|_| "at must be an RFC3339 timestamp")?
+            .with_timezone(&Utc),
+    };
+    let raw = args.get("command").ok_or("Missing graph command")?;
+    let action = field(raw, "action")?;
+    let adapter_fields: Option<&[&str]> = match action {
+        "replay" => Some(&["action"]),
+        "memory_snapshot" => Some(&["action", "memory_id"]),
+        "refresh_memory" => Some(&["action", "memory_id", "event_id", "source_revision"]),
+        _ => None,
+    };
+    if let Some(allowed) = adapter_fields
+        && raw
+            .as_object()
+            .is_some_and(|object| object.keys().any(|key| !allowed.contains(&key.as_str())))
+    {
+        return Err("Unexpected field in intention graph adapter command".into());
+    }
+    match action {
+        "replay" => storage.replay_intention_graph(scope),
+        "memory_snapshot" => {
+            storage.intention_memory_snapshot(scope, field(raw, "memory_id")?, now)
+        }
+        "refresh_memory" => {
+            let snapshot =
+                storage.intention_memory_snapshot(scope, field(raw, "memory_id")?, now)?;
+            let revision = raw
+                .get("source_revision")
+                .and_then(Value::as_u64)
+                .filter(|r| *r > 0)
+                .ok_or("source_revision must be a positive integer")?;
+            let command: Command = serde_json::from_value(json!({"action":"observe",
+                "event_id":field(raw,"event_id")?,"source_key":snapshot["source_key"],
+                "source_revision":revision,"value":snapshot["value"],
+                "observed_events":[],"covered_events":[]}))
+            .map_err(|e| format!("Invalid memory observation: {e}"))?;
+            storage.apply_intention_graph(scope, command, now)
+        }
+        _ => {
+            if action == "observe" && field(raw, "source_key")?.starts_with("memory:") {
+                return Err("memory: sources are reserved; use refresh_memory to read the local scoped snapshot".into());
+            }
+            let command: Command = serde_json::from_value(raw.clone())
+                .map_err(|e| format!("Invalid graph command: {e}"))?;
+            storage.apply_intention_graph(scope, command, now)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn graph_schema_advertises_engine_and_adapter_commands() {
+        let schema = schema();
+        let variants = schema["properties"]["command"]["oneOf"].as_array().unwrap();
+        let actions: std::collections::BTreeSet<_> = variants
+            .iter()
+            .filter_map(|variant| variant["properties"]["action"]["const"].as_str())
+            .collect();
+        for action in [
+            "plan",
+            "revise",
+            "observe",
+            "evaluate",
+            "explain",
+            "portfolio",
+            "complete",
+            "cancel",
+            "acknowledge",
+            "replay",
+            "memory_snapshot",
+            "refresh_memory",
+        ] {
+            assert!(actions.contains(action), "missing graph command {action}");
+        }
+        assert_eq!(actions.len(), 12);
+    }
+
+    #[test]
+    fn graph_memory_bridge_derives_values_and_replays_recorded_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new(Some(dir.path().join("test.db"))).unwrap();
+        let node = storage
+            .ingest_in_scope(
+                vestige_core::IngestInput {
+                    content: "Synthetic memory premise".into(),
+                    ..Default::default()
+                },
+                "fixture",
+            )
+            .unwrap();
+        let at = "2026-10-01T09:00:00Z";
+        let snapshot = execute_graph(
+            &storage,
+            &json!({"action":"graph","scope":"fixture","at":at,
+            "command":{"action":"memory_snapshot","memory_id":node.id}}),
+        )
+        .unwrap();
+        execute_graph(&storage, &json!({"action":"graph","scope":"fixture","at":at,
+            "command":{"action":"plan","id":"p","description":"Retain the premise","requirements":[{
+                "type":"evidence","id":"premise","source_key":snapshot["source_key"],"memory_id":node.id,
+                "condition":{"op":"equals","value":snapshot["value"]}}]}})).unwrap();
+        let observed = execute_graph(&storage, &json!({"action":"graph","scope":"fixture","at":at,
+            "command":{"action":"refresh_memory","memory_id":node.id,"event_id":"local-1","source_revision":1}})).unwrap();
+        assert!(observed.to_string().contains("satisfied"));
+        assert!(!observed.to_string().contains("Synthetic memory premise"));
+        assert!(execute_graph(&storage, &json!({"action":"graph","scope":"fixture","at":at,
+            "command":{"action":"refresh_memory","memory_id":node.id,"event_id":"forged","source_revision":2,"value":"forged"}})).is_err());
+        let replay = execute_graph(
+            &storage,
+            &json!({"action":"graph","scope":"fixture",
+            "command":{"action":"replay"}}),
+        )
+        .unwrap();
+        assert_eq!(replay["matched"], true);
+        assert_eq!(replay["commands"], 2);
+    }
+
+    #[test]
+    fn graph_rejects_invalid_clock_and_reserved_memory_assertions() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new(Some(dir.path().join("test.db"))).unwrap();
+        assert!(
+            execute_graph(
+                &storage,
+                &json!({"action":"graph","at":"tomorrow","command":{"action":"portfolio"}})
+            )
+            .is_err()
+        );
+        assert!(execute_graph(&storage,&json!({"action":"graph","command":{"action":"observe","source_key":"memory:forged"}})).is_err());
+        assert!(
+            execute_graph(
+                &storage,
+                &json!({"action":"graph","scope":12,"command":{"action":"portfolio"}})
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn graph_plan_round_trips_through_public_adapter_and_replay() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let storage = Storage::new(Some(path.clone())).unwrap();
+        let result=execute_graph(&storage,&json!({"action":"graph","at":"2026-10-01T09:00:00Z",
+            "command":{"action":"plan","id":"projector","description":"Buy the selected projector", "requirements":[],"conflict_keys":[]}})).unwrap();
+        assert!(result["journal_seq"].as_i64().is_some());
+        drop(storage);
+        let reopened = Storage::new(Some(path)).unwrap();
+        let result = execute_graph(
+            &reopened,
+            &json!({"action":"graph","command":{"action":"replay"}}),
+        )
+        .unwrap();
+        assert_eq!(result["matched"], true);
+        let result = execute_graph(
+            &reopened,
+            &json!({"action":"graph","at":"2026-10-01T09:00:00Z","command":{"action":"explain","id":"projector"}}),
+        )
+        .unwrap();
+        assert!(result.to_string().contains("Buy the selected projector"));
+    }
+}

--- a/crates/vestige-mcp/src/tools/intention_unified.rs
+++ b/crates/vestige-mcp/src/tools/intention_unified.rs
@@ -17,14 +17,95 @@ use uuid::Uuid;
 use crate::cognitive::CognitiveEngine;
 use vestige_core::IntentionRecord;
 use vestige_core::Storage;
-use vestige_core::neuroscience::ProspectiveContext;
-use vestige_core::neuroscience::prospective_memory::IntentionTrigger as ProspectiveTrigger;
+use vestige_core::neuroscience::{
+    ContextPattern, IntentionTrigger as ProspectiveTrigger, ProspectiveContext, RecurrencePattern,
+    TriggerPattern,
+};
+
+const MAX_TRIGGER_DEPTH: usize = 5;
+const MAX_TRIGGER_NODES: usize = 32;
+const MAX_TRIGGER_BRANCHES: usize = 16;
+const MAX_TRIGGER_TEXT_BYTES: usize = 4_096;
+const MAX_ARGUMENT_BYTES: usize = 128 * 1_024;
+const MAX_CONTEXT_ITEMS: usize = 32;
+const MAX_DURATION_MINUTES: i64 = 10 * 365 * 24 * 60;
+const MAX_LIST_LIMIT: i32 = 1_000;
+const MAX_ONE_SHOT_REMINDERS: i32 = 5;
+const MIN_ONE_SHOT_REMINDER_INTERVAL_MINUTES: i64 = 30;
 
 /// Unified schema for the `intention` tool
 pub fn schema() -> Value {
     serde_json::json!({
         "type": "object",
         "description": "Unified intention management tool. Supports setting, checking, updating (complete/snooze/cancel), and listing intentions.",
+        "$defs": {
+            "trigger": {
+                "type": "object",
+                "description": "A simple, recurring, activity, or bounded compound trigger.",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["time", "context", "event", "activity", "recurring", "compound"]
+                    },
+                    "at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Absolute RFC3339 trigger or recurrence anchor (UTC-normalized on storage)"
+                    },
+                    "in_minutes": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": MAX_DURATION_MINUTES,
+                        "description": "Positive minutes from intention creation for a one-shot time trigger"
+                    },
+                    "codebase": { "type": "string", "maxLength": MAX_TRIGGER_TEXT_BYTES },
+                    "file_pattern": { "type": "string", "maxLength": MAX_TRIGGER_TEXT_BYTES },
+                    "topic": { "type": "string", "maxLength": MAX_TRIGGER_TEXT_BYTES },
+                    "condition": {
+                        "type": "string",
+                        "maxLength": MAX_TRIGGER_TEXT_BYTES,
+                        "description": "Case-insensitive text matched against check context events"
+                    },
+                    "activity": {
+                        "type": "string",
+                        "maxLength": MAX_TRIGGER_TEXT_BYTES,
+                        "description": "Activity whose completion is matched against check context events"
+                    },
+                    "recurrence": {
+                        "description": "Named cadence or a bounded absolute interval. Fortnightly is exactly 20,160 minutes.",
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "description": "hourly, daily, weekly, fortnightly, or 'every N minutes/hours/days/weeks/fortnights'"
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "every": { "type": "integer", "minimum": 1 },
+                                    "unit": {
+                                        "type": "string",
+                                        "enum": ["minute", "minutes", "hour", "hours", "day", "days", "week", "weeks", "fortnight", "fortnights"]
+                                    },
+                                    "every_minutes": { "type": "integer", "minimum": 1, "maximum": MAX_DURATION_MINUTES },
+                                    "interval_minutes": { "type": "integer", "minimum": 1, "maximum": MAX_DURATION_MINUTES }
+                                }
+                            }
+                        ]
+                    },
+                    "base": { "$ref": "#/$defs/trigger" },
+                    "all_of": {
+                        "type": "array",
+                        "maxItems": MAX_TRIGGER_BRANCHES,
+                        "items": { "$ref": "#/$defs/trigger" }
+                    },
+                    "any_of": {
+                        "type": "array",
+                        "maxItems": MAX_TRIGGER_BRANCHES,
+                        "items": { "$ref": "#/$defs/trigger" }
+                    }
+                }
+            }
+        },
         "properties": {
             "action": {
                 "type": "string",
@@ -37,39 +118,8 @@ pub fn schema() -> Value {
                 "description": "[set] What to remember to do"
             },
             "trigger": {
-                "type": "object",
-                "description": "[set] When to trigger this intention",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "enum": ["time", "context", "event"],
-                        "description": "Trigger type: time-based, context-based, or event-based"
-                    },
-                    "at": {
-                        "type": "string",
-                        "description": "ISO timestamp for time-based triggers"
-                    },
-                    "in_minutes": {
-                        "type": "integer",
-                        "description": "Minutes from now for duration-based triggers"
-                    },
-                    "codebase": {
-                        "type": "string",
-                        "description": "Trigger when working in this codebase"
-                    },
-                    "file_pattern": {
-                        "type": "string",
-                        "description": "Trigger when editing files matching this pattern"
-                    },
-                    "topic": {
-                        "type": "string",
-                        "description": "Trigger when discussing this topic"
-                    },
-                    "condition": {
-                        "type": "string",
-                        "description": "Natural language condition for event triggers"
-                    }
-                }
+                "$ref": "#/$defs/trigger",
+                "description": "[set] When to trigger this intention"
             },
             "priority": {
                 "type": "string",
@@ -93,6 +143,8 @@ pub fn schema() -> Value {
             },
             "snooze_minutes": {
                 "type": "integer",
+                "minimum": 1,
+                "maximum": MAX_DURATION_MINUTES,
                 "default": 30,
                 "description": "[update] Minutes to snooze for (when status is 'snooze')"
             },
@@ -103,20 +155,30 @@ pub fn schema() -> Value {
                 "properties": {
                     "current_time": {
                         "type": "string",
-                        "description": "Current ISO timestamp (defaults to now)"
+                        "format": "date-time",
+                        "description": "Current RFC3339 timestamp (defaults to now)"
                     },
                     "codebase": {
                         "type": "string",
+                        "maxLength": MAX_TRIGGER_TEXT_BYTES,
                         "description": "Current codebase/project name"
                     },
                     "file": {
                         "type": "string",
+                        "maxLength": MAX_TRIGGER_TEXT_BYTES,
                         "description": "Current file path"
                     },
                     "topics": {
                         "type": "array",
-                        "items": { "type": "string" },
+                        "maxItems": MAX_CONTEXT_ITEMS,
+                        "items": { "type": "string", "maxLength": MAX_TRIGGER_TEXT_BYTES },
                         "description": "Current discussion topics"
+                    },
+                    "events": {
+                        "type": "array",
+                        "maxItems": MAX_CONTEXT_ITEMS,
+                        "items": { "type": "string", "maxLength": MAX_TRIGGER_TEXT_BYTES },
+                        "description": "Recent event or activity descriptions for event/activity triggers"
                     }
                 }
             },
@@ -134,6 +196,8 @@ pub fn schema() -> Value {
             },
             "limit": {
                 "type": "integer",
+                "minimum": 1,
+                "maximum": MAX_LIST_LIMIT,
                 "default": 20,
                 "description": "[list] Maximum number to return"
             }
@@ -146,29 +210,40 @@ pub fn schema() -> Value {
 // ARGUMENT STRUCTS
 // ============================================================================
 
-#[derive(Debug, Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 struct TriggerSpec {
     #[serde(rename = "type")]
     trigger_type: Option<String>,
     at: Option<String>,
-    #[serde(alias = "in_minutes")]
+    #[serde(alias = "inMinutes")]
     in_minutes: Option<i64>,
     codebase: Option<String>,
-    #[serde(alias = "file_pattern")]
+    #[serde(alias = "filePattern")]
     file_pattern: Option<String>,
     topic: Option<String>,
     condition: Option<String>,
+    activity: Option<String>,
+    recurrence: Option<Value>,
+    base: Option<Box<TriggerSpec>>,
+    #[serde(default, alias = "allOf")]
+    all_of: Vec<TriggerSpec>,
+    #[serde(default, alias = "anyOf")]
+    any_of: Vec<TriggerSpec>,
+    #[serde(alias = "nextOccurrence")]
+    next_occurrence: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 struct ContextSpec {
-    #[allow(dead_code)]
+    #[serde(alias = "currentTime")]
     current_time: Option<String>,
     codebase: Option<String>,
     file: Option<String>,
     topics: Option<Vec<String>>,
+    #[serde(default, alias = "recentEvents", alias = "recent_events")]
+    events: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -195,6 +270,490 @@ struct UnifiedIntentionArgs {
     limit: Option<i32>,
 }
 
+fn parse_rfc3339(value: &str, field: &str) -> Result<DateTime<Utc>, String> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|_| format!("'{field}' must be a valid RFC3339 timestamp"))
+}
+
+fn checked_minutes(amount: i64, multiplier: i64) -> Result<i64, String> {
+    let minutes = amount
+        .checked_mul(multiplier)
+        .ok_or_else(|| "Recurrence interval is too large".to_string())?;
+    if !(1..=MAX_DURATION_MINUTES).contains(&minutes) {
+        return Err(format!(
+            "Recurrence interval must be between 1 and {MAX_DURATION_MINUTES} minutes"
+        ));
+    }
+    Ok(minutes)
+}
+
+fn recurrence_minutes(value: &Value) -> Result<i64, String> {
+    if let Some(name) = value.as_str() {
+        let normalized = name.trim().to_ascii_lowercase();
+        let named = match normalized.as_str() {
+            "hourly" | "every hour" => Some(60),
+            "daily" | "every day" => Some(1_440),
+            "weekly" | "every week" => Some(10_080),
+            "fortnightly" | "fortnight" | "every fortnight" | "every two weeks"
+            | "every other week" | "every 2 weeks" => Some(20_160),
+            _ => None,
+        };
+        if let Some(minutes) = named {
+            return Ok(minutes);
+        }
+
+        let words: Vec<&str> = normalized.split_whitespace().collect();
+        if words.len() == 3 && words[0] == "every" {
+            let amount = words[1]
+                .parse::<i64>()
+                .map_err(|_| "Recurrence must use a positive integer amount".to_string())?;
+            let multiplier = match words[2] {
+                "minute" | "minutes" => 1,
+                "hour" | "hours" => 60,
+                "day" | "days" => 1_440,
+                "week" | "weeks" => 10_080,
+                "fortnight" | "fortnights" => 20_160,
+                _ => {
+                    return Err(
+                        "Unsupported recurrence unit; use minutes, hours, days, weeks, or fortnights"
+                            .to_string(),
+                    );
+                }
+            };
+            return checked_minutes(amount, multiplier);
+        }
+        return Err(
+            "Unsupported recurrence; use hourly, daily, weekly, fortnightly, or 'every N <unit>'"
+                .to_string(),
+        );
+    }
+
+    let object = value
+        .as_object()
+        .ok_or_else(|| "'recurrence' must be a string or object".to_string())?;
+    for key in [
+        "every_minutes",
+        "everyMinutes",
+        "interval_minutes",
+        "intervalMinutes",
+    ] {
+        if let Some(raw) = object.get(key) {
+            let minutes = raw
+                .as_i64()
+                .ok_or_else(|| format!("'{key}' must be an integer"))?;
+            return checked_minutes(minutes, 1);
+        }
+    }
+
+    let amount = object.get("every").and_then(Value::as_i64).ok_or_else(|| {
+        "Recurrence object requires 'every' with 'unit', or 'every_minutes'".to_string()
+    })?;
+    let unit = object
+        .get("unit")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "Recurrence object with 'every' requires string 'unit'".to_string())?
+        .to_ascii_lowercase();
+    let multiplier = match unit.as_str() {
+        "minute" | "minutes" => 1,
+        "hour" | "hours" => 60,
+        "day" | "days" => 1_440,
+        "week" | "weeks" => 10_080,
+        "fortnight" | "fortnights" => 20_160,
+        _ => {
+            return Err(
+                "Unsupported recurrence unit; use minutes, hours, days, weeks, or fortnights"
+                    .to_string(),
+            );
+        }
+    };
+    checked_minutes(amount, multiplier)
+}
+
+fn normalize_text(value: &mut Option<String>, field: &str) -> Result<(), String> {
+    let Some(text) = value else {
+        return Ok(());
+    };
+    *text = text.trim().to_string();
+    if text.is_empty() {
+        return Err(format!("'{field}' cannot be empty"));
+    }
+    if text.len() > MAX_TRIGGER_TEXT_BYTES {
+        return Err(format!(
+            "'{field}' is too large (max {MAX_TRIGGER_TEXT_BYTES} bytes)"
+        ));
+    }
+    Ok(())
+}
+
+impl TriggerSpec {
+    fn inferred_type(&self) -> &str {
+        if self.recurrence.is_some() {
+            "recurring"
+        } else if !self.all_of.is_empty() || !self.any_of.is_empty() {
+            "compound"
+        } else if self.activity.is_some() {
+            "activity"
+        } else if self.condition.is_some() {
+            "event"
+        } else if self.codebase.is_some() || self.file_pattern.is_some() || self.topic.is_some() {
+            "context"
+        } else {
+            "time"
+        }
+    }
+
+    fn normalize(
+        &mut self,
+        now: DateTime<Utc>,
+        depth: usize,
+        nodes: &mut usize,
+    ) -> Result<(), String> {
+        if depth > MAX_TRIGGER_DEPTH {
+            return Err(format!(
+                "Trigger nesting exceeds maximum depth {MAX_TRIGGER_DEPTH}"
+            ));
+        }
+        *nodes += 1;
+        if *nodes > MAX_TRIGGER_NODES {
+            return Err(format!(
+                "Trigger contains more than {MAX_TRIGGER_NODES} total nodes"
+            ));
+        }
+
+        for (value, field) in [
+            (&mut self.codebase, "codebase"),
+            (&mut self.file_pattern, "file_pattern"),
+            (&mut self.topic, "topic"),
+            (&mut self.condition, "condition"),
+            (&mut self.activity, "activity"),
+        ] {
+            normalize_text(value, field)?;
+        }
+
+        let trigger_type = self
+            .trigger_type
+            .as_deref()
+            .unwrap_or_else(|| self.inferred_type())
+            .trim()
+            .to_ascii_lowercase();
+        self.trigger_type = Some(trigger_type.clone());
+
+        match trigger_type.as_str() {
+            "time" => {
+                if self.at.is_some() == self.in_minutes.is_some() {
+                    return Err("Time trigger requires exactly one of 'at' or 'in_minutes'".into());
+                }
+                if let Some(at) = &self.at {
+                    self.at = Some(parse_rfc3339(at, "trigger.at")?.to_rfc3339());
+                }
+                if let Some(minutes) = self.in_minutes
+                    && !(1..=MAX_DURATION_MINUTES).contains(&minutes)
+                {
+                    return Err(format!(
+                        "'in_minutes' must be between 1 and {MAX_DURATION_MINUTES}"
+                    ));
+                }
+            }
+            "context" => {
+                if self.codebase.is_none() && self.file_pattern.is_none() && self.topic.is_none() {
+                    return Err(
+                        "Context trigger requires at least one of 'codebase', 'file_pattern', or 'topic'"
+                            .into(),
+                    );
+                }
+            }
+            "event" => {
+                if self.condition.is_none() {
+                    return Err("Event trigger requires 'condition'".into());
+                }
+            }
+            "activity" => {
+                if self.activity.is_none() {
+                    return Err("Activity trigger requires 'activity'".into());
+                }
+            }
+            "recurring" => {
+                let recurrence = self
+                    .recurrence
+                    .as_ref()
+                    .ok_or("Recurring trigger requires 'recurrence'")?;
+                let minutes = recurrence_minutes(recurrence)?;
+                self.recurrence = Some(serde_json::json!({ "every_minutes": minutes }));
+
+                let next = if let Some(value) = &self.next_occurrence {
+                    parse_rfc3339(value, "trigger.next_occurrence")?
+                } else if let Some(value) = &self.at {
+                    parse_rfc3339(value, "trigger.at")?
+                } else if let Some(delay) = self.in_minutes {
+                    if !(1..=MAX_DURATION_MINUTES).contains(&delay) {
+                        return Err(format!(
+                            "'in_minutes' must be between 1 and {MAX_DURATION_MINUTES}"
+                        ));
+                    }
+                    now + Duration::minutes(delay)
+                } else {
+                    now + Duration::minutes(minutes)
+                };
+                self.next_occurrence = Some(next.to_rfc3339());
+                if let Some(at) = &self.at {
+                    self.at = Some(parse_rfc3339(at, "trigger.at")?.to_rfc3339());
+                }
+
+                if let Some(base) = &mut self.base {
+                    base.normalize(now, depth + 1, nodes)?;
+                } else {
+                    *nodes += 1;
+                    if *nodes > MAX_TRIGGER_NODES {
+                        return Err(format!(
+                            "Trigger contains more than {MAX_TRIGGER_NODES} total nodes"
+                        ));
+                    }
+                    self.base = Some(Box::new(Self {
+                        trigger_type: Some("time".to_string()),
+                        at: Some(next.to_rfc3339()),
+                        in_minutes: None,
+                        codebase: None,
+                        file_pattern: None,
+                        topic: None,
+                        condition: None,
+                        activity: None,
+                        recurrence: None,
+                        base: None,
+                        all_of: Vec::new(),
+                        any_of: Vec::new(),
+                        next_occurrence: None,
+                    }));
+                }
+            }
+            "compound" => {
+                if self.all_of.is_empty() && self.any_of.is_empty() {
+                    return Err("Compound trigger requires non-empty 'all_of' or 'any_of'".into());
+                }
+                if self.all_of.len() > MAX_TRIGGER_BRANCHES
+                    || self.any_of.len() > MAX_TRIGGER_BRANCHES
+                {
+                    return Err(format!(
+                        "Each compound branch list is limited to {MAX_TRIGGER_BRANCHES} triggers"
+                    ));
+                }
+                for child in self.all_of.iter_mut().chain(self.any_of.iter_mut()) {
+                    child.normalize(now, depth + 1, nodes)?;
+                }
+            }
+            other => {
+                return Err(format!(
+                    "Unknown trigger type '{other}'. Valid types: time, context, event, activity, recurring, compound"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn to_prospective(&self, created_at: DateTime<Utc>) -> Result<ProspectiveTrigger, String> {
+        match self.trigger_type.as_deref().unwrap_or("time") {
+            "time" => {
+                if let Some(at) = &self.at {
+                    Ok(ProspectiveTrigger::TimeBased {
+                        at: parse_rfc3339(at, "trigger.at")?,
+                    })
+                } else if let Some(minutes) = self.in_minutes {
+                    Ok(ProspectiveTrigger::DurationBased {
+                        after: Duration::minutes(minutes),
+                        trigger_at: Some(created_at + Duration::minutes(minutes)),
+                    })
+                } else {
+                    Err("Stored time trigger has no time".into())
+                }
+            }
+            "context" => {
+                let mut all = Vec::new();
+                if let Some(value) = &self.codebase {
+                    all.push(ContextPattern::InCodebase(value.clone()));
+                }
+                if let Some(value) = &self.file_pattern {
+                    all.push(ContextPattern::FilePattern(value.clone()));
+                }
+                if let Some(value) = &self.topic {
+                    all.push(ContextPattern::TopicActive(value.clone()));
+                }
+                let context_match = if all.len() == 1 {
+                    all.pop().expect("one context pattern")
+                } else {
+                    ContextPattern::Composite {
+                        all,
+                        any: Vec::new(),
+                    }
+                };
+                Ok(ProspectiveTrigger::ContextBased { context_match })
+            }
+            "event" => {
+                let condition = self
+                    .condition
+                    .clone()
+                    .ok_or("Stored event has no condition")?;
+                Ok(ProspectiveTrigger::EventBased {
+                    pattern: TriggerPattern::contains(&condition),
+                    condition,
+                })
+            }
+            "activity" => {
+                let activity = self
+                    .activity
+                    .clone()
+                    .ok_or("Stored activity has no activity")?;
+                let match_text = self.condition.clone().unwrap_or_else(|| activity.clone());
+                Ok(ProspectiveTrigger::ActivityBased {
+                    activity,
+                    completion_pattern: TriggerPattern::contains(match_text),
+                })
+            }
+            "recurring" => {
+                let minutes = recurrence_minutes(
+                    self.recurrence
+                        .as_ref()
+                        .ok_or("Stored recurrence has no cadence")?,
+                )?;
+                let next = self
+                    .next_occurrence
+                    .as_deref()
+                    .ok_or("Stored recurrence has no next occurrence")?;
+                Ok(ProspectiveTrigger::Recurring {
+                    base: Box::new(
+                        self.base
+                            .as_ref()
+                            .ok_or("Stored recurrence has no base")?
+                            .to_prospective(created_at)?,
+                    ),
+                    recurrence: RecurrencePattern::EveryMinutes(minutes),
+                    next_occurrence: Some(parse_rfc3339(next, "trigger.next_occurrence")?),
+                })
+            }
+            "compound" => Ok(ProspectiveTrigger::Compound {
+                all_of: self
+                    .all_of
+                    .iter()
+                    .map(|trigger| trigger.to_prospective(created_at))
+                    .collect::<Result<Vec<_>, _>>()?,
+                any_of: self
+                    .any_of
+                    .iter()
+                    .map(|trigger| trigger.to_prospective(created_at))
+                    .collect::<Result<Vec<_>, _>>()?,
+            }),
+            other => Err(format!("Unsupported stored trigger type '{other}'")),
+        }
+    }
+
+    fn from_prospective(trigger: &ProspectiveTrigger) -> Self {
+        match trigger {
+            ProspectiveTrigger::TimeBased { at } => Self::time_at(*at),
+            ProspectiveTrigger::DurationBased { after, .. } => Self {
+                trigger_type: Some("time".into()),
+                in_minutes: Some(after.num_minutes().max(1)),
+                ..Self::empty()
+            },
+            ProspectiveTrigger::EventBased { condition, .. } => Self {
+                trigger_type: Some("event".into()),
+                condition: Some(condition.clone()),
+                ..Self::empty()
+            },
+            ProspectiveTrigger::ContextBased { context_match } => {
+                Self::from_context_pattern(context_match)
+            }
+            ProspectiveTrigger::ActivityBased { activity, .. } => Self {
+                trigger_type: Some("activity".into()),
+                activity: Some(activity.clone()),
+                ..Self::empty()
+            },
+            ProspectiveTrigger::Recurring {
+                base,
+                recurrence,
+                next_occurrence,
+            } => {
+                let minutes = match recurrence {
+                    RecurrencePattern::EveryMinutes(value) => *value,
+                    RecurrencePattern::EveryHours(value) => value.saturating_mul(60),
+                    RecurrencePattern::Daily { .. } => 1_440,
+                    RecurrencePattern::Weekly { .. } => 10_080,
+                    RecurrencePattern::Monthly { .. } => 43_200,
+                    RecurrencePattern::Custom { interval } => interval.num_minutes(),
+                };
+                Self {
+                    trigger_type: Some("recurring".into()),
+                    recurrence: Some(serde_json::json!({ "every_minutes": minutes.max(1) })),
+                    base: Some(Box::new(Self::from_prospective(base))),
+                    next_occurrence: next_occurrence.map(|value| value.to_rfc3339()),
+                    ..Self::empty()
+                }
+            }
+            ProspectiveTrigger::Compound { all_of, any_of } => Self {
+                trigger_type: Some("compound".into()),
+                all_of: all_of.iter().map(Self::from_prospective).collect(),
+                any_of: any_of.iter().map(Self::from_prospective).collect(),
+                ..Self::empty()
+            },
+        }
+    }
+
+    fn from_context_pattern(pattern: &ContextPattern) -> Self {
+        match pattern {
+            ContextPattern::InCodebase(value) => Self {
+                trigger_type: Some("context".into()),
+                codebase: Some(value.clone()),
+                ..Self::empty()
+            },
+            ContextPattern::FilePattern(value) => Self {
+                trigger_type: Some("context".into()),
+                file_pattern: Some(value.clone()),
+                ..Self::empty()
+            },
+            ContextPattern::TopicActive(value) => Self {
+                trigger_type: Some("context".into()),
+                topic: Some(value.clone()),
+                ..Self::empty()
+            },
+            ContextPattern::UserMode(value) => Self {
+                trigger_type: Some("event".into()),
+                condition: Some(value.clone()),
+                ..Self::empty()
+            },
+            ContextPattern::Composite { all, any } => Self {
+                trigger_type: Some("compound".into()),
+                all_of: all.iter().map(Self::from_context_pattern).collect(),
+                any_of: any.iter().map(Self::from_context_pattern).collect(),
+                ..Self::empty()
+            },
+        }
+    }
+
+    fn empty() -> Self {
+        Self {
+            trigger_type: None,
+            at: None,
+            in_minutes: None,
+            codebase: None,
+            file_pattern: None,
+            topic: None,
+            condition: None,
+            activity: None,
+            recurrence: None,
+            base: None,
+            all_of: Vec::new(),
+            any_of: Vec::new(),
+            next_occurrence: None,
+        }
+    }
+
+    fn time_at(at: DateTime<Utc>) -> Self {
+        Self {
+            trigger_type: Some("time".into()),
+            at: Some(at.to_rfc3339()),
+            ..Self::empty()
+        }
+    }
+}
+
 // ============================================================================
 // MAIN EXECUTE FUNCTION
 // ============================================================================
@@ -206,7 +765,17 @@ pub async fn execute(
     args: Option<Value>,
 ) -> Result<Value, String> {
     let args: UnifiedIntentionArgs = match args {
-        Some(v) => serde_json::from_value(v).map_err(|e| format!("Invalid arguments: {}", e))?,
+        Some(v) => {
+            let encoded_size = serde_json::to_vec(&v)
+                .map_err(|error| format!("Invalid arguments: {error}"))?
+                .len();
+            if encoded_size > MAX_ARGUMENT_BYTES {
+                return Err(format!(
+                    "Arguments exceed the {MAX_ARGUMENT_BYTES}-byte limit"
+                ));
+            }
+            serde_json::from_value(v).map_err(|e| format!("Invalid arguments: {}", e))?
+        }
         None => return Err("Missing arguments".to_string()),
     };
 
@@ -252,8 +821,7 @@ async fn execute_set(
     // COGNITIVE: NLP parsing + intent auto-tagging
     // ====================================================================
     let mut nlp_parsed = false;
-    let mut nlp_trigger_type = None;
-    let mut nlp_trigger_data = None;
+    let mut nlp_trigger = None;
     let mut nlp_priority = None;
     let mut tags = Vec::new();
 
@@ -263,39 +831,9 @@ async fn execute_set(
             && let Ok(parsed) = cog.intention_parser.parse(description)
         {
             nlp_parsed = true;
-            // Extract trigger info from parsed intention
-            let (t_type, t_data) = match &parsed.trigger {
-                ProspectiveTrigger::TimeBased { .. } => (
-                    "time".to_string(),
-                    serde_json::json!({"type": "time"}).to_string(),
-                ),
-                ProspectiveTrigger::DurationBased { after, .. } => {
-                    let mins = after.num_minutes();
-                    (
-                        "time".to_string(),
-                        serde_json::json!({"type": "time", "in_minutes": mins}).to_string(),
-                    )
-                }
-                ProspectiveTrigger::EventBased { condition, .. } => (
-                    "event".to_string(),
-                    serde_json::json!({"type": "event", "condition": condition}).to_string(),
-                ),
-                ProspectiveTrigger::ContextBased { context_match } => (
-                    "context".to_string(),
-                    serde_json::json!({"type": "context", "topic": format!("{:?}", context_match)})
-                        .to_string(),
-                ),
-                ProspectiveTrigger::Recurring { .. } => (
-                    "recurring".to_string(),
-                    serde_json::json!({"type": "recurring"}).to_string(),
-                ),
-                _ => (
-                    "event".to_string(),
-                    serde_json::json!({"type": "event"}).to_string(),
-                ),
-            };
-            nlp_trigger_type = Some(t_type);
-            nlp_trigger_data = Some(t_data);
+            // Preserve the full parsed trigger tree, including recurrence base,
+            // cadence, next occurrence, activity, and compound branches.
+            nlp_trigger = Some(TriggerSpec::from_prospective(&parsed.trigger));
 
             // Use NLP-detected priority if user didn't specify one
             if args.priority.is_none() {
@@ -316,19 +854,39 @@ async fn execute_set(
         }
     }
 
-    // Determine trigger type and data (explicit > NLP > manual)
-    let (trigger_type, trigger_data) = if let Some(trigger) = &args.trigger {
-        let t_type = trigger
-            .trigger_type
-            .clone()
-            .unwrap_or_else(|| "time".to_string());
-        let data = serde_json::to_string(trigger).unwrap_or_else(|_| "{}".to_string());
-        (t_type, data)
-    } else if let (Some(t_type), Some(t_data)) = (nlp_trigger_type, nlp_trigger_data) {
-        (t_type, t_data)
-    } else {
-        ("manual".to_string(), "{}".to_string())
-    };
+    // Determine and validate trigger (explicit > NLP > manual). Manual
+    // intentions preserve the existing non-triggering `{}` storage shape.
+    let mut normalized_trigger = args.trigger.clone().or(nlp_trigger);
+    let (trigger_type, trigger_data, trigger_at, next_occurrence) =
+        if let Some(trigger) = &mut normalized_trigger {
+            let mut nodes = 0;
+            trigger.normalize(now, 1, &mut nodes)?;
+            let trigger_type = trigger
+                .trigger_type
+                .clone()
+                .expect("normalization assigns trigger type");
+            let trigger_at = if trigger_type == "time" {
+                if let Some(at) = &trigger.at {
+                    Some(parse_rfc3339(at, "trigger.at")?)
+                } else {
+                    trigger
+                        .in_minutes
+                        .map(|minutes| now + Duration::minutes(minutes))
+                }
+            } else {
+                None
+            };
+            let next_occurrence = trigger
+                .next_occurrence
+                .as_deref()
+                .map(|value| parse_rfc3339(value, "trigger.next_occurrence"))
+                .transpose()?;
+            let data = serde_json::to_string(trigger)
+                .map_err(|error| format!("Failed to encode trigger: {error}"))?;
+            (trigger_type, data, trigger_at, next_occurrence)
+        } else {
+            ("manual".to_string(), "{}".to_string(), None, None)
+        };
 
     // Parse priority (explicit > NLP > normal)
     let priority = match args.priority.as_deref() {
@@ -354,24 +912,11 @@ async fn execute_set(
     };
 
     // Parse deadline
-    let deadline = args.deadline.as_ref().and_then(|s| {
-        DateTime::parse_from_rfc3339(s)
-            .ok()
-            .map(|dt| dt.with_timezone(&Utc))
-    });
-
-    // Calculate trigger time if specified
-    let trigger_at = if let Some(trigger) = &args.trigger {
-        if let Some(at) = &trigger.at {
-            DateTime::parse_from_rfc3339(at)
-                .ok()
-                .map(|dt| dt.with_timezone(&Utc))
-        } else {
-            trigger.in_minutes.map(|mins| now + Duration::minutes(mins))
-        }
-    } else {
-        None
-    };
+    let deadline = args
+        .deadline
+        .as_deref()
+        .map(|value| parse_rfc3339(value, "deadline"))
+        .transpose()?;
 
     let record = IntentionRecord {
         id: id.clone(),
@@ -402,6 +947,7 @@ async fn execute_set(
         "message": format!("Intention created: {}", description),
         "priority": priority,
         "triggerAt": trigger_at.map(|dt| dt.to_rfc3339()),
+        "nextOccurrence": next_occurrence.map(|dt| dt.to_rfc3339()),
         "deadline": deadline.map(|dt| dt.to_rfc3339()),
         "nlpParsed": nlp_parsed,
     }))
@@ -413,15 +959,52 @@ async fn execute_check(
     cognitive: &Arc<Mutex<CognitiveEngine>>,
     args: &UnifiedIntentionArgs,
 ) -> Result<Value, String> {
-    let now = Utc::now();
+    let now = args
+        .context
+        .as_ref()
+        .and_then(|context| context.current_time.as_deref())
+        .map(|value| parse_rfc3339(value, "context.current_time"))
+        .transpose()?
+        .unwrap_or_else(Utc::now);
 
-    // ====================================================================
-    // COGNITIVE: Update prospective memory context
-    // ====================================================================
-    if let Some(ctx) = &args.context
-        && let Ok(cog) = cognitive.try_lock()
-    {
-        let mut prospective_ctx = ProspectiveContext::new();
+    let mut prospective_ctx = ProspectiveContext::new();
+    prospective_ctx.timestamp = now;
+    if let Some(ctx) = &args.context {
+        for (value, field) in [(&ctx.codebase, "codebase"), (&ctx.file, "file")] {
+            if let Some(value) = value
+                && value.len() > MAX_TRIGGER_TEXT_BYTES
+            {
+                return Err(format!(
+                    "'context.{field}' is limited to {MAX_TRIGGER_TEXT_BYTES} bytes"
+                ));
+            }
+        }
+        if ctx.topics.as_ref().map(Vec::len).unwrap_or(0) > MAX_CONTEXT_ITEMS {
+            return Err(format!(
+                "'context.topics' is limited to {MAX_CONTEXT_ITEMS} items"
+            ));
+        }
+        if let Some(topics) = &ctx.topics {
+            for topic in topics {
+                if topic.len() > MAX_TRIGGER_TEXT_BYTES {
+                    return Err(format!(
+                        "Each context topic is limited to {MAX_TRIGGER_TEXT_BYTES} bytes"
+                    ));
+                }
+            }
+        }
+        if ctx.events.len() > MAX_CONTEXT_ITEMS {
+            return Err(format!(
+                "'context.events' is limited to {MAX_CONTEXT_ITEMS} items"
+            ));
+        }
+        for event in &ctx.events {
+            if event.len() > MAX_TRIGGER_TEXT_BYTES {
+                return Err(format!(
+                    "Each context event is limited to {MAX_TRIGGER_TEXT_BYTES} bytes"
+                ));
+            }
+        }
         if let Some(codebase) = &ctx.codebase {
             prospective_ctx.project_name = Some(codebase.clone());
         }
@@ -431,88 +1014,133 @@ async fn execute_check(
         if let Some(topics) = &ctx.topics {
             prospective_ctx.active_topics = topics.clone();
         }
-        // Update context on prospective memory (triggers internal monitoring)
-        let _ = cog.prospective_memory.update_context(prospective_ctx);
+        prospective_ctx.recent_events = ctx.events.clone();
     }
 
-    // Get active intentions. `include_snoozed=true` folds snoozed intentions
-    // back into the check pool so time/context triggers can wake them up when
-    // their snooze window has elapsed or a matching context appears — before
-    // v2.0.7 this flag was advertised in the schema but silently ignored, so
-    // snoozed intentions were invisible to `check` regardless of the arg.
+    // ====================================================================
+    // COGNITIVE: Update prospective memory context
+    // ====================================================================
+    if args.context.is_some()
+        && let Ok(cog) = cognitive.try_lock()
+    {
+        // Update context on prospective memory (triggers internal monitoring)
+        let _ = cog
+            .prospective_memory
+            .update_context(prospective_ctx.clone());
+    }
+
+    // Always inspect snoozed records so an expired snooze can wake on this
+    // check. `include_snoozed` controls only whether records whose snooze is
+    // still in force are returned as pending.
     let mut intentions = storage.get_active_intentions().map_err(|e| e.to_string())?;
-    if args.include_snoozed.unwrap_or(false) {
-        let snoozed = storage
-            .get_intentions_by_status("snoozed")
-            .map_err(|e| e.to_string())?;
-        // Deduplicate defensively — an intention should never be in both lists
-        // but we pay the O(n) hash-set cost to stay correct if storage semantics
-        // shift under us.
-        use std::collections::HashSet;
-        let seen: HashSet<String> = intentions.iter().map(|i| i.id.clone()).collect();
-        for s in snoozed {
-            if !seen.contains(&s.id) {
-                intentions.push(s);
-            }
+    let snoozed = storage
+        .get_intentions_by_status("snoozed")
+        .map_err(|e| e.to_string())?;
+    use std::collections::HashSet;
+    let seen: HashSet<String> = intentions.iter().map(|i| i.id.clone()).collect();
+    for intention in snoozed {
+        let expired = intention
+            .snoozed_until
+            .map(|until| now >= until)
+            .unwrap_or(true);
+        if (expired || args.include_snoozed.unwrap_or(false)) && !seen.contains(&intention.id) {
+            intentions.push(intention);
         }
     }
 
     let mut triggered = Vec::new();
     let mut pending = Vec::new();
+    let mut changes = Vec::new();
 
-    for intention in intentions {
-        // Parse trigger data
-        let trigger: Option<TriggerSpec> = serde_json::from_str(&intention.trigger_data).ok();
+    for mut intention in intentions {
+        let original = intention.clone();
+        let mut changed = false;
+        let snooze_in_force = intention
+            .snoozed_until
+            .map(|until| now < until)
+            .unwrap_or(false)
+            && intention.status == "snoozed";
+        if intention.status == "snoozed" && !snooze_in_force {
+            intention.status = "active".to_string();
+            intention.snoozed_until = None;
+            changed = true;
+        }
 
-        // Check if triggered
-        let is_triggered = if let Some(t) = &trigger {
-            match t.trigger_type.as_deref() {
-                Some("time") => {
-                    if let Some(at) = &t.at {
-                        if let Ok(trigger_time) = DateTime::parse_from_rfc3339(at) {
-                            trigger_time.with_timezone(&Utc) <= now
-                        } else {
-                            false
-                        }
-                    } else if let Some(mins) = t.in_minutes {
-                        let trigger_time = intention.created_at + Duration::minutes(mins);
-                        trigger_time <= now
-                    } else {
-                        false
-                    }
-                }
-                Some("context") => {
-                    if let Some(ctx) = &args.context {
-                        // Check codebase match
-                        if let (Some(trigger_codebase), Some(current_codebase)) =
-                            (&t.codebase, &ctx.codebase)
+        let (mut trigger, prospective_trigger, invalid_trigger) =
+            if intention.trigger_type == "manual" && intention.trigger_data.trim() == "{}" {
+                (None, None, None)
+            } else {
+                match serde_json::from_str::<TriggerSpec>(&intention.trigger_data) {
+                    Ok(mut spec) => {
+                        let mut nodes = 0;
+                        match spec
+                            .normalize(intention.created_at, 1, &mut nodes)
+                            .and_then(|_| spec.to_prospective(intention.created_at))
                         {
-                            current_codebase
-                                .to_lowercase()
-                                .contains(&trigger_codebase.to_lowercase())
-                        // Check file pattern match
-                        } else if let (Some(pattern), Some(file)) = (&t.file_pattern, &ctx.file) {
-                            file.contains(pattern)
-                        // Check topic match
-                        } else if let (Some(topic), Some(topics)) = (&t.topic, &ctx.topics) {
-                            topics
-                                .iter()
-                                .any(|t| t.to_lowercase().contains(&topic.to_lowercase()))
-                        } else {
-                            false
+                            Ok(prospective) => (Some(spec), Some(prospective), None),
+                            Err(error) => (Some(spec), None, Some(error)),
                         }
-                    } else {
-                        false
                     }
+                    Err(error) => (
+                        None,
+                        None,
+                        Some(format!("Stored trigger JSON is invalid: {error}")),
+                    ),
                 }
-                _ => false,
-            }
-        } else {
-            false
-        };
+            };
+        let trigger_matched = !snooze_in_force
+            && prospective_trigger
+                .as_ref()
+                .map(|value| {
+                    value.is_triggered_at(&prospective_ctx, &prospective_ctx.recent_events, now)
+                })
+                .unwrap_or(false);
 
-        // Check if overdue
-        let is_overdue = intention.deadline.map(|d| d < now).unwrap_or(false);
+        // Snooze suppresses both trigger and overdue delivery until it expires.
+        let is_overdue = !snooze_in_force
+            && intention
+                .deadline
+                .map(|deadline| deadline < now)
+                .unwrap_or(false);
+        // Determine whether a recurring branch actually fired by advancing a
+        // clone. Tree membership alone is insufficient: an `any_of` may match
+        // its event branch while a sibling recurrence is still in the future.
+        let mut advanced_trigger = prospective_trigger.clone();
+        let scheduled_recurrence = trigger_matched
+            && advanced_trigger
+                .as_mut()
+                .map(|value| {
+                    value.re_arm_triggered(&prospective_ctx, &prospective_ctx.recent_events, now)
+                })
+                .unwrap_or(false);
+        let within_one_shot_limits = intention.reminder_count < MAX_ONE_SHOT_REMINDERS
+            && intention
+                .last_reminded_at
+                .map(|last| now - last >= Duration::minutes(MIN_ONE_SHOT_REMINDER_INTERVAL_MINUTES))
+                .unwrap_or(true);
+        let should_deliver =
+            (trigger_matched || is_overdue) && (scheduled_recurrence || within_one_shot_limits);
+
+        if should_deliver {
+            intention.reminder_count = intention.reminder_count.saturating_add(1);
+            intention.last_reminded_at = Some(now);
+            changed = true;
+
+            if scheduled_recurrence && let Some(value) = &advanced_trigger {
+                let advanced = TriggerSpec::from_prospective(value);
+                intention.trigger_type = advanced
+                    .trigger_type
+                    .clone()
+                    .unwrap_or_else(|| intention.trigger_type.clone());
+                intention.trigger_data = serde_json::to_string(&advanced)
+                    .map_err(|error| format!("Failed to persist recurrence: {error}"))?;
+                trigger = Some(advanced);
+            }
+        }
+
+        let next_occurrence = trigger
+            .as_ref()
+            .and_then(|value| value.next_occurrence.clone());
 
         let item = serde_json::json!({
             "id": intention.id,
@@ -528,13 +1156,28 @@ async fn execute_check(
             "deadline": intention.deadline.map(|d| d.to_rfc3339()),
             "snoozedUntil": intention.snoozed_until.map(|d| d.to_rfc3339()),
             "isOverdue": is_overdue,
+            "reminderCount": intention.reminder_count,
+            "nextOccurrence": next_occurrence,
+            "invalid_trigger": invalid_trigger,
         });
 
-        if is_triggered || is_overdue {
+        if should_deliver {
             triggered.push(item);
         } else {
             pending.push(item);
         }
+
+        if changed {
+            changes.push((original, intention));
+        }
+    }
+
+    // Claim every due occurrence and wake every expired snooze in one
+    // compare-and-swap transaction. A concurrent check that read the same old
+    // state loses the CAS and returns an error instead of duplicating delivery;
+    // a conflict also rolls back the whole batch so no prefix is consumed.
+    if !changes.is_empty() {
+        storage.commit_intention_check(&changes)?;
     }
 
     Ok(serde_json::json!({
@@ -577,6 +1220,11 @@ async fn execute_update(
         }
         "snooze" => {
             let minutes = args.snooze_minutes.unwrap_or(30);
+            if !(1..=MAX_DURATION_MINUTES).contains(&minutes) {
+                return Err(format!(
+                    "'snooze_minutes' must be between 1 and {MAX_DURATION_MINUTES}"
+                ));
+            }
             let snooze_until = Utc::now() + Duration::minutes(minutes);
 
             let updated = storage
@@ -655,7 +1303,11 @@ async fn execute_list(
             .map_err(|e| e.to_string())?
     };
 
-    let limit = args.limit.unwrap_or(20) as usize;
+    let requested_limit = args.limit.unwrap_or(20);
+    if !(1..=MAX_LIST_LIMIT).contains(&requested_limit) {
+        return Err(format!("'limit' must be between 1 and {MAX_LIST_LIMIT}"));
+    }
+    let limit = requested_limit as usize;
     let now = Utc::now();
 
     let items: Vec<Value> = intentions
@@ -1538,5 +2190,404 @@ mod tests {
             pending[0]["status"], "active",
             "freshly-created intention must report status=\"active\""
         );
+    }
+
+    #[tokio::test]
+    async fn test_public_recurring_trigger_advances_persistently_without_immediate_duplicate() {
+        let (storage, _dir) = test_storage().await;
+        let anchor = Utc::now() - Duration::minutes(1);
+        let first_check = anchor + Duration::minutes(2);
+        let set = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "action": "set",
+                "description": "repeatable reminder",
+                "trigger": {
+                    "type": "recurring",
+                    "at": anchor.to_rfc3339(),
+                    "recurrence": { "every": 5, "unit": "minutes" }
+                }
+            })),
+        )
+        .await
+        .unwrap();
+        let id = set["intentionId"].as_str().unwrap();
+
+        let check = |current_time: DateTime<Utc>| {
+            serde_json::json!({
+                "action": "check",
+                "context": { "current_time": current_time.to_rfc3339() }
+            })
+        };
+        let first = execute(&storage, &test_cognitive(), Some(check(first_check)))
+            .await
+            .unwrap();
+        assert_eq!(first["triggered"].as_array().unwrap().len(), 1);
+        let next = parse_rfc3339(
+            first["triggered"][0]["nextOccurrence"].as_str().unwrap(),
+            "nextOccurrence",
+        )
+        .unwrap();
+        assert!(next > first_check);
+
+        let duplicate = execute(&storage, &test_cognitive(), Some(check(first_check)))
+            .await
+            .unwrap();
+        assert!(duplicate["triggered"].as_array().unwrap().is_empty());
+
+        let repeated = execute(&storage, &test_cognitive(), Some(check(next)))
+            .await
+            .unwrap();
+        assert_eq!(repeated["triggered"].as_array().unwrap().len(), 1);
+        let stored = storage.get_intention(id).unwrap().unwrap();
+        assert_eq!(stored.reminder_count, 2);
+        assert!(stored.last_reminded_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_recurring_base_event_is_required_and_snooze_suppresses_delivery() {
+        let (storage, _dir) = test_storage().await;
+        let anchor = Utc::now() - Duration::minutes(1);
+        let set = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "action": "set",
+                "description": "event-gated recurrence",
+                "trigger": {
+                    "type": "recurring",
+                    "at": anchor.to_rfc3339(),
+                    "recurrence": "every 5 minutes",
+                    "base": {
+                        "type": "event",
+                        "condition": "deployment completed"
+                    }
+                }
+            })),
+        )
+        .await
+        .unwrap();
+        let id = set["intentionId"].as_str().unwrap().to_string();
+        let due = anchor + Duration::minutes(2);
+
+        let missing_event = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "action": "check",
+                "context": { "current_time": due.to_rfc3339() }
+            })),
+        )
+        .await
+        .unwrap();
+        assert!(missing_event["triggered"].as_array().unwrap().is_empty());
+
+        execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "action": "update",
+                "id": id,
+                "status": "snooze",
+                "snooze_minutes": 1
+            })),
+        )
+        .await
+        .unwrap();
+        let while_snoozed = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "action": "check",
+                "include_snoozed": true,
+                "context": {
+                    "current_time": Utc::now().to_rfc3339(),
+                    "events": ["deployment completed"]
+                }
+            })),
+        )
+        .await
+        .unwrap();
+        assert!(while_snoozed["triggered"].as_array().unwrap().is_empty());
+
+        let after_snooze = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "action": "check",
+                "context": {
+                    "current_time": (Utc::now() + Duration::minutes(2)).to_rfc3339(),
+                    "events": ["deployment completed successfully"]
+                }
+            })),
+        )
+        .await
+        .unwrap();
+        assert_eq!(after_snooze["triggered"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_compound_context_is_conjunctive_and_activity_event_branches_work() {
+        let (storage, _dir) = test_storage().await;
+        execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "action": "set",
+                "description": "compound public trigger",
+                "trigger": {
+                    "type": "compound",
+                    "all_of": [{
+                        "type": "context",
+                        "codebase": "vestige",
+                        "file_pattern": "intention_unified.rs"
+                    }],
+                    "any_of": [
+                        { "type": "event", "condition": "review approved" },
+                        { "type": "activity", "activity": "tests completed" }
+                    ]
+                }
+            })),
+        )
+        .await
+        .unwrap();
+
+        let missing_file = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "action": "check",
+                "context": {
+                    "codebase": "vestige",
+                    "file": "other.rs",
+                    "events": ["tests completed"]
+                }
+            })),
+        )
+        .await
+        .unwrap();
+        assert!(missing_file["triggered"].as_array().unwrap().is_empty());
+
+        let matching = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "action": "check",
+                "context": {
+                    "codebase": "vestige",
+                    "file": "crates/vestige-mcp/src/tools/intention_unified.rs",
+                    "events": ["all tests completed"]
+                }
+            })),
+        )
+        .await
+        .unwrap();
+        assert_eq!(matching["triggered"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_future_recurring_any_of_branch_does_not_disable_event_cooldown() {
+        let (storage, _dir) = test_storage().await;
+        let now = Utc::now();
+        execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "action": "set",
+                "description": "mixed any-of cooldown",
+                "trigger": {
+                    "type": "compound",
+                    "any_of": [
+                        { "type": "event", "condition": "review approved" },
+                        {
+                            "type": "recurring",
+                            "at": (now + Duration::hours(2)).to_rfc3339(),
+                            "recurrence": "daily"
+                        }
+                    ]
+                }
+            })),
+        )
+        .await
+        .unwrap();
+
+        let check = serde_json::json!({
+            "action": "check",
+            "context": {
+                "current_time": now.to_rfc3339(),
+                "events": ["review approved"]
+            }
+        });
+        let first = execute(&storage, &test_cognitive(), Some(check.clone()))
+            .await
+            .unwrap();
+        assert_eq!(first["triggered"].as_array().unwrap().len(), 1);
+
+        let duplicate = execute(&storage, &test_cognitive(), Some(check))
+            .await
+            .unwrap();
+        assert!(duplicate["triggered"].as_array().unwrap().is_empty());
+        assert_eq!(duplicate["pending"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_invalid_stored_trigger_is_visible_in_pending_item() {
+        let (storage, _dir) = test_storage().await;
+        let now = Utc::now();
+        storage
+            .save_intention(&IntentionRecord {
+                id: "invalid-recurring".to_string(),
+                content: "legacy partial recurrence".to_string(),
+                trigger_type: "recurring".to_string(),
+                trigger_data: serde_json::json!({ "type": "recurring" }).to_string(),
+                priority: 2,
+                status: "active".to_string(),
+                created_at: now,
+                deadline: None,
+                fulfilled_at: None,
+                reminder_count: 0,
+                last_reminded_at: None,
+                notes: None,
+                tags: Vec::new(),
+                related_memories: Vec::new(),
+                snoozed_until: None,
+                source_type: "legacy".to_string(),
+                source_data: None,
+            })
+            .unwrap();
+
+        let result = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({ "action": "check" })),
+        )
+        .await
+        .unwrap();
+        assert!(result["triggered"].as_array().unwrap().is_empty());
+        assert!(result["pending"][0]["invalid_trigger"].is_string());
+    }
+
+    #[tokio::test]
+    async fn test_nlp_fortnight_recurrence_is_persisted_in_full() {
+        let (storage, _dir) = test_storage().await;
+        let set = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "action": "set",
+                "description": "remind me to review the roadmap every fortnight"
+            })),
+        )
+        .await
+        .unwrap();
+        assert_eq!(set["nlpParsed"], true);
+        let id = set["intentionId"].as_str().unwrap();
+        let stored = storage.get_intention(id).unwrap().unwrap();
+        let trigger: Value = serde_json::from_str(&stored.trigger_data).unwrap();
+        assert_eq!(trigger["type"], "recurring");
+        assert_eq!(trigger["recurrence"]["every_minutes"], 20_160);
+        assert!(trigger["base"].is_object());
+        assert!(trigger["next_occurrence"].is_string());
+    }
+
+    #[tokio::test]
+    async fn test_invalid_trigger_time_recurrence_depth_and_public_limits_fail_closed() {
+        let (storage, _dir) = test_storage().await;
+        for trigger in [
+            serde_json::json!({ "type": "time", "at": "tomorrow" }),
+            serde_json::json!({
+                "type": "recurring",
+                "recurrence": { "every_minutes": 0 }
+            }),
+            serde_json::json!({ "type": "compound", "all_of": [], "any_of": [] }),
+            serde_json::json!({
+                "type": "compound",
+                "all_of": [{
+                    "type": "compound",
+                    "all_of": [{
+                        "type": "compound",
+                        "all_of": [{
+                            "type": "compound",
+                            "all_of": [{
+                                "type": "compound",
+                                "all_of": [{
+                                    "type": "context",
+                                    "topic": "too deep"
+                                }]
+                            }]
+                        }]
+                    }]
+                }]
+            }),
+        ] {
+            let result = execute(
+                &storage,
+                &test_cognitive(),
+                Some(serde_json::json!({
+                    "action": "set",
+                    "description": "invalid",
+                    "trigger": trigger
+                })),
+            )
+            .await;
+            assert!(result.is_err());
+        }
+
+        let bad_time = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "action": "check",
+                "context": { "current_time": "not-rfc3339" }
+            })),
+        )
+        .await;
+        assert!(bad_time.is_err());
+
+        let bad_snooze = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "action": "update",
+                "id": "missing",
+                "status": "snooze",
+                "snooze_minutes": 0
+            })),
+        )
+        .await;
+        assert!(bad_snooze.is_err());
+
+        let bad_limit = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({ "action": "list", "limit": -1 })),
+        )
+        .await;
+        assert!(bad_limit.is_err());
+
+        let oversized_args = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "action": "set",
+                "description": "x".repeat(MAX_ARGUMENT_BYTES)
+            })),
+        )
+        .await;
+        assert!(oversized_args.is_err());
+
+        let too_many_topics = execute(
+            &storage,
+            &test_cognitive(),
+            Some(serde_json::json!({
+                "action": "check",
+                "context": {
+                    "topics": vec!["topic"; MAX_CONTEXT_ITEMS + 1]
+                }
+            })),
+        )
+        .await;
+        assert!(too_many_topics.is_err());
     }
 }

--- a/crates/vestige-mcp/src/tools/mod.rs
+++ b/crates/vestige-mcp/src/tools/mod.rs
@@ -96,3 +96,6 @@ pub mod memory_states;
 pub mod review;
 #[allow(dead_code)]
 pub mod tagging;
+
+/// Evidence-aware intention command adapter.
+pub mod intention_graph;

--- a/docs/INTENTIONS.md
+++ b/docs/INTENTIONS.md
@@ -1,0 +1,465 @@
+# Evidence-aware intentions
+
+Vestige intentions connect a future plan to the premises and observations that
+support it. The first implementation is a deterministic, local evaluator: it
+can show which plans are affected when supplied evidence changes, reconcile a
+completion against later evidence, and explain the current evaluation without
+performing the planned action.
+
+This document describes the implementation contract introduced by the
+evidence-aware intention change. Reproducible local checks are linked below.
+The research extensions described under [Boundaries](#boundaries) are not
+implemented behavior.
+
+## Public interface
+
+The existing `intention` actions (`set`, `check`, `update`, and `list`) remain
+available. Evidence-aware operations use `action: "graph"` and a nested
+command:
+
+```json
+{
+  "action": "graph",
+  "scope": "user",
+  "at": "2026-10-01T09:00:00Z",
+  "command": {
+    "action": "portfolio"
+  }
+}
+```
+
+`scope` defaults to `user`. It selects an independent local namespace; it is
+not authentication, authorization, or a tenancy boundary. Use the host's real
+access controls to isolate users who must not read or change each other's data.
+
+`at` is optional and normally defaults to the current time. Supply an RFC 3339
+timestamp for reproducible fixtures and deterministic evaluation. Treat it as
+an evaluation clock supplied by the caller, not proof that an event occurred at
+that time. It is not a historical-query interface: current-state reads and
+state-changing commands with a timestamp earlier than the graph's last mutation
+are rejected. An exact state-neutral retry can return its original result.
+
+The nested commands are:
+
+| Command | Purpose |
+| --- | --- |
+| `plan` | Create a plan with explicit requirements and conflict keys. |
+| `revise` | Replace the mutable fields of an existing plan using its expected revision. |
+| `observe` | Add a bounded, typed caller assertion for one source revision and reevaluate only affected plans. |
+| `evaluate` | Evaluate a plan from the currently stored observations. |
+| `explain` | Return the plan, requirement results, current source snapshots, pending attention, and evidence boundary. |
+| `portfolio` | Return plans, shared prerequisites, declared conflicts, and queued interventions. |
+| `complete` | Record a user report or evidence completion against an expected plan version. |
+| `cancel` | Cancel an expected plan version while retaining its history. |
+| `acknowledge` | Acknowledge a queued intervention so cooldown and deduplication state advance. |
+| `replay` | Rebuild the graph from the committed command journal and compare stored digests. |
+| `memory_snapshot` | Read the current same-scope memory content commitment without copying its text into the intention graph. |
+| `refresh_memory` | Read that commitment and append it as a reserved local-memory observation. |
+
+IDs are caller-chosen stable strings. Keep one plan ID across revisions instead
+of creating a new plan to represent an edit. `revise`, `complete`, and `cancel`
+use optimistic versioning: pass the version last returned by Vestige in
+`expected_version` and handle a version conflict by reading the current plan
+before retrying. This value guards the plan definition, not its entire lifecycle:
+`revise` increments the definition version, while `complete` and `cancel` do
+not. Cancellation deliberately moves the current version to `cancelled` from
+another lifecycle state. An exact repeated completion or cancellation is a
+state-neutral retry that preserves its original timestamps; changing the basis
+or reason is rejected as a conflicting retry. Observation event IDs provide the
+same rule for observations: an exact retry is idempotent, while reusing an
+event ID with different content is rejected.
+
+## Deterministic evidence model
+
+A plan stores its desired outcome separately from the evidence-dependent means
+of achieving it. Requirements refer to explicit source keys and predicates.
+Observing a newer source revision updates the relevant source, finds the plans
+that depend on it, and reevaluates that affected set. An unrelated source update
+does not invalidate every plan.
+
+Observations accept a bounded scalar value (boolean, signed integer, nonempty
+string, or `null`) and explicit event lists. They are assertions from the caller.
+Vestige records the source key, monotonically increasing source revision, event
+ID, value, observed event types, covered event types, and evaluation time. It
+does not infer a product specification from prose, fetch a URL, poll an inbox,
+or decide that the assertion is authoritative.
+
+Requirements have three explicit forms:
+
+- `evidence` compares a source value with `exists`, `equals`, or `not_equals`;
+- `event` requires an event to have occurred or remained absent, with explicit
+  coverage and time-window rules for absence; and
+- `plan_fulfilled` makes another plan's fulfilled lifecycle a prerequisite.
+
+Absence predicates are coverage-aware. An expected event is absent only when
+the observation declares coverage for that event type over the relevant input.
+If the source was disconnected or its coverage is unknown, the result remains
+unknown. A missing event in an uncovered channel is never turned into a false
+"did not happen" claim.
+
+Observation coverage cannot end after the command's evaluation time. When an
+event requirement has a time window, an assertion that it occurred must carry
+a bounded observation interval inside that required window; otherwise its state
+remains unknown. Establishing absence is stricter: the requirement needs an
+explicit window, the observation must cover that whole window and named event,
+and the configured grace period must have elapsed.
+
+The evaluator also exposes relationships across plans. Requirements with the
+same normalized definition are shared prerequisites; explicit conflict keys
+show plans that compete for the same declared resource or choice. These are
+structural results from caller-supplied data, not semantic or causal inferences.
+
+Each new logical evaluation of an active or disputed plan receives a stable
+attention fingerprint. The queue deduplicates repeated states, supersedes an
+older unacknowledged state for the same plan, and retains withheld entries until
+their cooldown expires. Acknowledging a queue ID starts that plan's cooldown;
+fulfilled and cancelled states retire older pending entries. Vestige returns
+deliverable and withheld queue IDs for a host to present. It does not deliver a
+notification itself.
+
+Completion is evidence-aware without making ordinary personal reminders
+needlessly strict. A completion basis is either `user_report` with a bounded
+report string or `evidence` with a nonempty subset of the plan's requirement
+IDs. Evidence-based completion is accepted only when every current requirement
+is satisfied. The selected subset records which evidence the caller cites, but
+later reconciliation still considers every current requirement: if any reverses,
+the lifecycle becomes `disputed`. A disputed evidence completion must be revised
+to a new plan version before it can be completed again. Later evidence does not
+automatically dispute a `user_report`. Revising any fulfilled plan activates
+the new version and marks the prior completion for reconciliation; cancellation
+moves the current version to `cancelled`. No completion transition can cause
+Vestige to repeat an external action.
+
+## Projector fixture
+
+The following scenario is synthetic. Product dimensions, bag fit, price,
+availability, purchase, and cancellation are fixture assertions, not live
+facts. The evaluator never buys the projector.
+
+The plan keeps the desired outcome separate from the premise that a selected
+projector fits a travel bag. This creates version 1:
+
+```json
+{
+  "action": "graph",
+  "scope": "projector-fixture",
+  "at": "2026-10-01T09:00:00Z",
+  "command": {
+    "action": "plan",
+    "id": "portable-projector",
+    "description": "Synthetic: buy the selected projector on October 30, 2026",
+    "priority": "normal",
+    "requirements": [
+      {
+        "type": "evidence",
+        "id": "fits-travel-bag",
+        "source_key": "fixture:projector-spec",
+        "condition": {
+          "op": "equals",
+          "value": true
+        }
+      }
+    ],
+    "min_attention_interval_seconds": 1209600,
+    "conflict_keys": ["purchase:portable-projector"]
+  }
+}
+```
+
+The fixture can assert the premise without claiming it came from a live product
+source:
+
+```json
+{
+  "action": "graph",
+  "scope": "projector-fixture",
+  "at": "2026-10-01T09:05:00Z",
+  "command": {
+    "action": "observe",
+    "event_id": "projector-spec-1",
+    "source_key": "fixture:projector-spec",
+    "source_revision": 1,
+    "value": true,
+    "observed_events": [],
+    "covered_events": []
+  }
+}
+```
+
+If a newer supplied specification reverses that value, Vestige reevaluates
+only plans that depend on `fixture:projector-spec` and queues the changed
+readiness for review:
+
+```json
+{
+  "action": "graph",
+  "scope": "projector-fixture",
+  "at": "2026-10-02T09:00:00Z",
+  "command": {
+    "action": "observe",
+    "event_id": "projector-spec-2",
+    "source_key": "fixture:projector-spec",
+    "source_revision": 2,
+    "value": false,
+    "observed_events": [],
+    "covered_events": []
+  }
+}
+```
+
+If the user then chooses another synthetic candidate, the caller revises the
+same plan using the current version:
+
+```json
+{
+  "action": "graph",
+  "scope": "projector-fixture",
+  "at": "2026-10-02T10:00:00Z",
+  "command": {
+    "action": "revise",
+    "id": "portable-projector",
+    "expected_version": 1,
+    "description": "Synthetic: buy candidate B on October 30, 2026",
+    "requirements": [
+      {
+        "type": "evidence",
+        "id": "fits-travel-bag",
+        "source_key": "fixture:candidate-b-spec",
+        "condition": {
+          "op": "equals",
+          "value": true
+        }
+      }
+    ]
+  }
+}
+```
+
+The response retains `portable-projector`, preserves the original description
+in history, and appends version 2. Omitting a mutable field from `revise` keeps
+its version-1 value. `min_attention_interval_seconds` is an attention cooldown
+after acknowledgement; it is not a recurrence schedule or proof that an alert
+was delivered.
+
+This is the behavior the fixture is intended to demonstrate:
+
+1. A plan is created with a stable ID, an explicit bag-fit requirement, and a
+   declared purchase conflict key.
+2. Source revision 1 says the selected projector fits the bag. Evaluation can
+   show the requirement as satisfied.
+3. Source revision 2 says it does not fit. The graph reevaluates the affected
+   plan, records the changed premise, and queues one review intervention.
+4. Repeating the same observation event does not create another state change.
+5. A revision can change the candidate or requirements only when its
+   `expected_version` matches the current plan version.
+6. Evidence-based completion becomes disputed if a later observation
+   invalidates any current requirement. No replacement order is placed.
+
+## Local memory sources
+
+Direct `observe` calls may not use a source key beginning with `memory:`. That
+namespace is reserved so a caller cannot forge a local memory snapshot. Read a
+same-scope commitment first:
+
+```json
+{
+  "action": "graph",
+  "scope": "user",
+  "command": {
+    "action": "memory_snapshot",
+    "memory_id": "00000000-0000-4000-8000-000000000001"
+  }
+}
+```
+
+The result contains a source key such as
+`memory:00000000-0000-4000-8000-000000000001`, the memory ID, and either a
+SHA-256 content commitment in `value` or `null` when no currently available
+same-scope memory can be committed. It never copies the raw memory text into
+intention history. The adapter computes a digest of its local content snapshot;
+the digest alone does not prove the read, its origin, or the remembered claim.
+Unkeyed SHA-256 also does not conceal low-entropy content from guessing.
+
+Bind a requirement only after a non-null commitment is available. A null
+snapshot means the memory is unavailable; it is not an equality value.
+Bind a requirement to the exact returned commitment by copying the snapshot's
+`source_key` and `value` into the plan. For example, if `memory_snapshot`
+returns a value of 64 `a` characters, the requirement is:
+
+```json
+{
+  "type": "evidence",
+  "id": "remembered-projector-spec",
+  "source_key": "memory:00000000-0000-4000-8000-000000000001",
+  "memory_id": "00000000-0000-4000-8000-000000000001",
+  "condition": {
+    "op": "equals",
+    "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+}
+```
+
+The digest above is obviously synthetic. In a real call, use the exact
+`snapshot.value`; do not hash a summary or substitute a caller-computed value.
+
+Append the current commitment as an observation with `refresh_memory`:
+
+```json
+{
+  "action": "graph",
+  "scope": "user",
+  "at": "2026-10-01T09:00:00Z",
+  "command": {
+    "action": "refresh_memory",
+    "memory_id": "00000000-0000-4000-8000-000000000001",
+    "event_id": "projector-memory-refresh-1",
+    "source_revision": 1
+  }
+}
+```
+
+Refresh is manual. The first implementation has no background memory watcher,
+connector polling, or automatic refresh cadence. The caller owns the source
+revision sequence and should refresh at a deliberate lifecycle boundary, such
+as before evaluation or after updating a referenced memory.
+
+## Persistence and replay
+
+Each local scope has a current JSON snapshot and an append-only command journal
+in the same SQLite database as the rest of Vestige. A command that changes state
+commits the snapshot and journal row in one immediate transaction. SQLite
+serializes writers that share that database, so concurrent local processes do
+not commit the same next sequence number. An exact idempotent observation retry
+does not append another journal row because it does not change state.
+
+Each scope is deliberately bounded to 1,024 plans, 1,024 versions per plan, 128
+requirements per plan, 4,096 sources, 16,384 observation receipts, 16,384
+evaluations, 16,384 attention events, 20,000 committed changes, and a 16 MiB
+serialized snapshot. A single recorded observation response is limited to
+256 KiB; a change exceeding a resulting-state limit fails atomically. There is
+no intention-graph archive or compaction command
+in the first implementation. Before a scope reaches a cap, preserve a full
+backup of the SQLite database and start an explicit new scope with reviewed
+current plan definitions. The old scope keeps its history; Vestige does not
+silently discard it or claim indefinite capacity.
+
+`replay` starts with an empty graph, applies the recorded commands at their
+recorded evaluation times, and compares every output digest and state digest
+with the journal. It then compares the rebuilt graph with the current snapshot.
+A successful replay establishes deterministic reproduction of the locally
+recorded state transitions.
+
+Replay does not:
+
+- refetch a source or reverify an external fact;
+- prove that a caller's observation was honest or authoritative;
+- prove external delivery, purchase, completion, or cancellation;
+- provide a cryptographic signature or protect against an attacker rewriting
+  the entire database and recomputing its digests; or
+- synchronize an intention graph across devices or separate databases.
+
+Portable, distributed, and exactly-once external execution require additional
+coordination. The local journal does not claim those properties.
+
+## Existing triggers
+
+The ordinary `set` and `check` path also supports the core trigger forms that
+were previously lost or only partly evaluated by the public adapter:
+
+- `activity` matches an explicit activity or condition against supplied context
+  events;
+- `recurring` accepts a named recurrence such as `daily`, `weekly`, or
+  `fortnightly`, an `every ...` expression, or a bounded interval object, and
+  can wrap a base trigger;
+- `compound` recursively combines `all_of` and `any_of` triggers; and
+- context fields supplied within one context trigger are conjunctive.
+
+A fortnightly reminder can be created without a graph command:
+
+```json
+{
+  "action": "set",
+  "description": "Review the projector plan",
+  "trigger": {
+    "type": "recurring",
+    "at": "2026-10-02T09:00:00-07:00",
+    "recurrence": "every two weeks"
+  }
+}
+```
+
+Named recurrence strings include `hourly`, `daily`, `weekly`, and
+`fortnightly` (also `every other week`); `every N minutes|hours|days|weeks|fortnights` and interval
+objects are also accepted. A recurrence may wrap a recursive `base` trigger and
+fires only when its schedule is due and that base matches. Without `at` or
+`in_minutes`, its first occurrence is one interval after creation. Intervals
+are fixed elapsed UTC time, with a fortnight equal to 20,160 minutes; they do
+not infer a local time zone or daylight-saving policy.
+
+For `time`, provide exactly one RFC 3339 `at` or positive `in_minutes` value.
+For `context`, provide at least one of `codebase`, `file_pattern`, or `topic`;
+all supplied fields must match. `event.condition` and `activity.activity`
+case-insensitively substring-match `check.context.events`. A `compound` trigger
+recursively combines `all_of` and `any_of`; each nonempty list retains its usual
+all/any meaning, and both lists cannot be empty.
+
+Trigger trees are limited to depth 5 and 32 nodes, with at most 16 entries in
+each compound list. Duration, recurrence, and snooze intervals are 1 through
+5,256,000 minutes. One-shot reminders fire at most five times and at least 30
+minutes apart; a recurring schedule uses its cadence as its limiter and
+persists its next future occurrence before returning. An expired snooze wakes
+and evaluates during the same `check`.
+
+Each `intention` request is limited to 131,072 encoded JSON bytes. Check context
+accepts at most 32 topics and 32 events; its codebase, file, and every topic or
+event item are limited to 4,096 bytes. A stored trigger that no longer parses or
+validates remains pending and returns an `invalid_trigger` string instead of
+silently firing or disappearing. In a mixed compound trigger, only a recurrence
+branch that actually fired can bypass the one-shot 30-minute cooldown; a future
+recurrence sibling does not change the event branch's limiter.
+
+Canonical stored trigger fields use snake case. Accepted compatibility aliases
+include `inMinutes`, `filePattern`, `allOf`, `anyOf`, `nextOccurrence`,
+`everyMinutes`, and `intervalMinutes`. Check context also accepts
+`currentTime`, `recent_events`, and `recentEvents` for `current_time` and
+`events`.
+
+One `check` evaluates and persists snooze, reminder-count, and recurrence
+changes as a single local SQLite compare-and-swap batch. A concurrent conflict
+rejects and rolls back the whole batch so the caller can retry. This protects
+local state consistency; it does not establish exactly-once presentation or
+delivery outside Vestige.
+
+These scheduler triggers and the evidence-aware intention graph share the
+public `intention` tool, but they remain distinct contracts in the first
+implementation. A recurring reminder is not proof that a graph premise is true,
+and a queued graph intervention is not a delivered recurring notification.
+
+## Reproducible checks
+
+The [synthetic MCP demo](../scripts/demo-intentions.py) drives the public
+`intention` tool through an isolated subprocess and temporary SQLite database.
+The [core intention graph tests](../crates/vestige-core/src/intention_graph.rs)
+cover selective reevaluation, optimistic definition versions, evidence
+reconciliation, absence coverage, attention state, caps, and replay. The
+[public trigger tests](../crates/vestige-mcp/src/tools/intention_unified.rs)
+cover recurrence, compound and activity triggers, snooze, and duplicate checks.
+The [local intention claim tests](../crates/vestige-core/src/storage/intention_claim.rs)
+cover two-connection contention and whole-batch rollback. These checks exercise
+synthetic local behavior; they do not verify a product fact, external delivery,
+or an external action.
+
+## Boundaries
+
+The first implementation provides deterministic local state transitions,
+targeted reevaluation, bounded typed observations, coverage-aware absence,
+completion reconciliation, explicit shared prerequisites and conflicts, local
+queue/cooldown behavior, explanations, and atomic journal replay.
+
+It does not provide autonomous connectors, real notification delivery,
+semantic opportunity inference, model-generated premise extraction, causal
+proof, purchasing, refunds, or other external actions. Those require separate
+adapters, authority checks, and evidence. No worldwide-first, market-uniqueness,
+performance, reliability, or outcome-improvement claim follows from this
+implementation. Establish such claims with an independently reviewed frozen
+evaluation and publish its failures as well as its successes.

--- a/scripts/demo-intentions.py
+++ b/scripts/demo-intentions.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Exercise evidence-aware intentions through an isolated real MCP subprocess.
+
+Build first: cargo build -p vestige-mcp --no-default-features --bin vestige-mcp
+Run: python3 scripts/demo-intentions.py --binary target/debug/vestige-mcp
+All product observations are synthetic. No user database or external action is used.
+"""
+
+import argparse
+import hashlib
+import json
+import pathlib
+import selectors
+import subprocess
+import tempfile
+import time
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", required=True, type=pathlib.Path)
+    parser.add_argument("--output", type=pathlib.Path)
+    args = parser.parse_args()
+    binary = args.binary.resolve(strict=True)
+    transcript = []
+    with tempfile.TemporaryDirectory(prefix="vestige-intention-demo-") as fixture:
+        with open(pathlib.Path(fixture) / "stderr.log", "w+") as log:
+            process = subprocess.Popen(
+                [str(binary), "--data-dir", fixture], stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE, stderr=log, text=True, bufsize=1,
+            )
+            selector = selectors.DefaultSelector()
+            selector.register(process.stdout, selectors.EVENT_READ)
+            next_id = 0
+
+            def rpc(method, params):
+                nonlocal next_id
+                next_id += 1
+                request = {"jsonrpc": "2.0", "id": next_id, "method": method, "params": params}
+                process.stdin.write(json.dumps(request) + "\n")
+                process.stdin.flush()
+                deadline = time.monotonic() + 30
+                while time.monotonic() < deadline:
+                    if not selector.select(max(0, deadline - time.monotonic())):
+                        break
+                    line = process.stdout.readline()
+                    if not line:
+                        raise RuntimeError("MCP subprocess closed stdout")
+                    response = json.loads(line)
+                    if response.get("id") == next_id:
+                        transcript.append({"request": request, "response": response})
+                        if "error" in response:
+                            raise RuntimeError(response["error"])
+                        result = response["result"]
+                        if result.get("isError"):
+                            raise RuntimeError(result)
+                        return result
+                raise TimeoutError(f"MCP response timed out for {method}")
+
+            def intention_call(arguments):
+                result = rpc("tools/call", {"name": "intention", "arguments": arguments})
+                if "structuredContent" in result:
+                    return result["structuredContent"]
+                return json.loads(next(c["text"] for c in result["content"] if c["type"] == "text"))
+
+            def graph(command, at="2026-10-01T09:00:00Z"):
+                return intention_call({"action": "graph", "scope": "demo", "at": at, "command": command})
+
+            try:
+                rpc("initialize", {"protocolVersion": "2025-06-18", "capabilities": {},
+                    "clientInfo": {"name": "intention-fixture", "version": "1"}})
+                tools = rpc("tools/list", {})["tools"]
+                intention = next(t for t in tools if t["name"] == "intention")
+                assert "graph" in intention["inputSchema"]["properties"]["action"]["enum"]
+                requirement = {"type": "evidence", "id": "fits-bag", "source_key": "spec:projector",
+                    "condition": {"op": "equals", "value": True}}
+                graph({"action": "plan", "id": "projector", "description": "Synthetic: buy the selected projector",
+                    "requirements": [requirement], "min_attention_interval_seconds": 0})
+                graph({"action": "plan", "id": "unrelated", "description": "Synthetic unrelated intention",
+                    "requirements": []})
+                graph({"action": "observe", "event_id": "spec-1", "source_key": "spec:projector",
+                    "source_revision": 1, "value": True})
+                graph({"action": "complete", "id": "projector", "expected_version": 1,
+                    "basis": {"type": "evidence", "requirement_ids": ["fits-bag"]}})
+                graph({"action": "observe", "event_id": "spec-2", "source_key": "spec:projector",
+                    "source_revision": 2, "value": False}, "2026-10-02T09:00:00Z")
+                explanation = graph({"action": "explain", "id": "projector"}, "2026-10-02T09:00:00Z")
+                assert "disputed" in json.dumps(explanation).lower(), explanation
+                before = graph({"action": "replay"})
+                graph({"action": "observe", "event_id": "spec-2", "source_key": "spec:projector",
+                    "source_revision": 2, "value": False}, "2026-10-02T09:00:00Z")
+                duplicate = graph({"action": "replay"})
+                assert before["state_digest"] == duplicate["state_digest"]
+                graph({"action": "cancel", "id": "projector", "expected_version": 1, "reason": "Synthetic cancellation"}, "2026-10-02T09:00:00Z")
+                replay = graph({"action": "replay"})
+                assert replay["matched"] is True
+                intention_call({"action": "set", "description": "Synthetic fortnightly projector reminder",
+                    "trigger": {"type": "recurring", "at": "2026-10-16T16:00:00Z", "recurrence": "every other week"}})
+                def check(at):
+                    return intention_call({"action": "check", "context": {"current_time": at}})
+                first = check("2026-10-16T16:00:00Z")
+                assert len(first["triggered"]) == 1, first
+                assert not check("2026-10-16T16:00:00Z")["triggered"]
+                assert not check("2026-10-23T16:00:00Z")["triggered"]
+                second = check("2026-10-30T16:00:00Z")
+                assert len(second["triggered"]) == 1, second
+                assert second["triggered"][0]["reminderCount"] == 2
+                result = {"fixture": "synthetic projector through MCP stdio", "passed": True,
+                    "binary_sha256": hashlib.sha256(binary.read_bytes()).hexdigest(),
+                    "replay": replay, "transcript": transcript,
+                    "boundary": "Local synthetic behavior; no live facts, purchase, scheduler delivery, or competitive result."}
+                encoded = json.dumps(result, indent=2)
+                if args.output:
+                    args.output.write_text(encoded + "\n")
+                else:
+                    print(encoded)
+            finally:
+                selector.close()
+                process.stdin.close()
+                try:
+                    process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    process.terminate()
+                    process.wait(timeout=10)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Intentions now track explicit evidence requirements and prerequisite plans, reconcile completion when evidence changes, and retain a durable journal for deterministic replay. Recurring reminders recognize “every other week” and claim occurrences atomically so repeated checks do not immediately repeat a reminder.

## Included changes

- Add versioned intention definitions, typed evidence predicates, exact memory digest bindings, prerequisite ordering, and portfolio queries.
- Generate deduplicated attention on meaningful transitions; reconcile evidence-based completion and disputes.
- Model absence using explicit windows, grace periods, and reported coverage; unknown coverage remains unknown.
- Persist bounded graph snapshots and journals atomically in SQLite, with replay validation and migration 34.
- Preserve recurrence, snooze, cooldown, and occurrence-claim behavior across reminder checks.
- Expose graph commands through the existing intention MCP tool; add API documentation and an isolated executable MCP demo.

## Validation

Recovered candidate: c11f3af1d3cd2fc2a21436497294bac972113301, based on 0bba3e6267e1c7c11541b83ec116e24ea5cca2e1. The patch digest matches the previously reviewed candidate.

Fresh verification on the unchanged candidate:
- Core library: 777 passed, 0 failed.
- MCP library: 599 passed, 0 failed.
- Real isolated MCP subprocess demo: passed, including six-command deterministic replay and every-other-week reminder checks.
- Diff whitespace check: passed.
- Added-line scan for private paths, private-key markers, and common credential formats: no matches (not a comprehensive secret audit).

Previous acceptance also passed configured all-target Clippy and default-feature compilation; those two checks were not rerun for this unchanged commit.

## Boundaries

Observations remain caller assertions; digests and replay do not establish truth or authorize external actions. Autonomous watchers, host notification delivery, automatic memory lifecycle refresh, and graph export/sync are not included. Fixed recurrence uses elapsed UTC intervals and does not preserve local wall-clock time across DST changes.

Migration 34 has no down migration. Activating against an existing database requires a verified pre-migration backup; rollback requires the matching backup. This PR does not replace the installed memory server or activate a live-data migration.
